### PR TITLE
Describe how to start api before contributing to the web-app

### DIFF
--- a/apps/web-app/README.md
+++ b/apps/web-app/README.md
@@ -5,7 +5,7 @@
 Start the MongoDB instance that hosts the data managed by the challenge registry
 API. The following command must be run from the root of the workspace.
 
-    docker compose up api-db -d
+    docker compose up challenge-registry-api-db -d
 
 Start the challenge registry REST API in development mode.
 

--- a/apps/web-app/README.md
+++ b/apps/web-app/README.md
@@ -1,5 +1,17 @@
 # Challenge Registry Web App
 
+## Development
+
+Start the MongoDB instance that hosts the data managed by the challenge registry
+API. The following command must be run from the root of the workspace.
+
+    docker compose up api-db -d
+
+Start the challenge registry REST API in development mode.
+
+    nx serve api
+
+
 ## TODO
 
 Restore target `test`:

--- a/apps/web-app/README.md
+++ b/apps/web-app/README.md
@@ -2,15 +2,35 @@
 
 ## Development
 
-Start the MongoDB instance that hosts the data managed by the challenge registry
-API. The following command must be run from the root of the workspace.
+Start the REST API server using Docker. This will also start the DB instance
+that backs the REST API. This command must be run from the root of the
+workspace.
 
-    docker compose up challenge-registry-api-db -d
+```console
+docker compose up challenge-registry-api -d
+```
 
-Start the challenge registry REST API in development mode.
+Another option is to start the REST API server in development mode if you aim to
+contribute to it at the same time you develop this web app. In that case, start
+the DB instance using Docker and start the REST API server in development mode.
+See the [README of the REST API](../api/README.md) on how to prepare this
+project. This command must be run from the root of the workspace.
 
-    nx serve api
+```console
+docker compose up challenge-registry-api-db -d
+```
 
+Then, start the REST API server in development mode.
+
+```console
+nx server api
+```
+
+Either way, the web app can now be started in development mode.
+
+```console
+nx serve web-app
+```
 
 ## TODO
 


### PR DESCRIPTION
Fixes #166 

## Changelog

- Describe how to start the challenge registry REST API before starting to contribute to the challenge registry web app.
- The challenge registry REST API already includes instructions on how to start the MongoDB instance required to develop the REST API.