### PR TITLE
fix(user-service): fix image build of the User API microservice

### DIFF
--- a/apps/challenge-user-service/build.gradle
+++ b/apps/challenge-user-service/build.gradle
@@ -63,6 +63,10 @@ springBoot {
   mainClass = 'org.sagebionetworks.challenge.ChallengeUserServiceApplication'
 }
 
+bootBuildImage {
+  imageName = 'sagebionetworks/challenge-user-service:latest'
+}
+
 spotless {
   // format 'misc', {
   //   target '*.gradle', '*.md', '.gitignore'

--- a/apps/challenge-user-service/project.json
+++ b/apps/challenge-user-service/project.json
@@ -79,10 +79,7 @@
     "build-image": {
       "executor": "@nxrocks/nx-spring-boot:build-image",
       "options": {
-        "root": "apps/challenge-user-service",
-        "args": [
-          "-Dspring-boot.build-image.imageName=sagebionetworks/challenge-user-service:latest"
-        ]
+        "root": "apps/challenge-user-service"
       },
       "dependsOn": ["^install"]
     },

--- a/apps/challenge-user-service/project.json
+++ b/apps/challenge-user-service/project.json
@@ -98,10 +98,10 @@
   },
   "tags": ["type:service", "scope:backend"],
   "implicitDependencies": [
-    // "challenge-mariadb",
-    // "challenge-keycloak",
-    // "challenge-service-registry",
-    // "challenge-api-gateway",
-    // "shared-java-challenge-util"
+    "challenge-mariadb",
+    "challenge-keycloak",
+    "challenge-service-registry",
+    "challenge-api-gateway",
+    "shared-java-challenge-util"
   ]
 }


### PR DESCRIPTION
Fixes #758 

## Changelog

- Fix how the docker image is built for this first Java project with Gradle.

## Preview

Start the Challenge User API service and all its dependencies (e.g. dockerized MariaDB instance) with:

```console
nx serve-detach challenge-user-service
``

Open your browser and navigate to http://localhost:8083 to access the Swagger UI.