### PR TITLE
chore(deps): disable renovate PR autorebase and enable gradle-wrapper manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":rebaseStalePrs"],
+  "extends": ["config:base"],
   "enabled": true,
   "assignees": ["tschaffter"],
   "semanticCommitScope": "deps",
@@ -8,9 +8,6 @@
   "prHourlyLimit": 2,
   "prConcurrentLimit": 5,
   "gradle": {
-    "enabled": false
-  },
-  "gradle-wrapper": {
     "enabled": false
   },
   "ignorePaths": [


### PR DESCRIPTION
Motivations:

- Avoid wasting CPU time spent in running rebased PR branches
- Free resources for important CI workflow
- Avoid making noise in the contribution graphs