### PR TITLE
Restore docker networks

### DIFF
--- a/apps/challenge-api-gateway/docker-compose.yml
+++ b/apps/challenge-api-gateway/docker-compose.yml
@@ -8,13 +8,12 @@ services:
     environment:
       - KEYCLOAK_URL=http://challenge-keycloak:8080
       - SERVICE_REGISTRY_URL=http://challenge-service-registry:8081/eureka
-    # networks:
-    #   - challenge
-    network_mode: "host"
+    networks:
+      - challenge
     ports:
       - "8082:8082"
     command: start-dev
 
-# networks:
-#   challenge:
-#     name: challenge
+networks:
+  challenge:
+    name: challenge

--- a/apps/challenge-api-gateway/requests.http
+++ b/apps/challenge-api-gateway/requests.http
@@ -1,6 +1,6 @@
-@serviceRegistryHost = http://localhost:8081
-@apiGatewayHost = http://localhost:8082
-@userServiceHost = http://localhost:8083
+@serviceRegistryHost = http://challenge-service-registry:8081
+@apiGatewayHost = http://challenge-api-gateway:8082
+@userServiceHost = http://challenge-user-service:8083
 @keycloakHost = http://localhost:8080
 
 ### Check API gateway actuator (expected to redirect to Keycloak login page)

--- a/apps/challenge-keycloak/docker-compose.yml
+++ b/apps/challenge-keycloak/docker-compose.yml
@@ -9,13 +9,12 @@ services:
       - .env
     volumes:
       - ./data/h2:/opt/keycloak/data/h2
-    # networks:
-    #   - challenge
-    network_mode: "host"
+    networks:
+      - challenge
     ports:
       - "8080:8080"
     command: start-dev
 
-# networks:
-#   challenge:
-#     name: challenge
+networks:
+  challenge:
+    name: challenge

--- a/apps/challenge-mariadb/docker-compose.yml
+++ b/apps/challenge-mariadb/docker-compose.yml
@@ -9,9 +9,8 @@ services:
       - .env
     volumes:
       - challenge-mariadb:/data/db
-    # networks:
-    #   - challenge
-    network_mode: "host"
+    networks:
+      - challenge
     ports:
       - "3306:3306"
 
@@ -19,6 +18,6 @@ volumes:
   challenge-mariadb:
     name: challenge-mariadb
 
-# networks:
-#   challenge:
-#     name: challenge
+networks:
+  challenge:
+    name: challenge

--- a/apps/challenge-mongodb/docker-compose.yml
+++ b/apps/challenge-mongodb/docker-compose.yml
@@ -7,9 +7,8 @@ services:
     restart: always
     env_file:
       - .env
-    # networks:
-    #   - challenge
-    network_mode: "host"
+    networks:
+      - challenge
     volumes:
       - challenge-mongodb:/data/db
     ports:
@@ -19,6 +18,6 @@ volumes:
   challenge-mongodb:
     name: challenge-mongodb
 
-# networks:
-#   challenge:
-#     name: challenge
+networks:
+  challenge:
+    name: challenge

--- a/apps/challenge-postgresql/docker-compose.yml
+++ b/apps/challenge-postgresql/docker-compose.yml
@@ -9,9 +9,8 @@ services:
     volumes:
       - challenge-postgresql:/var/lib/postgresql/data
       - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
-    # networks:
-    #   - challenge
-    network_mode: "host"
+    networks:
+      - challenge
     ports:
       - "5432:5432"
 
@@ -19,6 +18,6 @@ volumes:
   challenge-postgresql:
     name: challenge-postgresql
 
-# networks:
-#   challenge:
-#     name: challenge
+networks:
+  challenge:
+    name: challenge

--- a/apps/challenge-service-registry/docker-compose.yml
+++ b/apps/challenge-service-registry/docker-compose.yml
@@ -7,13 +7,12 @@ services:
     restart: always
     environment:
       - DEFAULT_ZONE=http://challenge-service-registry:8081/eureka
-    # networks:
-    #   - challenge
-    network_mode: "host"
+    networks:
+      - challenge
     ports:
       - "8081:8081"
     command: start-dev
 
-# networks:
-#   challenge:
-#     name: challenge
+networks:
+  challenge:
+    name: challenge

--- a/apps/challenge-user-service/docker-compose.yml
+++ b/apps/challenge-user-service/docker-compose.yml
@@ -9,13 +9,12 @@ services:
       - KEYCLOAK_URL=http://challenge-keycloak:8080
       - SERVICE_REGISTRY_URL=http://challenge-service-registry:8081/eureka
       - DB_URL=jdbc:mysql://challenge-mariadb:3306/challenge
-    # networks:
-    #   - challenge
-    network_mode: "host"
+    networks:
+      - challenge
     ports:
       - "8083:8083"
     command: start-dev
 
-# networks:
-#   challenge:
-#     name: challenge
+networks:
+  challenge:
+    name: challenge

--- a/apps/challenge-user-service/src/main/resources/application.yml
+++ b/apps/challenge-user-service/src/main/resources/application.yml
@@ -16,6 +16,8 @@ eureka:
   client:
     service-url:
       defaultZone: ${service.registry.url}
+  instance:
+    preferIpAddress: true
 
 management:
   info:

--- a/tools/devcontainers/challenge-devcontainer/.devcontainer/Dockerfile
+++ b/tools/devcontainers/challenge-devcontainer/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@ RUN groupadd docker \
   && apt-get install --no-install-recommends -qq -y \
     ca-certificates curl git bash-completion gnupg2 lsb-release ssh sudo \
     python3-pip python-is-python3 openjdk-17-jre \
-    htop unzip vim wget lsof \
+    htop unzip vim wget lsof iproute2 \
   && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
   && apt-get update -qq -y \
   && apt-get install --no-install-recommends -qq -y \


### PR DESCRIPTION
- Fixes #338 
- Fixes #336 
  - This PR does not replace all the occurrences of `localhost`. This is fine as the remaining occurrences will be replaced when the respective apps are updated.

## Changelogs

- Place ELK+ apps in docker network `challenge-elk`.
- Place backend apps in docker network `challenge`.
- Configure user service to register to Eureka using its IP address instead of its hostname (solves the `localhost` issue).
- Use hostnames aliases instead of `localhost` in `requests.http` of the API gateway.
- Add the command `ip` to the devcontainer to get host and docker IP addresses.