### PR TITLE
fix: Fix issue that arises when downloading Java dependencies concurrently

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -11,7 +11,11 @@
 
 # When the third script parameter is "1" we are executing a branch checkout
 if [ "$3" = "1" ]; then
+  # Install the Node.js dependencies.
   yarn install --frozen-lockfile
+
+  # Install the Java dependencies.
+  yarn nx run-many --target=prepare-java --parallel=1
 
   # Notify the developer when a different dev container must be used.
   node tools/check-devcontainer-version.js

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,6 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+# Install the Node.js dependencies.
 rm -rf node_modules && yarn install --frozen-lockfile
 
 # Notify the developer when a different dev container must be used.

--- a/.husky/post-rebase
+++ b/.husky/post-rebase
@@ -1,7 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-echo "post-rebased hook called 2"
+echo "post-rebased hook called 3"
 
 # rm -rf node_modules && yarn install --frozen-lockfile
 

--- a/.husky/post-rebase
+++ b/.husky/post-rebase
@@ -1,7 +1,9 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-rm -rf node_modules && yarn install --frozen-lockfile
+echo "post-rebased hook called"
 
-# Notify the developer when a different dev container must be used.
-node tools/check-devcontainer-version.js
+# rm -rf node_modules && yarn install --frozen-lockfile
+
+# # Notify the developer when a different dev container must be used.
+# node tools/check-devcontainer-version.js

--- a/.husky/post-rebase
+++ b/.husky/post-rebase
@@ -1,7 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-echo "post-rebased hook called"
+echo "post-rebased hook called 2"
 
 # rm -rf node_modules && yarn install --frozen-lockfile
 

--- a/.husky/post-rebase
+++ b/.husky/post-rebase
@@ -1,9 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-echo "post-rebased hook called 3"
-
-# rm -rf node_modules && yarn install --frozen-lockfile
-
-# # Notify the developer when a different dev container must be used.
-# node tools/check-devcontainer-version.js

--- a/.husky/post-rewrite
+++ b/.husky/post-rewrite
@@ -1,7 +1,11 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+# Install the Node.js dependencies.
 yarn install --frozen-lockfile
+
+# Install the Java dependencies.
+yarn nx run-many --target=prepare-java --parallel=1
 
 # Notify the developer when a different dev container must be used.
 node tools/check-devcontainer-version.js


### PR DESCRIPTION
Fixes #564

## Note

I adopt the same approach as we use to install the Node.js dependencies: I configured the git hooks to install all the Java dependencies one by one to avoid the concurrency issue.