### PR TITLE
Add .code-workspace for API spec development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ nx-cloud.env
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+!.vscode/*.code-workspace
 
 # misc
 /.sass-cache

--- a/.vscode/api-spec.code-workspace
+++ b/.vscode/api-spec.code-workspace
@@ -1,0 +1,13 @@
+{
+  "folders": [
+    {
+      "name": "API specification",
+      "path": "../libs/api-spec"
+    },
+    {
+      "name": "Documentation",
+      "path": "../docs"
+    }
+  ],
+  "settings": {}
+}


### PR DESCRIPTION
Fixes #169

## Changelog

- Define a multi-root VS Code workspace that includes only folders relevant to the development of the challenge registry API spec