### PR TITLE
Add Challenges page

### DIFF
--- a/apps/web-app/src/app/app-routing.module.ts
+++ b/apps/web-app/src/app/app-routing.module.ts
@@ -8,6 +8,13 @@ export const routes: Routes = [
       import('@challenge-registry/web/about').then((m) => m.AboutModule),
   },
   {
+    path: 'search',
+    loadChildren: () =>
+      import('@challenge-registry/web/challenges').then(
+        (m) => m.ChallengesModule
+      ),
+  },
+  {
     path: 'login',
     loadChildren: () =>
       import('@challenge-registry/web/login').then((m) => m.LoginModule),

--- a/apps/web-app/src/app/app-sections.ts
+++ b/apps/web-app/src/app/app-sections.ts
@@ -6,7 +6,7 @@ export const APP_SECTIONS: { [key: string]: NavbarSection } = {
     summary: 'About ROCC',
   },
   search: {
-    name: 'Search',
+    name: 'Challenges',
     summary: 'Search challenges',
   },
 };

--- a/libs/web/challenges/.eslintrc.json
+++ b/libs/web/challenges/.eslintrc.json
@@ -1,0 +1,40 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "env": {
+    "jest": true
+  },
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates",
+        "plugin:jest/recommended"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "challengeRegistry",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "challenge-registry",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/web/challenges/README.md
+++ b/libs/web/challenges/README.md
@@ -1,0 +1,7 @@
+# web-challenges
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test web-challenges` to execute the unit tests.

--- a/libs/web/challenges/jest.config.js
+++ b/libs/web/challenges/jest.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  displayName: 'web-challenges',
+  preset: '../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+    },
+  },
+  coverageDirectory: '../../../coverage/libs/web/challenges',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/web/challenges/project.json
+++ b/libs/web/challenges/project.json
@@ -1,0 +1,26 @@
+{
+  "projectType": "library",
+  "root": "libs/web/challenges",
+  "sourceRoot": "libs/web/challenges/src",
+  "prefix": "challenge-registry",
+  "targets": {
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/web/challenges"],
+      "options": {
+        "jestConfig": "libs/web/challenges/jest.config.js",
+        "passWithNoTests": true
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "options": {
+        "lintFilePatterns": [
+          "libs/web/challenges/src/**/*.ts",
+          "libs/web/challenges/src/**/*.html"
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/web/challenges/src/index.ts
+++ b/libs/web/challenges/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/challenges.module';

--- a/libs/web/challenges/src/lib/challenges.component.html
+++ b/libs/web/challenges/src/lib/challenges.component.html
@@ -1,0 +1,5 @@
+<main>
+  <p>challenges works!</p>
+</main>
+
+<challenge-registry-footer [version]="appVersion"></challenge-registry-footer>

--- a/libs/web/challenges/src/lib/challenges.component.spec.ts.off
+++ b/libs/web/challenges/src/lib/challenges.component.spec.ts.off
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChallengesComponent } from './challenges.component';
+
+describe('ChallengesComponent', () => {
+  let component: ChallengesComponent;
+  let fixture: ComponentFixture<ChallengesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ChallengesComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChallengesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/web/challenges/src/lib/challenges.component.ts
+++ b/libs/web/challenges/src/lib/challenges.component.ts
@@ -1,0 +1,15 @@
+import { Component, Inject } from '@angular/core';
+import { APP_CONFIG, AppConfig } from '@challenge-registry/web/config';
+
+@Component({
+  selector: 'challenge-registry-challenges',
+  templateUrl: './challenges.component.html',
+  styleUrls: ['./challenges.component.scss'],
+})
+export class ChallengesComponent {
+  public appVersion: string;
+
+  constructor(@Inject(APP_CONFIG) private appConfig: AppConfig) {
+    this.appVersion = appConfig.appVersion;
+  }
+}

--- a/libs/web/challenges/src/lib/challenges.module.ts
+++ b/libs/web/challenges/src/lib/challenges.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { ChallengesComponent } from './challenges.component';
+import { WebUiModule } from '@challenge-registry/web/ui';
+
+const routes: Routes = [{ path: '', component: ChallengesComponent }];
+
+@NgModule({
+  imports: [CommonModule, RouterModule.forChild(routes), WebUiModule],
+  declarations: [ChallengesComponent],
+  exports: [ChallengesComponent],
+})
+export class ChallengesModule {}

--- a/libs/web/challenges/src/test-setup.ts
+++ b/libs/web/challenges/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/libs/web/challenges/tsconfig.json
+++ b/libs/web/challenges/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/web/challenges/tsconfig.lib.json
+++ b/libs/web/challenges/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/web/challenges/tsconfig.spec.json
+++ b/libs/web/challenges/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/libs/web/org-profile/project.json
+++ b/libs/web/org-profile/project.json
@@ -23,7 +23,5 @@
     }
   },
   "tags": [],
-  "implicitDependencies": [
-    "web-assets"
-  ]
+  "implicitDependencies": ["web-assets"]
 }

--- a/libs/web/org-profile/src/lib/org-profile.component.html
+++ b/libs/web/org-profile/src/lib/org-profile.component.html
@@ -8,7 +8,6 @@
         [routerLinkActiveOptions]="{exact: true}"
         [active]="rla.isActive">{{section.label}}</a>
     </nav>
-    <!-- <challenge-registry-org-profile-overview [org]="org"></challenge-registry-org-profile-overview> -->
 
     <router-outlet></router-outlet>
   </div>

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,6 +25,9 @@
       "@challenge-registry/web/about": ["libs/web/about/src/index.ts"],
       "@challenge-registry/web/assets": ["libs/web/assets/src/index.ts"],
       "@challenge-registry/web/auth": ["libs/web/auth/src/index.ts"],
+      "@challenge-registry/web/challenges": [
+        "libs/web/challenges/src/index.ts"
+      ],
       "@challenge-registry/web/config": ["libs/web/config/src/index.ts"],
       "@challenge-registry/web/home": ["libs/web/home/src/index.ts"],
       "@challenge-registry/web/login": ["libs/web/login/src/index.ts"],

--- a/workspace.json
+++ b/workspace.json
@@ -18,6 +18,7 @@
     "web-app-react-e2e": "apps/web-app-react-e2e",
     "web-assets": "libs/web/assets",
     "web-auth": "libs/web/auth",
+    "web-challenges": "libs/web/challenges",
     "web-config": "libs/web/config",
     "web-home": "libs/web/home",
     "web-login": "libs/web/login",


### PR DESCRIPTION
Adds the Challenges page, previously called "Search" page. The new name and route (`/challenges`) is more descriptive. This change is motivated by our plan to add another "search" page to search for people, organizations and sponsors.

This search page is currently empty. Its original content will be restored in the near future.