### PR TITLE
fix: Increase the max number of file watchers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Challenge",
-  "image": "sagebionetworks/challenge-devcontainer:dbdc75b5",
+  "image": "sagebionetworks/challenge-devcontainer:34f2121",
 
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:1.0.6": {

--- a/tools/devcontainers/challenge/.devcontainer/Dockerfile
+++ b/tools/devcontainers/challenge/.devcontainer/Dockerfile
@@ -46,6 +46,9 @@ RUN groupadd docker \
     -o /tmp/hyperfine.deb \
   && apt-get install --no-install-recommends -qq -y /tmp/hyperfine.deb \
   && rm -fr /tmp/hyperfine.deb \
+  # Increase the max number of file watchers
+  # See https://github.com/Sage-Bionetworks/challenge-registry/issues/856
+  && echo fs.inotify.max_user_watches=524288 | tee -a /etc/sysctl.conf \
   # Cleanup
   && apt-get -y autoclean \
   && apt-get -y autoremove \


### PR DESCRIPTION
Fixes #856

## Preview

The default value was around 8k.

```console
vscode@13deef517dad:/workspaces/challenge-registry$ cat /proc/sys/fs/inotify/max_user_watches
524288
```