### PR TITLE
feat(java): Serve Spring Boot apps in watch mode with Gradle

### DIFF
--- a/apps/challenge-user-service/build.gradle
+++ b/apps/challenge-user-service/build.gradle
@@ -50,7 +50,6 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-actuator:${springVersion}"
   implementation "org.springframework.boot:spring-boot-starter-web:${springVersion}"
   implementation "org.springframework.boot:spring-boot-starter-security:${springVersion}"
-  implementation "org.springframework.boot:spring-boot-devtools:${springVersion}"
   implementation "org.springframework.cloud:spring-cloud-starter-netflix-eureka-client:${springCloudVersion}"
   implementation "org.springframework.cloud:spring-cloud-starter-openfeign:${springCloudVersion}"
   implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
@@ -60,8 +59,12 @@ dependencies {
   implementation 'org.keycloak:keycloak-admin-client:18.0.0'
   implementation 'com.h2database:h2:2.1.214'
   implementation 'org.sagebionetworks.challenge:challenge-util:0.0.1-SNAPSHOT'
+
+  implementation "org.springframework.boot:spring-boot-devtools:${springVersion}"
+
   compileOnly 'org.projectlombok:lombok:1.18.24'
   runtimeOnly 'mysql:mysql-connector-java:8.0.30'
+
   annotationProcessor 'org.projectlombok:lombok:1.18.24'
 
   testImplementation "org.springframework.boot:spring-boot-starter-test:${springVersion}"
@@ -79,6 +82,10 @@ configurations {
 // configure the integrationTest to run as part of a regular build
 // tasks.named('check') {
 //   dependsOn(testing.suites.integrationTest)
+// }
+
+// bootRun {
+//   addResources = true
 // }
 
 test {

--- a/apps/challenge-user-service/build.gradle
+++ b/apps/challenge-user-service/build.gradle
@@ -79,10 +79,6 @@ configurations {
 //   dependsOn(testing.suites.integrationTest)
 // }
 
-// bootRun {
-//   addResources = true
-// }
-
 test {
 	useJUnitPlatform()
 

--- a/apps/challenge-user-service/build.gradle
+++ b/apps/challenge-user-service/build.gradle
@@ -46,32 +46,27 @@ testing {
 }
 
 dependencies {
-  implementation "org.springframework.boot:spring-boot-starter-data-jpa:${springVersion}"
-  implementation "org.springframework.boot:spring-boot-starter-actuator:${springVersion}"
-  implementation "org.springframework.boot:spring-boot-starter-web:${springVersion}"
-  implementation "org.springframework.boot:spring-boot-starter-security:${springVersion}"
-  implementation "org.springframework.cloud:spring-cloud-starter-netflix-eureka-client:${springCloudVersion}"
-  implementation "org.springframework.cloud:spring-cloud-starter-openfeign:${springCloudVersion}"
-  implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
+  annotationProcessor 'org.projectlombok:lombok:1.18.24'
+  compileOnly 'org.projectlombok:lombok:1.18.24'
+  implementation 'com.h2database:h2:2.1.214'
   implementation 'org.flywaydb:flyway-core:9.3.0'
   implementation 'org.flywaydb:flyway-mysql:9.3.0'
-  implementation 'org.keycloak:keycloak-spring-boot-starter:18.0.0'
   implementation 'org.keycloak:keycloak-admin-client:18.0.0'
-  implementation 'com.h2database:h2:2.1.214'
+  implementation 'org.keycloak:keycloak-spring-boot-starter:18.0.0'
   implementation 'org.sagebionetworks.challenge:challenge-util:0.0.1-SNAPSHOT'
-
+  implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
   implementation "org.springframework.boot:spring-boot-devtools:${springVersion}"
-
-  compileOnly 'org.projectlombok:lombok:1.18.24'
-  runtimeOnly 'mysql:mysql-connector-java:8.0.30'
-
-  annotationProcessor 'org.projectlombok:lombok:1.18.24'
-
-  testImplementation "org.springframework.boot:spring-boot-starter-test:${springVersion}"
-  testImplementation 'org.assertj:assertj-core:3.23.1'
-
-  integrationTestImplementation "org.springframework.boot:spring-boot-starter-test:${springVersion}"
+  implementation "org.springframework.boot:spring-boot-starter-actuator:${springVersion}"
+  implementation "org.springframework.boot:spring-boot-starter-data-jpa:${springVersion}"
+  implementation "org.springframework.boot:spring-boot-starter-security:${springVersion}"
+  implementation "org.springframework.boot:spring-boot-starter-web:${springVersion}"
+  implementation "org.springframework.cloud:spring-cloud-starter-netflix-eureka-client:${springCloudVersion}"
+  implementation "org.springframework.cloud:spring-cloud-starter-openfeign:${springCloudVersion}"
   integrationTestImplementation 'org.assertj:assertj-core:3.23.1'
+  integrationTestImplementation "org.springframework.boot:spring-boot-starter-test:${springVersion}"
+  runtimeOnly 'mysql:mysql-connector-java:8.0.30'
+  testImplementation 'org.assertj:assertj-core:3.23.1'
+  testImplementation "org.springframework.boot:spring-boot-starter-test:${springVersion}"
 }
 
 configurations {

--- a/apps/challenge-user-service/project.json
+++ b/apps/challenge-user-service/project.json
@@ -66,12 +66,16 @@
       }
     },
     "serve": {
-      "executor": "@nxrocks/nx-spring-boot:serve",
+      "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "root": "apps/challenge-user-service"
+        "commands": [
+          "./gradlew build --continuous",
+          "./gradlew bootRun"
+        ],
+        "cwd": "apps/challenge-user-service",
+        "parallel": true
       },
       "dependsOn": [
-        "build",
         "prepare",
         "^serve-detach"
       ]

--- a/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/ChallengeUserServiceApplication.java
+++ b/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/ChallengeUserServiceApplication.java
@@ -17,7 +17,6 @@ import io.swagger.v3.oas.models.info.Info;
 public class ChallengeUserServiceApplication {
 
   public static void main(String[] args) {
-    int a = 1;
     SpringApplication.run(ChallengeUserServiceApplication.class, args);
   }
 

--- a/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/ChallengeUserServiceApplication.java
+++ b/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/ChallengeUserServiceApplication.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.models.info.Info;
 public class ChallengeUserServiceApplication {
 
   public static void main(String[] args) {
+    int a = 1;
     SpringApplication.run(ChallengeUserServiceApplication.class, args);
   }
 


### PR DESCRIPTION
Fixes #701 

## Changelog

- Running `nx serve challenge-user-service` now starts two processes:
  - `./gradlew build --continuous` rebuild the app upon saving files.
  - `./gradlew bootRun` in combination with `spring-boot-devtools` reload the Spring Boot app when build files have changed.

## Preview

```console
$ nx serve challenge-user-service
...

> Task :check
> Task :build

BUILD SUCCESSFUL in 8s
8 actionable tasks: 5 executed, 3 up-to-date

Waiting for changes to input files...
```