### PR TITLE
Add GUI plugin in vscode for jest

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,7 +44,8 @@
     "nrwl.angular-console",
     "stkb.rewrap",
     "webhint.vscode-webhint",
-    "GitHub.vscode-pull-request-github"
+    "GitHub.vscode-pull-request-github",
+    "orta.vscode-jest"
   ],
   "forwardPorts": [
     80,

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,6 +8,7 @@
     "nrwl.angular-console",
     "stkb.rewrap",
     "webhint.vscode-webhint",
-    "GitHub.vscode-pull-request-github"
+    "GitHub.vscode-pull-request-github",
+    "orta.vscode-jest"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,5 +24,11 @@
   "eslint.workingDirectories": [
     "./apps/db-cli",
     "."
-  ]
+  ],
+  "jest.jestCommandLine": "bash -c '. ./dev-env.sh && challenge-registry-test'",
+  "jest.autoRun": {
+    "watch": false,
+    "onSave": "test-file",
+    "onStartup": ["all-tests"]
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,7 +26,8 @@
     "."
   ],
   "jest.autoRun": {
-    "watch": true,
-    "onStartup": ["all-tests"]
+    "watch": false,
+    "onSave": "test-file",
+    "onStartup": []
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,10 +25,8 @@
     "./apps/db-cli",
     "."
   ],
-  "jest.jestCommandLine": "bash -c '. ./dev-env.sh && challenge-registry-test'",
   "jest.autoRun": {
-    "watch": false,
-    "onSave": "test-file",
+    "watch": true,
     "onStartup": ["all-tests"]
   }
 }


### PR DESCRIPTION
- fixes #154 

---
❌  force the extension to run jest testing via nx 

```json
"jest.jestCommandLine": "bash -c '. ./dev-env.sh && challenge-registry-test'",
```
The test can run successfully, but the UI is not displayed properly: 1. pass/fail icons not showing anymore 2. folder is not able to expand 3. the test result (0/0 passed) is not right. Not sure how to make this extension fit our nx config yet. 

<img width="224" alt="Screen Shot 2022-04-25 at 12 40 28 PM" src="https://user-images.githubusercontent.com/73901500/165145350-46a5d48d-5bcc-4226-87a4-d39aea33103f.png">

I just use default settings for now, the caveat is that it will not benefit from the nx caches. The `--runInBand` is enabled by default setting of this extension, so the overall speed is not bad. 

<img width="521" alt="Screen Shot 2022-04-25 at 1 55 43 PM" src="https://user-images.githubusercontent.com/73901500/165146255-04bd03d4-0f42-4568-9c78-a102238929c2.png">

