### PR TITLE
Configure Java formatter to use Google Style

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "java.format.enabled": true,
-  "java.format.settings.url": "eclipse-java-google-style.xml",
+  "java.format.settings.url": "${workspaceFolder}/eclipse-java-google-style.xml",
   "java.checkstyle.configuration": "${workspaceFolder}/google_checks.xml",
   "java.checkstyle.version": "10.3",
   "java.jdt.ls.lombokSupport.enabled": false,


### PR DESCRIPTION
Fixes #420 

This PR configure the Java formatter (RedHat) to use Google Style configuration file already located in the root folder. This configuration specifies that the max line length is 100.