### PR TITLE
Fix challenge registry blank page

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,9 +33,49 @@
 
   // Use 'forwardPorts' to make a list of ports inside the container available
 	// locally.
-  "forwardPorts": [],
+  "forwardPorts": [
+    4200,
+    5432,
+    8080,
+    8081,
+    9000,
+    27017
+  ],
+
+  // Object that maps a port number, "host:port" value, range, or regular
+  // expression to a set of default options.
+  "portsAttributes": {
+    "4200": {
+      "label": "challenge-registry-app"
+    },
+    "5432": {
+      "label": "challenge-keycloak-db",
+      "onAutoForward": "silent"
+    },
+    "8080": {
+      "label": "challenge-registry-api",
+      "onAutoForward": "silent"
+    },
+    "8081": {
+      "label": "challenge-keycloak",
+      "onAutoForward": "silent"
+    },
+    "9000": {
+      "label": "challenge-registry-movie-api",
+      "onAutoForward": "silent"
+    },
+    "27017": {
+      "label": "challenge-registry-api-db",
+      "onAutoForward": "silent"
+    }
+  },
 
   // Comment out to connect as root instead. More info:
   // https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+
+  // Indicates whether VS Code and other devcontainer.json supporting tools
+  // should stop the containers when the related tool window is closed / shut
+  // down.
+  "shutdownAction": "stopContainer"
 }

--- a/apps/web-app/README.md
+++ b/apps/web-app/README.md
@@ -7,7 +7,7 @@ that backs the REST API. This command must be run from the root of the
 workspace.
 
 ```console
-docker compose up challenge-registry-api keycloak -d
+docker compose up challenge-registry-api challenge-keycloak -d
 ```
 
 Another option is to start the REST API server in development mode if you aim to
@@ -17,7 +17,7 @@ See the [README of the REST API](../api/README.md) on how to prepare this
 project. This command must be run from the root of the workspace.
 
 ```console
-docker compose up challenge-registry-api-db keycloak -d
+docker compose up challenge-registry-api-db challenge-keycloak -d
 ```
 
 Then, start the REST API server in development mode.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,14 +58,14 @@ services:
     ports:
       - "9000:9000"
 
-  keycloak:
+  challenge-keycloak:
     image: sagebionetworks/challenge-keycloak:latest
     container_name: challenge-keycloak
     restart: always
     env_file:
-      - ./apps/keycloak/.env
+      - ./apps/challenge-keycloak/.env
     volumes:
-      - ./apps/keycloak/data/h2:/opt/keycloak/data/h2
+      - ./apps/challenge-keycloak/data/h2:/opt/keycloak/data/h2
     networks:
       - challenge-registry
     ports:
@@ -75,15 +75,15 @@ services:
       - challenge-keycloak-db
       - challenge-registry-movie-api  # cheating temporarily to make it easier to start the stack.
 
-  keycloak-db:
+  challenge-keycloak-db:
     image: sagebionetworks/challenge-keycloak-db:latest
     container_name: challenge-keycloak-db
     restart: always
     env_file:
-      - ./apps/keycloak-db/.env
+      - ./apps/challenge-keycloak-db/.env
     volumes:
       - challenge-keycloak-db:/var/lib/postgresql/data
-      - ./apps/keycloak-db/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+      - ./apps/challenge-keycloak-db/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
     networks:
       - challenge-registry
     ports:

--- a/tools/devcontainers/challenge-devcontainer/.devcontainer/devcontainer.json
+++ b/tools/devcontainers/challenge-devcontainer/.devcontainer/devcontainer.json
@@ -25,33 +25,25 @@
   "settings": {},
 
   // Add the IDs of extensions you want installed when the container is created.
-  "extensions": [
-    "dbaeumer.vscode-eslint@2.2.2",
-    "esbenp.prettier-vscode@9.5.0",
-    "firsttris.vscode-jest-runner@0.4.48",
-    "mhutchie.git-graph@1.30.0",
-    "ms-python.python@2022.6.3",
-    "nrwl.angular-console@17.17.0",
-    "stkb.rewrap@1.16.3",
-    "webhint.vscode-webhint@1.6.8",
-    "GitHub.vscode-pull-request-github@0.42.0",
-    "orta.vscode-jest@4.6.0",
-    "humao.rest-client@0.24.6",
-    "vscjava.vscode-java-pack@0.23.0",
-    "Pivotal.vscode-boot-dev-pack@0.1.0",
-    "mtxr.sqltools@0.23.0",
-    "mtxr.sqltools-driver-mysql@0.2.0",
-    "GabrielBB.vscode-lombok@1.0.1"
-  ],
+  "extensions": [],
 
   // Use 'forwardPorts' to make a list of ports inside the container available
 	// locally.
   "forwardPorts": [],
+
+    // Object that maps a port number, "host:port" value, range, or regular
+  // expression to a set of default options.
+  "portsAttributes": {},
 
   // Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "yarn install",
 
   // Comment out to connect as root instead. More info:
   // https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+
+  // Indicates whether VS Code and other devcontainer.json supporting tools
+  // should stop the containers when the related tool window is closed / shut
+  // down.
+  "shutdownAction": "stopContainer"
 }


### PR DESCRIPTION
- Fixes #261 
- Fixes #279

## Solution

The issue was that the web app is requiring Keycloak (KC) to be up and running. Another reason may have been that the KC port may not have been forwarded to the host (see #279).

I may have said that the web app was not yet depending on KC, which is not true. Running the following commands solves the issue should enable to start the backend components with Docker + start the web app in development mode:

```console
challenge-registry-prepare
yarn build-images
docker compose up challenge-registry-api challenge-keycloak -d
nx serve web-app
```

Navigate to http://localhost:4200

Note: The commands listed above work for this commit. They are expected to be renamed in future PRs.