### PR TITLE
fix(api): : add the dependency `^install` to the user service task `serve`

### DIFF
--- a/apps/challenge-user-service/project.json
+++ b/apps/challenge-user-service/project.json
@@ -50,7 +50,7 @@
         "cwd": "apps/challenge-user-service",
         "parallel": true
       },
-      "dependsOn": ["prepare", "^serve-detach"]
+      "dependsOn": ["prepare", "^install", "^serve-detach"]
     },
     "serve-detach": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
## Changelog

- Add the dependency `^install` to the user service task `serve`. This is required to install the local Java libraries that the user service depends on.