### PR TITLE
feat(devcontainer): add VS Code extension Todo Tree

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,7 @@
     "esbenp.prettier-vscode",
     "firsttris.vscode-jest-runner",
     "GitHub.vscode-pull-request-github",
+    "Gruntfuggly.todo-tree",
     "humao.rest-client",
     "mhutchie.git-graph",
     "mongodb.mongodb-vscode",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,7 @@
     "esbenp.prettier-vscode",
     "firsttris.vscode-jest-runner",
     "GitHub.vscode-pull-request-github",
+    "Gruntfuggly.todo-tree",
     "humao.rest-client",
     "mhutchie.git-graph",
     "mongodb.mongodb-vscode",


### PR DESCRIPTION
Fixes #726

## Changelog

- Add the VS Code extension [Todo Tree](https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.todo-tree) to quickly find TODO across the entire workspace.

## Preview

In VS Code:

`Ctrl + Shift + P` > `Todo Tree: Export tree`:

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/3056480/193921331-7102a2eb-763b-407c-949b-425fdf5fa886.png">

Extension panel is accessible from VS Code vertical toolbar:

<img width="754" alt="image" src="https://user-images.githubusercontent.com/3056480/193921861-fff7d40f-4600-45fe-a4e3-50393605bb83.png">

Support multiple tags (e.g. `TODO` and FIXME`) and allow to create/customize tags:

<img width="620" alt="image" src="https://user-images.githubusercontent.com/3056480/193922620-41f479b5-7ed3-470e-b2ac-cd49e8577f38.png">

