### PR TITLE
Add org search page

### DIFF
--- a/apps/web-app/src/app/app-routing.module.ts
+++ b/apps/web-app/src/app/app-routing.module.ts
@@ -15,6 +15,13 @@ export const routes: Routes = [
       ),
   },
   {
+    path: 'orgs',
+    loadChildren: () =>
+      import('@challenge-registry/web/org-search').then(
+        (m) => m.OrgSearchModule
+      ),
+  },
+  {
     path: 'login',
     loadChildren: () =>
       import('@challenge-registry/web/login').then((m) => m.LoginModule),

--- a/libs/web/org-search/.eslintrc.json
+++ b/libs/web/org-search/.eslintrc.json
@@ -1,0 +1,40 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "env": {
+    "jest": true
+  },
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates",
+        "plugin:jest/recommended"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "challengeRegistry",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "challenge-registry",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/web/org-search/README.md
+++ b/libs/web/org-search/README.md
@@ -1,0 +1,7 @@
+# web-org-search
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test web-org-search` to execute the unit tests.

--- a/libs/web/org-search/jest.config.js
+++ b/libs/web/org-search/jest.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  displayName: 'web-org-search',
+  preset: '../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+    },
+  },
+  coverageDirectory: '../../../coverage/libs/web/org-search',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/web/org-search/project.json
+++ b/libs/web/org-search/project.json
@@ -1,0 +1,26 @@
+{
+  "projectType": "library",
+  "root": "libs/web/org-search",
+  "sourceRoot": "libs/web/org-search/src",
+  "prefix": "challenge-registry",
+  "targets": {
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/web/org-search"],
+      "options": {
+        "jestConfig": "libs/web/org-search/jest.config.js",
+        "passWithNoTests": true
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "options": {
+        "lintFilePatterns": [
+          "libs/web/org-search/src/**/*.ts",
+          "libs/web/org-search/src/**/*.html"
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/web/org-search/src/index.ts
+++ b/libs/web/org-search/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/org-search.module';

--- a/libs/web/org-search/src/lib/org-search.component.html
+++ b/libs/web/org-search/src/lib/org-search.component.html
@@ -1,0 +1,5 @@
+<main>
+  <p>org-search works!</p>
+</main>
+
+<challenge-registry-footer [version]="appVersion"></challenge-registry-footer>

--- a/libs/web/org-search/src/lib/org-search.component.spec.ts
+++ b/libs/web/org-search/src/lib/org-search.component.spec.ts
@@ -1,0 +1,28 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { APP_CONFIG, MOCK_APP_CONFIG } from '@challenge-registry/web/config';
+
+import { OrgSearchComponent } from './org-search.component';
+
+describe('OrgSearchComponent', () => {
+  let component: OrgSearchComponent;
+  let fixture: ComponentFixture<OrgSearchComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [OrgSearchComponent],
+      providers: [{ provide: APP_CONFIG, useValue: MOCK_APP_CONFIG }],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OrgSearchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/web/org-search/src/lib/org-search.component.ts
+++ b/libs/web/org-search/src/lib/org-search.component.ts
@@ -1,0 +1,15 @@
+import { Component, Inject } from '@angular/core';
+import { APP_CONFIG, AppConfig } from '@challenge-registry/web/config';
+
+@Component({
+  selector: 'challenge-registry-org-search',
+  templateUrl: './org-search.component.html',
+  styleUrls: ['./org-search.component.scss'],
+})
+export class OrgSearchComponent {
+  public appVersion: string;
+
+  constructor(@Inject(APP_CONFIG) private appConfig: AppConfig) {
+    this.appVersion = appConfig.appVersion;
+  }
+}

--- a/libs/web/org-search/src/lib/org-search.module.ts
+++ b/libs/web/org-search/src/lib/org-search.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+  imports: [CommonModule],
+})
+export class OrgSearchModule {}

--- a/libs/web/org-search/src/lib/org-search.module.ts
+++ b/libs/web/org-search/src/lib/org-search.module.ts
@@ -1,7 +1,14 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { WebUiModule } from '@challenge-registry/web/ui';
+import { OrgSearchComponent } from './org-search.component';
+
+const routes: Routes = [{ path: '', component: OrgSearchComponent }];
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, RouterModule.forChild(routes), WebUiModule],
+  declarations: [OrgSearchComponent],
+  exports: [OrgSearchComponent],
 })
 export class OrgSearchModule {}

--- a/libs/web/org-search/src/test-setup.ts
+++ b/libs/web/org-search/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/libs/web/org-search/tsconfig.json
+++ b/libs/web/org-search/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/web/org-search/tsconfig.lib.json
+++ b/libs/web/org-search/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/web/org-search/tsconfig.spec.json
+++ b/libs/web/org-search/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -35,6 +35,9 @@
       "@challenge-registry/web/org-profile": [
         "libs/web/org-profile/src/index.ts"
       ],
+      "@challenge-registry/web/org-search": [
+        "libs/web/org-search/src/index.ts"
+      ],
       "@challenge-registry/web/pages": ["libs/web/pages/src/index.ts"],
       "@challenge-registry/web/signup": ["libs/web/signup/src/index.ts"],
       "@challenge-registry/web/styles": ["libs/web/styles/src/index.ts"],

--- a/workspace.json
+++ b/workspace.json
@@ -24,6 +24,7 @@
     "web-login": "libs/web/login",
     "web-not-found": "libs/web/not-found",
     "web-org-profile": "libs/web/org-profile",
+    "web-org-search": "libs/web/org-search",
     "web-signup": "libs/web/signup",
     "web-styles": "libs/web/styles",
     "web-themes": "libs/web/themes",


### PR DESCRIPTION
Add org search page. This PR adds the route `/orgs`. The page is currently empty.