### PR TITLE
fix: `check-devcontainer-version.js` no longer needs non-native Node packages

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,18 +1,13 @@
 {
   "name": "Challenge",
   "image": "sagebionetworks/challenge-devcontainer:ff081d0a",
-  // "image": "sagebionetworks/challenge-devcontainer:test",
 
   "features": {
-    // docker features must be specified in the developer facing
-    // devcontainer.json for VS Code to properly mount the docker sockets.
     "docker-in-docker": "20.10"
   },
 
-  // Set *default* container specific settings.json values on container create.
   "settings": {},
 
-  // Add the IDs of extensions you want installed when the container is created.
   "extensions": [
     "Angular.ng-template",
     "dbaeumer.vscode-eslint",
@@ -37,8 +32,6 @@
     "1000ch.svgo"
   ],
 
-  // Use 'forwardPorts' to make a list of ports inside the container available
-	// locally.
   "forwardPorts": [
     3306,
     4200,
@@ -61,8 +54,6 @@
     27017
   ],
 
-  // Object that maps a port number, "host:port" value, range, or regular
-  // expression to a set of default options.
   "portsAttributes": {
     "3306": {
       "label": "challenge-mariadb",
@@ -139,15 +130,7 @@
     }
   },
 
-  // Comment out to connect as root instead. More info:
-  // https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
-
-  // Indicates whether VS Code and other devcontainer.json supporting tools
-  // should stop the containers when the related tool window is closed / shut
-  // down.
   "shutdownAction": "stopContainer",
-
-  // An array of Docker CLI arguments
   "runArgs": ["--name", "challenge_devcontainer"]
 }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "ibm-openapi-validator": "^0.55.0",
     "jest": "27.5.1",
     "jest-preset-angular": "11.1.2",
-    "json5": "^2.2.1",
     "ng-packagr": "14.1.0",
     "nx": "14.5.4",
     "postcss": "^8.4.5",

--- a/tools/check-devcontainer-version.js
+++ b/tools/check-devcontainer-version.js
@@ -1,10 +1,9 @@
 'use strict';
 
 const fs = require('fs');
-const JSON5 = require('json5');
 
 const data = fs.readFileSync('.devcontainer/devcontainer.json');
-const json = JSON5.parse(data);
+const json = JSON.parse(data);
 
 const image = json['image'];
 if (image === undefined) {
@@ -25,7 +24,7 @@ if (currentDevcontainerVersion === undefined) {
 }
 
 if (expectedDevcontainerVersion !== currentDevcontainerVersion) {
-  console.info('🐋 The dev container has changed. Please stop the dev container and rebuild it.');
+  console.info('🐋 The dev container has changed. Please rebuild it.');
   // console.debug(`Expected dev container version: ${expectedDevcontainerVersion}`);
   // console.debug(`Current dev container version: ${currentDevcontainerVersion}`);
 }


### PR DESCRIPTION
Fixes #594