### PR TITLE
Add alias `challenge-docker-stop` to stop running containers

### DIFF
--- a/dev-env.sh
+++ b/dev-env.sh
@@ -96,3 +96,7 @@ function challenge-welcome {
     challenge-nx-cloud-help
   fi
 }
+
+function challenge-docker-stop {
+  docker stop $(docker ps -q)
+}


### PR DESCRIPTION
The projects that compose the backend have now the task `serve-detach` that starts the project using docker. For example, running `challenge-registry-serve` automatically starts all the required backend services using docker.

I currently need to often stop all the containers using `docker stop $(docker ps -q)`. It's not a complicated command but I could use an alias, which is what this PR suggests. The alias is `challenge-docker-stop`.