### PR TITLE
feat(ui): Fix width of user profile page

### DIFF
--- a/libs/challenge-registry/user-profile/src/lib/user-profile.component.scss
+++ b/libs/challenge-registry/user-profile/src/lib/user-profile.component.scss
@@ -112,6 +112,7 @@ $dl-radius-radius-round: 50%;
   align-self: auto;
   text-align: left;
   text-decoration: none;
+  white-space: nowrap;
 }
 .base-text04 {
   top: 33px;
@@ -121,6 +122,7 @@ $dl-radius-radius-round: 50%;
   align-self: auto;
   text-align: left;
   text-decoration: none;
+  white-space: nowrap;
 }
 .base-updatedat {
   top: 328px;
@@ -141,6 +143,7 @@ $dl-radius-radius-round: 50%;
   align-self: auto;
   text-align: left;
   text-decoration: none;
+  white-space: nowrap;
 }
 .base-text06 {
   top: 32px;
@@ -150,6 +153,7 @@ $dl-radius-radius-round: 50%;
   align-self: auto;
   text-align: left;
   text-decoration: none;
+  white-space: nowrap;
 }
 .base-basic-stats {
   right: 166px;

--- a/libs/challenge-registry/user-profile/src/lib/user-profile.component.scss
+++ b/libs/challenge-registry/user-profile/src/lib/user-profile.component.scss
@@ -4,19 +4,19 @@ $dl-radius-radius-round: 50%;
   min-height: 100vh;
 }
 .base-container1 {
-  width: 1920px;
+  width: 100%;
   height: 2100px;
   display: flex;
   overflow: hidden;
   position: relative;
-  max-width: 1920px;
+  // max-width: 1920px;
   box-sizing: border-box;
   align-items: flex-start;
 }
 .base-top-section {
   top: 1px;
   left: 0px;
-  width: 1920px;
+  width: 100%;
   height: 608px;
   display: flex;
   position: absolute;
@@ -95,7 +95,7 @@ $dl-radius-radius-round: 50%;
 }
 .base-createdat {
   top: 241px;
-  left: 1606px;
+  right: 166px;
   width: 149px;
   height: 57px;
   display: flex;
@@ -124,7 +124,7 @@ $dl-radius-radius-round: 50%;
 }
 .base-updatedat {
   top: 328px;
-  left: 1582px;
+  right: 166px;
   width: 173px;
   height: 56px;
   display: flex;
@@ -152,7 +152,7 @@ $dl-radius-radius-round: 50%;
   text-decoration: none;
 }
 .base-basic-stats {
-  left: 801px;
+  right: 166px;
   width: 954px;
   bottom: 1px;
   height: 100px;
@@ -194,7 +194,7 @@ $dl-radius-radius-round: 50%;
 .base-main-section {
   top: 729px;
   left: 495px;
-  width: 1259px;
+  width: 100%;
   height: 1200px;
   display: flex;
   position: absolute;


### PR DESCRIPTION
fixes #533

I stretch the width to 100% on the user profile page to match navbar and footer, which are using 100% width. The font sizes in the user profile page will remain relatively larger since it's configured using wider predefined screen width - I will leave it for now.

<img width="1902" alt="Screen Shot 2022-08-30 at 4 54 47 PM" src="https://user-images.githubusercontent.com/73901500/187541553-069abba8-e53b-46b8-a464-2cda6937a06d.png">
