### PR TITLE
Enable nx scan option

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -16,7 +16,17 @@
   "tasksRunnerOptions": {
     "default": {
       "runner": "@nrwl/nx-cloud",
-      "options": {}
+      "options": {
+        "cacheableOperations": [
+          "build",
+          "test",
+          "lint",
+          "e2e"
+        ],
+        "canTrackAnalytics": false,
+        "showUsageWarnings": true,
+        "scan": true
+      }
     }
   },
   "targetDependencies": {


### PR DESCRIPTION
## Changelogs

- Enable caching for several tasks
- Enable the `scan` option to push the log output of cacheable tasks to Nx cloud