### PR TITLE
Install Maven and Java project dependencies sequentially

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,13 @@ jobs:
       - name: Install Node.js dependencies
         if: steps.cache-node.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
-      - name: Prepare the projects
-        run: yarn nx run-many --all --parallel --target=prepare
-      - name: Setup Python virtualenvs
-        if: steps.cache-pipenv.outputs.cache-hit != 'true'
-        run: yarn nx python api
-      - run: yarn nx affected --target=lint --parallel --max-parallel=3
-      - run: yarn nx affected --target=build --parallel --max-parallel=3
+      # - name: Setup Python virtualenvs
+      #   if: steps.cache-pipenv.outputs.cache-hit != 'true'
+      #   run: yarn nx python api
+      - run: yarn nx affected --target=prepare
+      - run: yarn nx affected --target=install-maven --parallel=1
+      - run: yarn nx affected --target=lint
+      - run: yarn nx affected --target=build
       - run: yarn nx run-many --all --target=test --parallel --max-parallel=2
       - name: Merge coverage reports
         run: yarn coverage:merge
@@ -88,12 +88,12 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-      - name: Setup pipenv cache
-        id: cache-pipenv
-        uses: actions/cache@v3
-        with:
-          path: ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
+      # - name: Setup pipenv cache
+      #   id: cache-pipenv
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/.local/share/virtualenvs
+      #     key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
       - name: Setup Maven cache
         uses: actions/cache@v3
         with:
@@ -106,11 +106,11 @@ jobs:
       - name: Install Node.js dependencies
         if: steps.cache-node.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
-      - name: Prepare the projects
-        run: yarn nx run-many --all --parallel --target=prepare
-      - name: Setup Python virtualenvs
-        if: steps.cache-pipenv.outputs.cache-hit != 'true'
-        run: yarn nx python api
-      - run: yarn nx affected --target=lint --parallel --max-parallel=3
-      - run: yarn nx affected --target=build --parallel --max-parallel=3
-      - run: yarn nx affected --target=test --parallel --max-parallel=2
+      # - name: Setup Python virtualenvs
+      #   if: steps.cache-pipenv.outputs.cache-hit != 'true'
+      #   run: yarn nx python api
+      - run: yarn nx affected --target=prepare
+      - run: yarn nx affected --target=install-maven --parallel=1
+      - run: yarn nx affected --target=lint
+      - run: yarn nx affected --target=build
+      - run: yarn nx affected --target=test --parallel=2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,11 @@ jobs:
       #   if: steps.cache-pipenv.outputs.cache-hit != 'true'
       #   run: yarn nx python api
       - run: yarn nx affected --target=prepare
-      - run: yarn nx affected --target=install-maven --parallel=1
+      - run: yarn nx affected --target=prepare-java --parallel=1
       - run: yarn nx affected --target=lint
       - run: yarn nx affected --target=build
-      - run: yarn nx run-many --all --target=test --parallel --max-parallel=2
+      - run: yarn nx affected --target=test
+      # - run: yarn nx run-many --all --target=test --parallel --max-parallel=2
       - name: Merge coverage reports
         run: yarn coverage:merge
       - name: Push coverage report to Coveralls
@@ -110,7 +111,7 @@ jobs:
       #   if: steps.cache-pipenv.outputs.cache-hit != 'true'
       #   run: yarn nx python api
       - run: yarn nx affected --target=prepare
-      - run: yarn nx affected --target=install-maven --parallel=1
+      - run: yarn nx affected --target=prepare-java --parallel=1
       - run: yarn nx affected --target=lint
       - run: yarn nx affected --target=build
-      - run: yarn nx affected --target=test --parallel=2
+      - run: yarn nx affected --target=test

--- a/apps/challenge-api-gateway/project.json
+++ b/apps/challenge-api-gateway/project.json
@@ -10,6 +10,15 @@
         "cwd": "apps/challenge-api-gateway"
       }
     },
+    "install-maven": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "commands": [
+          "./mvnw --version"
+        ],
+        "cwd": "apps/challenge-api-gateway"
+      }
+    },
     "build": {
       "executor": "@nxrocks/nx-spring-boot:build",
       "options": {

--- a/apps/challenge-api-gateway/project.json
+++ b/apps/challenge-api-gateway/project.json
@@ -14,7 +14,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:resolve"
+          "./mvnw dependency:resolve -DexcludeGroupIds=org.sagebionetworks.challenge"
         ],
         "cwd": "apps/challenge-api-gateway"
       }

--- a/apps/challenge-api-gateway/project.json
+++ b/apps/challenge-api-gateway/project.json
@@ -14,7 +14,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge"
+          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge || true"
         ],
         "cwd": "apps/challenge-api-gateway"
       }

--- a/apps/challenge-api-gateway/project.json
+++ b/apps/challenge-api-gateway/project.json
@@ -10,11 +10,11 @@
         "cwd": "apps/challenge-api-gateway"
       }
     },
-    "install-maven": {
+    "prepare-java": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw --version"
+          "./mvnw dependency:resolve"
         ],
         "cwd": "apps/challenge-api-gateway"
       }

--- a/apps/challenge-api-gateway/project.json
+++ b/apps/challenge-api-gateway/project.json
@@ -14,7 +14,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:resolve -DexcludeGroupIds=org.sagebionetworks.challenge"
+          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge"
         ],
         "cwd": "apps/challenge-api-gateway"
       }

--- a/apps/challenge-auth-service/project.json
+++ b/apps/challenge-auth-service/project.json
@@ -10,11 +10,11 @@
         "cwd": "apps/challenge-auth-service"
       }
     },
-    "install-maven": {
+    "prepare-java": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw --version"
+          "./mvnw dependency:resolve"
         ],
         "cwd": "apps/challenge-auth-service"
       }

--- a/apps/challenge-auth-service/project.json
+++ b/apps/challenge-auth-service/project.json
@@ -14,7 +14,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:resolve"
+          "./mvnw dependency:resolve -DexcludeGroupIds=org.sagebionetworks.challenge"
         ],
         "cwd": "apps/challenge-auth-service"
       }

--- a/apps/challenge-auth-service/project.json
+++ b/apps/challenge-auth-service/project.json
@@ -10,6 +10,15 @@
         "cwd": "apps/challenge-auth-service"
       }
     },
+    "install-maven": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "commands": [
+          "./mvnw --version"
+        ],
+        "cwd": "apps/challenge-auth-service"
+      }
+    },
     "build": {
       "executor": "@nxrocks/nx-spring-boot:build",
       "options": {

--- a/apps/challenge-auth-service/project.json
+++ b/apps/challenge-auth-service/project.json
@@ -14,7 +14,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:resolve -DexcludeGroupIds=org.sagebionetworks.challenge"
+          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge"
         ],
         "cwd": "apps/challenge-auth-service"
       }

--- a/apps/challenge-auth-service/project.json
+++ b/apps/challenge-auth-service/project.json
@@ -14,7 +14,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge"
+          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge || true"
         ],
         "cwd": "apps/challenge-auth-service"
       }

--- a/apps/challenge-config-service/project.json
+++ b/apps/challenge-config-service/project.json
@@ -3,6 +3,15 @@
   "sourceRoot": "apps/challenge-config-service/src",
   "projectType": "application",
   "targets": {
+    "install-maven": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "commands": [
+          "./mvnw --version"
+        ],
+        "cwd": "apps/challenge-config-service"
+      }
+    },
     "build": {
       "executor": "@nxrocks/nx-spring-boot:build",
       "options": {

--- a/apps/challenge-config-service/project.json
+++ b/apps/challenge-config-service/project.json
@@ -7,7 +7,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:resolve"
+          "./mvnw dependency:resolve -DexcludeGroupIds=org.sagebionetworks.challenge"
         ],
         "cwd": "apps/challenge-config-service"
       }

--- a/apps/challenge-config-service/project.json
+++ b/apps/challenge-config-service/project.json
@@ -3,11 +3,11 @@
   "sourceRoot": "apps/challenge-config-service/src",
   "projectType": "application",
   "targets": {
-    "install-maven": {
+    "prepare-java": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw --version"
+          "./mvnw dependency:resolve"
         ],
         "cwd": "apps/challenge-config-service"
       }

--- a/apps/challenge-config-service/project.json
+++ b/apps/challenge-config-service/project.json
@@ -7,7 +7,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:resolve -DexcludeGroupIds=org.sagebionetworks.challenge"
+          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge"
         ],
         "cwd": "apps/challenge-config-service"
       }

--- a/apps/challenge-config-service/project.json
+++ b/apps/challenge-config-service/project.json
@@ -7,7 +7,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge"
+          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge || true"
         ],
         "cwd": "apps/challenge-config-service"
       }

--- a/apps/challenge-core-service/pom.xml
+++ b/apps/challenge-core-service/pom.xml
@@ -102,6 +102,23 @@
 					</excludes>
 				</configuration>
 			</plugin>
+      <!-- <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <phase>dependency</phase>
+            <goals>
+              <goal>go-offline</goal>
+            </goals>
+            <configuration>
+              <excludeGroupIds>org.sagebionetworks.challenge</excludeGroupIds>
+              <excludeArtifactIds>challenge-util</excludeArtifactIds>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin> -->
 		</plugins>
     <pluginManagement>
       <plugins>

--- a/apps/challenge-core-service/project.json
+++ b/apps/challenge-core-service/project.json
@@ -14,7 +14,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:resolve"
+          "./mvnw dependency:resolve -DexcludeGroupIds=org.sagebionetworks.challenge"
         ],
         "cwd": "apps/challenge-core-service"
       }

--- a/apps/challenge-core-service/project.json
+++ b/apps/challenge-core-service/project.json
@@ -14,7 +14,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:resolve -DexcludeGroupIds=org.sagebionetworks.challenge"
+          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge"
         ],
         "cwd": "apps/challenge-core-service"
       }

--- a/apps/challenge-core-service/project.json
+++ b/apps/challenge-core-service/project.json
@@ -14,7 +14,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge"
+          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge || true"
         ],
         "cwd": "apps/challenge-core-service"
       }

--- a/apps/challenge-core-service/project.json
+++ b/apps/challenge-core-service/project.json
@@ -10,6 +10,15 @@
         "cwd": "apps/challenge-core-service"
       }
     },
+    "install-maven": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "commands": [
+          "./mvnw --version"
+        ],
+        "cwd": "apps/challenge-core-service"
+      }
+    },
     "build": {
       "executor": "@nxrocks/nx-spring-boot:build",
       "options": {

--- a/apps/challenge-core-service/project.json
+++ b/apps/challenge-core-service/project.json
@@ -10,11 +10,11 @@
         "cwd": "apps/challenge-core-service"
       }
     },
-    "install-maven": {
+    "prepare-java": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw --version"
+          "./mvnw dependency:resolve"
         ],
         "cwd": "apps/challenge-core-service"
       }

--- a/apps/challenge-service-registry/project.json
+++ b/apps/challenge-service-registry/project.json
@@ -10,11 +10,11 @@
         "cwd": "apps/challenge-service-registry"
       }
     },
-    "install-maven": {
+    "prepare-java": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw --version"
+          "./mvnw dependency:resolve"
         ],
         "cwd": "apps/challenge-service-registry"
       }

--- a/apps/challenge-service-registry/project.json
+++ b/apps/challenge-service-registry/project.json
@@ -10,6 +10,15 @@
         "cwd": "apps/challenge-service-registry"
       }
     },
+    "install-maven": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "commands": [
+          "./mvnw --version"
+        ],
+        "cwd": "apps/challenge-service-registry"
+      }
+    },
     "build": {
       "executor": "@nxrocks/nx-spring-boot:build",
       "options": {

--- a/apps/challenge-service-registry/project.json
+++ b/apps/challenge-service-registry/project.json
@@ -14,7 +14,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge"
+          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge || true"
         ],
         "cwd": "apps/challenge-service-registry"
       }

--- a/apps/challenge-service-registry/project.json
+++ b/apps/challenge-service-registry/project.json
@@ -14,7 +14,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:resolve"
+          "./mvnw dependency:resolve -DexcludeGroupIds=org.sagebionetworks.challenge"
         ],
         "cwd": "apps/challenge-service-registry"
       }

--- a/apps/challenge-service-registry/project.json
+++ b/apps/challenge-service-registry/project.json
@@ -14,7 +14,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:resolve -DexcludeGroupIds=org.sagebionetworks.challenge"
+          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge"
         ],
         "cwd": "apps/challenge-service-registry"
       }

--- a/apps/challenge-user-service/project.json
+++ b/apps/challenge-user-service/project.json
@@ -14,7 +14,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:resolve -DexcludeGroupIds=org.sagebionetworks.challenge"
+          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge"
         ],
         "cwd": "apps/challenge-user-service"
       }

--- a/apps/challenge-user-service/project.json
+++ b/apps/challenge-user-service/project.json
@@ -10,11 +10,11 @@
         "cwd": "apps/challenge-user-service"
       }
     },
-    "install-maven": {
+    "prepare-java": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw --version"
+          "./mvnw dependency:resolve"
         ],
         "cwd": "apps/challenge-user-service"
       }

--- a/apps/challenge-user-service/project.json
+++ b/apps/challenge-user-service/project.json
@@ -14,7 +14,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:resolve"
+          "./mvnw dependency:resolve -DexcludeGroupIds=org.sagebionetworks.challenge"
         ],
         "cwd": "apps/challenge-user-service"
       }

--- a/apps/challenge-user-service/project.json
+++ b/apps/challenge-user-service/project.json
@@ -14,7 +14,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge"
+          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge || true"
         ],
         "cwd": "apps/challenge-user-service"
       }

--- a/apps/challenge-user-service/project.json
+++ b/apps/challenge-user-service/project.json
@@ -10,6 +10,15 @@
         "cwd": "apps/challenge-user-service"
       }
     },
+    "install-maven": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "commands": [
+          "./mvnw --version"
+        ],
+        "cwd": "apps/challenge-user-service"
+      }
+    },
     "build": {
       "executor": "@nxrocks/nx-spring-boot:build",
       "options": {

--- a/libs/shared-java/challenge-util/project.json
+++ b/libs/shared-java/challenge-util/project.json
@@ -7,7 +7,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:resolve"
+          "./mvnw dependency:resolve -DexcludeGroupIds=org.sagebionetworks.challenge"
         ],
         "cwd": "libs/shared-java/challenge-util"
       }

--- a/libs/shared-java/challenge-util/project.json
+++ b/libs/shared-java/challenge-util/project.json
@@ -3,6 +3,15 @@
   "sourceRoot": "libs/shared-java/challenge-util/src",
   "projectType": "library",
   "targets": {
+    "install-maven": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "commands": [
+          "./mvnw --version"
+        ],
+        "cwd": "libs/shared-java/challenge-util"
+      }
+    },
     "build": {
       "executor": "@nxrocks/nx-spring-boot:build",
       "options": {

--- a/libs/shared-java/challenge-util/project.json
+++ b/libs/shared-java/challenge-util/project.json
@@ -7,7 +7,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:resolve -DexcludeGroupIds=org.sagebionetworks.challenge"
+          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge"
         ],
         "cwd": "libs/shared-java/challenge-util"
       }

--- a/libs/shared-java/challenge-util/project.json
+++ b/libs/shared-java/challenge-util/project.json
@@ -7,7 +7,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge"
+          "./mvnw dependency:go-offline -DexcludeGroupIds=org.sagebionetworks.challenge || true"
         ],
         "cwd": "libs/shared-java/challenge-util"
       }

--- a/libs/shared-java/challenge-util/project.json
+++ b/libs/shared-java/challenge-util/project.json
@@ -3,11 +3,11 @@
   "sourceRoot": "libs/shared-java/challenge-util/src",
   "projectType": "library",
   "targets": {
-    "install-maven": {
+    "prepare-java": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "./mvnw --version"
+          "./mvnw dependency:resolve"
         ],
         "cwd": "libs/shared-java/challenge-util"
       }


### PR DESCRIPTION
- Fixes #422 
- Fixes #503 

## Changelog

- Install sequentially the maven binary required by each Java project.
- Install sequentially the dependencies of the Java projects.