### PR TITLE
Fix coverage in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,15 +52,14 @@ jobs:
         run: yarn nx python api
       - run: yarn nx affected --target=lint --parallel --max-parallel=3
       - run: yarn nx affected --target=build --parallel --max-parallel=3
-      - run: yarn nx affected --target=test --parallel --max-parallel=2
-      # - run: yarn nx run-many --all --target=test --parallel --max-parallel=2
-      # - name: Merge coverage reports
-      #   run: yarn coverage:merge
-      # - name: Push coverage report to Coveralls
-      #   uses: coverallsapp/github-action@master
-      #   with:
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     path-to-lcov: coverage/lcov.info
+      - run: yarn nx run-many --all --target=test --parallel --max-parallel=2
+      - name: Merge coverage reports
+        run: yarn coverage:merge
+      - name: Push coverage report to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: coverage/lcov.info
   pr:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,13 +54,13 @@ jobs:
       - run: yarn nx affected --target=build --parallel --max-parallel=3
       - run: yarn nx affected --target=test --parallel --max-parallel=2
       # - run: yarn nx run-many --all --target=test --parallel --max-parallel=2
-      - name: Merge coverage reports
-        run: yarn coverage:merge
-      - name: Push coverage report to Coveralls
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: coverage/lcov.info
+      # - name: Merge coverage reports
+      #   run: yarn coverage:merge
+      # - name: Push coverage report to Coveralls
+      #   uses: coverallsapp/github-action@master
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     path-to-lcov: coverage/lcov.info
   pr:
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Test again all the projects in the CI workflow instead of just the affected projects. Since we are using Nx Cloud, the CI workflow should be able to leverage the remote cache instead of effectively running the tests for all the projects.