### PR TITLE
docs: Add `yarn.lock.readme.md`

### DIFF
--- a/yarn.lock.readme.md
+++ b/yarn.lock.readme.md
@@ -1,0 +1,25 @@
+All of our npm dependencies are locked via the `yarn.lock` file for the following reasons:
+
+- our project has lots of dependencies which update at unpredictable times, so it's important that
+  we update them explicitly once in a while rather than implicitly when any of us runs `yarn install`
+- locked dependencies allow us to reuse yarn cache on CircleCI, significantly speeding up our builds
+  (by 5 minutes or more)
+- locked dependencies allow us to detect when node_modules folder is out of date after a branch switch
+  which allows us to build the project with the correct dependencies every time
+
+Before changing a dependency, do the following:
+
+- make sure you are in sync with `upstream/main`: `git fetch upstream && git rebase upstream/main`
+- ensure that your `node_modules` directory is not stale by running `yarn install`
+
+
+To add a new dependency do the following: `yarn add <packagename> --dev`
+
+To update an existing dependency do the following: run `yarn upgrade <packagename>@<version|latest> --dev`
+or `yarn upgrade <packagename> --dev` to update to the latest version that matches version constraint
+in `package.json`
+
+To Remove an existing dependency do the following: run `yarn remove <packagename>`
+
+
+Once you've changed the dependency, commit the changes to `package.json` & `yarn.lock`, and you are done.

--- a/yarn.lock.readme.md
+++ b/yarn.lock.readme.md
@@ -1,27 +1,26 @@
 All of our npm dependencies are locked via the `yarn.lock` file for the following reasons:
 
-- our project has lots of dependencies which update at unpredictable times, so it's important that
+- Our project has lots of dependencies which update at unpredictable times, so it's important that
   we update them explicitly once in a while rather than implicitly when any of us runs `yarn
-  install`
-- locked dependencies allow us to reuse yarn cache on GitHub, significantly speeding up our builds
-  (by 5 minutes or more)
-- locked dependencies allow us to detect when `node_modules` folder is out of date after a branch
-  switch which allows us to build the project with the correct dependencies every time
+  install`.
+- Locked dependencies allow us to reuse yarn cache on GitHub, significantly speeding up our builds
+  (by 5 minutes or more).
+- Locked dependencies allow us to detect when `node_modules` folder is out of date after a branch
+  switch which allows us to build the project with the correct dependencies every time.
 
 Before changing a dependency, do the following:
 
-- make sure you are in sync with `upstream/main`: `git fetch upstream && git rebase upstream/main`.
-- ensure that your `node_modules` directory is not stale by running `yarn install`.
+- Make sure you are in sync with `upstream/main`: `git fetch upstream && git rebase upstream/main`.
+- Ensure that your `node_modules` directory is not stale by running `yarn install`.
 
 
 To add a new dependency do the following: `yarn add <packagename> --dev`
 
 To update an existing dependency do the following: run `yarn upgrade <packagename>@<version|latest>
---dev`
-or `yarn upgrade <packagename> --dev` to update to the latest version that matches version
-constraint in `package.json`
+--dev` or `yarn upgrade <packagename> --dev` to update to the latest version that matches version
+constraint in `package.json`.
 
-To Remove an existing dependency do the following: run `yarn remove <packagename>`
+To remove an existing dependency do the following: run `yarn remove <packagename>`
 
 
 Once you've changed the dependency, commit the changes to `package.json` & `yarn.lock`, and you are

--- a/yarn.lock.readme.md
+++ b/yarn.lock.readme.md
@@ -1,25 +1,28 @@
 All of our npm dependencies are locked via the `yarn.lock` file for the following reasons:
 
 - our project has lots of dependencies which update at unpredictable times, so it's important that
-  we update them explicitly once in a while rather than implicitly when any of us runs `yarn install`
-- locked dependencies allow us to reuse yarn cache on CircleCI, significantly speeding up our builds
+  we update them explicitly once in a while rather than implicitly when any of us runs `yarn
+  install`
+- locked dependencies allow us to reuse yarn cache on GitHub, significantly speeding up our builds
   (by 5 minutes or more)
-- locked dependencies allow us to detect when node_modules folder is out of date after a branch switch
-  which allows us to build the project with the correct dependencies every time
+- locked dependencies allow us to detect when `node_modules` folder is out of date after a branch
+  switch which allows us to build the project with the correct dependencies every time
 
 Before changing a dependency, do the following:
 
-- make sure you are in sync with `upstream/main`: `git fetch upstream && git rebase upstream/main`
-- ensure that your `node_modules` directory is not stale by running `yarn install`
+- make sure you are in sync with `upstream/main`: `git fetch upstream && git rebase upstream/main`.
+- ensure that your `node_modules` directory is not stale by running `yarn install`.
 
 
 To add a new dependency do the following: `yarn add <packagename> --dev`
 
-To update an existing dependency do the following: run `yarn upgrade <packagename>@<version|latest> --dev`
-or `yarn upgrade <packagename> --dev` to update to the latest version that matches version constraint
-in `package.json`
+To update an existing dependency do the following: run `yarn upgrade <packagename>@<version|latest>
+--dev`
+or `yarn upgrade <packagename> --dev` to update to the latest version that matches version
+constraint in `package.json`
 
 To Remove an existing dependency do the following: run `yarn remove <packagename>`
 
 
-Once you've changed the dependency, commit the changes to `package.json` & `yarn.lock`, and you are done.
+Once you've changed the dependency, commit the changes to `package.json` & `yarn.lock`, and you are
+done.


### PR DESCRIPTION
Fixes #633 

## Notes

- This PR aims to clarify how to add, remove and update npm dependencies. It also provide the main motivations for using `yarn.lock` in this project.