### PR TITLE
Restore pipenv cache in CI/CD workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,12 @@ jobs:
           python-version: ${{ env.PRIMARY_PYTHON_VERSION }}
       - name: Install pipenv
         run: python -m pip install --upgrade pipenv wheel
-      # - name: Setup pipenv cache
-      #   id: cache-pipenv
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ~/.local/share/virtualenvs
-      #     key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
+      - name: Setup pipenv cache
+        id: cache-pipenv
+        uses: actions/cache@v3
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
       - name: Install Node.js dependencies
         if: steps.cache-node.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -92,12 +92,12 @@ jobs:
           python-version: ${{ env.PRIMARY_PYTHON_VERSION }}
       - name: Install pipenv
         run: python -m pip install --upgrade pipenv wheel
-      # - name: Setup pipenv cache
-      #   id: cache-pipenv
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ~/.local/share/virtualenvs
-      #     key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
+      - name: Setup pipenv cache
+        id: cache-pipenv
+        uses: actions/cache@v3
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
       - name: Install Node.js dependencies
         if: steps.cache-node.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
Fixes #143 

Cache is retained for only [7 days](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy). The cache is now no longer poisoned.