### PR TITLE
feat(ui): search page

### DIFF
--- a/libs/challenge-registry/challenge-search/src/_lib-theme.scss
+++ b/libs/challenge-registry/challenge-search/src/_lib-theme.scss
@@ -1,0 +1,5 @@
+@use './lib/challenge-search-theme' as challenge-search;
+
+@mixin theme($theme) {
+  @include challenge-search.theme($theme);
+}

--- a/libs/challenge-registry/challenge-search/src/lib/_challenge-search-theme.scss
+++ b/libs/challenge-registry/challenge-search/src/lib/_challenge-search-theme.scss
@@ -1,0 +1,51 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+
+@mixin color($theme) {
+  $config: mat.get-color-config($theme);
+  $primary: map.get($config, 'primary');
+  $accent: map.get($config, 'accent');
+  $warn: map.get($config, 'warn');
+  $figma: map.get($config, 'figma');
+
+  .search-field > i {
+    color: map.get($figma, dl-color-default-primary2);
+  }
+  .search-field > input {
+    background-color: #fff;
+    border-color: map.get($figma, dl-color-default-hover2);
+  }
+  .search-field > input:active,
+  .search-field > input:focus {
+    border-color: map.get($figma, dl-color-default-primary1);
+  }
+  #top {
+    background-color: #F8F8F8;
+  }
+  .facets {
+    border-color: map.get($figma, dl-color-default-primary2);
+    background-color: rgba(255, 255, 255, 1);
+  }
+  hr {
+    background-color: map.get($figma, dl-color-default-primary2);
+  }
+}
+
+@mixin typography($theme) { 
+  .mat-checkbox,
+  .mat-select {
+    font-family: 'Lato', sans-serif;
+  }
+}
+
+@mixin theme($theme) {
+  $color-config: mat.get-color-config($theme);
+  @if $color-config != null {
+    @include color($theme);
+  }
+
+  $typography-config: mat.get-typography-config($theme);
+  @if $typography-config != null {
+    @include typography($theme);
+  }
+}

--- a/libs/challenge-registry/challenge-search/src/lib/_challenge-search-theme.scss
+++ b/libs/challenge-registry/challenge-search/src/lib/_challenge-search-theme.scss
@@ -29,6 +29,9 @@
     border-color: map.get($figma, dl-color-default-primary2);
     background-color: rgba(255, 255, 255, 1);
   }
+  .mat-option {
+    background: white;
+  }
   hr {
     background-color: map.get($figma, dl-color-default-primary2);
   }

--- a/libs/challenge-registry/challenge-search/src/lib/_challenge-search-theme.scss
+++ b/libs/challenge-registry/challenge-search/src/lib/_challenge-search-theme.scss
@@ -8,6 +8,9 @@
   $warn: map.get($config, 'warn');
   $figma: map.get($config, 'figma');
 
+  #breadcrumbs a {
+    color: black;
+  }
   .search-field > i {
     color: map.get($figma, dl-color-default-primary2);
   }
@@ -32,6 +35,12 @@
 }
 
 @mixin typography($theme) { 
+  #breadcrumbs a {
+    text-decoration: none;
+  }
+  #breadcrumbs span {
+    font-weight: bolder;
+  }
   .mat-checkbox,
   .mat-select {
     font-family: 'Lato', sans-serif;

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
@@ -8,12 +8,13 @@
     <div id="title" class="row">
       <div class="col col-10">
         <h2>Search the Challenge Registry</h2>
+        <!-- TODO: add "Add Challenge" button when service is available -->
       </div>
       <div class="col col-2">
         <div class="stats-group">
           <div class="stat-item">
-            <h4>97</h4>
-            <p class="mat-caption">in the registry</p>
+            <h4>0</h4>
+            <p class="mat-caption">total in the registry</p>
           </div>
         </div>
       </div>

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
@@ -30,23 +30,41 @@
   </section>
   <section id="bottom" class="row">
     <div class="facets col">
-      <h4>Challenge Year</h4>
-      <mat-form-field appearance="fill" class="facet-year">
-        <mat-label></mat-label>
-        <mat-select>
-          <mat-option value="all">All</mat-option>
-          <mat-option value="2022">2022</mat-option>
-          <mat-option value="2021">2021</mat-option>
-        </mat-select>
-      </mat-form-field>
+      <mat-accordion class="facet-year">
+        <mat-expansion-panel (opened)="panelOpenState = true"
+                             (closed)="panelOpenState = false"
+                             [expanded]="true">
+          <mat-expansion-panel-header>
+            <mat-panel-title>
+              Challenge Year
+            </mat-panel-title>
+          </mat-expansion-panel-header>
+          <mat-form-field appearance="fill" class="facet-year">
+            <mat-label></mat-label>
+            <mat-select [(ngModel)]="yearSelect">
+              <mat-option value="all">All</mat-option>
+              <mat-option value="2022">2022</mat-option>
+              <mat-option value="2021">2021</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </mat-expansion-panel>
+      </mat-accordion>
       <hr />
-      <div>
-        <h4>Status</h4>
-        <p><mat-checkbox formControlName="upcoming">Upcoming</mat-checkbox></p>
-        <p><mat-checkbox formControlName="active">Active</mat-checkbox></p>
-        <p><mat-checkbox formControlName="onging">Ongoing</mat-checkbox></p>
-        <p><mat-checkbox formControlName="completed">Completed</mat-checkbox></p>
-      </div>
+      <mat-accordion class="facet-status">
+        <mat-expansion-panel (opened)="panelOpenState = true"
+                             (closed)="panelOpenState = false"
+                             [expanded]="true">
+          <mat-expansion-panel-header>
+            <mat-panel-title>
+              Status
+            </mat-panel-title>
+          </mat-expansion-panel-header>
+          <p><mat-checkbox formControlName="upcoming">Upcoming</mat-checkbox></p>
+          <p><mat-checkbox formControlName="active">Active</mat-checkbox></p>
+          <p><mat-checkbox formControlName="onging">Ongoing</mat-checkbox></p>
+          <p><mat-checkbox formControlName="completed">Completed</mat-checkbox></p>
+        </mat-expansion-panel>
+      </mat-accordion>
       <hr />
       <mat-accordion class="facet-difficulty">
         <mat-expansion-panel (opened)="panelOpenState = true"

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
@@ -1,6 +1,6 @@
 <div class="base mat-typography">
   <section id="top">
-    <div class="breadcrumbs">
+    <div id="breadcrumbs" class="row">
       <a aria-label="Back to home" href="/home"><mat-icon aria-hidden="true">home</mat-icon></a>
       <mat-icon aria-hidden="true">chevron_right</mat-icon>
       <span class="current-crumb">Search</span>

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
@@ -48,12 +48,19 @@
         <p><mat-checkbox formControlName="completed">Completed</mat-checkbox></p>
       </div>
       <hr />
-      <div>
-        <h4>Difficulty</h4>
-        <p><mat-checkbox formControlName="beginners">Good for Beginners</mat-checkbox></p>
-        <p><mat-checkbox formControlName="general">General</mat-checkbox></p>
-        <p><mat-checkbox formControlName="advanced">Advanced</mat-checkbox></p>
-      </div>
+      <mat-accordion class="facet-difficulty">
+        <mat-expansion-panel (opened)="panelOpenState = true"
+                             (closed)="panelOpenState = false">
+          <mat-expansion-panel-header>
+            <mat-panel-title>
+              Difficulty
+            </mat-panel-title>
+          </mat-expansion-panel-header>
+          <p><mat-checkbox formControlName="beginners">Good for Beginners</mat-checkbox></p>
+          <p><mat-checkbox formControlName="general">General</mat-checkbox></p>
+          <p><mat-checkbox formControlName="advanced" [disabled]="true">Advanced</mat-checkbox></p>
+        </mat-expansion-panel>
+      </mat-accordion>
     </div>
     <div class="main col">
       <h3>Results (0)</h3>

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
@@ -1,5 +1,29 @@
-<main>
-  <p>challenge-search works!</p>
-</main>
+<div class="base mat-typography">
+  <section id="top">
+    <div class="breadcrumbs">
+      <a aria-label="Back to home" href="/home"><mat-icon aria-hidden="true">home</mat-icon></a>
+      <mat-icon aria-hidden="true">chevron_right</mat-icon>
+      <span class="current-crumb">search</span>
+    </div>
+    <div class="row">
+      <div class="col">
+        <h2>Search the Challenge Registry</h2>
+      </div>
+      <div class="col">
+        97 total challenges
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col">
+        <div class="control control-expanded">
+          <input class="input" type="search" name="search" placeholder="Search challenges" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <section id="facets"></section>
+  <section id="main"></section>
+</div>
 
 <challenge-registry-footer [version]="appVersion"></challenge-registry-footer>

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
@@ -3,17 +3,21 @@
     <div class="breadcrumbs">
       <a aria-label="Back to home" href="/home"><mat-icon aria-hidden="true">home</mat-icon></a>
       <mat-icon aria-hidden="true">chevron_right</mat-icon>
-      <span class="current-crumb">search</span>
+      <span class="current-crumb">Search</span>
     </div>
-    <div class="row">
-      <div class="col">
+    <div id="title" class="row">
+      <div class="col col-10">
         <h2>Search the Challenge Registry</h2>
       </div>
-      <div class="col">
-        97 total challenges
+      <div class="col col-2">
+        <div class="stats-group">
+          <div class="stat-item">
+            <h4>97</h4>
+            <p class="mat-caption">in the registry</p>
+          </div>
+        </div>
       </div>
     </div>
-
     <div class="row">
       <div class="col">
         <div class="search-field">

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
@@ -31,7 +31,7 @@
   <section id="bottom" class="row">
     <div class="facets col">
       <h4>Challenge Year</h4>
-      <mat-form-field appearance="fill">
+      <mat-form-field appearance="fill" class="facet-year">
         <mat-label></mat-label>
         <mat-select>
           <mat-option value="all">All</mat-option>

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
@@ -3,7 +3,7 @@
     <div id="breadcrumbs" class="row">
       <a aria-label="Back to home" href="/home"><mat-icon aria-hidden="true">home</mat-icon></a>
       <mat-icon aria-hidden="true">chevron_right</mat-icon>
-      <span class="current-crumb">Search</span>
+      <span>Search</span>
     </div>
     <div id="title" class="row">
       <div class="col col-10">

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
@@ -27,8 +27,38 @@
       </div>
     </div>
   </section>
-  <section id="facets"></section>
-  <section id="main"></section>
+  <section id="bottom" class="row">
+    <div class="facets col">
+      <h4>Challenge Year</h4>
+      <mat-form-field appearance="fill">
+        <mat-label></mat-label>
+        <mat-select>
+          <mat-option value="all">All</mat-option>
+          <mat-option value="2022">2022</mat-option>
+          <mat-option value="2021">2021</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <hr />
+      <div>
+        <h4>Status</h4>
+        <p><mat-checkbox formControlName="upcoming">Upcoming</mat-checkbox></p>
+        <p><mat-checkbox formControlName="active">Active</mat-checkbox></p>
+        <p><mat-checkbox formControlName="onging">Ongoing</mat-checkbox></p>
+        <p><mat-checkbox formControlName="completed">Completed</mat-checkbox></p>
+      </div>
+      <hr />
+      <div>
+        <h4>Difficulty</h4>
+        <p><mat-checkbox formControlName="beginners">Good for Beginners</mat-checkbox></p>
+        <p><mat-checkbox formControlName="general">General</mat-checkbox></p>
+        <p><mat-checkbox formControlName="advanced">Advanced</mat-checkbox></p>
+      </div>
+    </div>
+    <div class="main col">
+      <h3>Results (0)</h3>
+      <!-- TODO: cards will be listed here -->
+    </div>
+  </section>
 </div>
 
 <challenge-registry-footer [version]="appVersion"></challenge-registry-footer>

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.html
@@ -16,8 +16,9 @@
 
     <div class="row">
       <div class="col">
-        <div class="control control-expanded">
-          <input class="input" type="search" name="search" placeholder="Search challenges" />
+        <div class="search-field">
+          <input aria-label="Search the registry" type="text" placeholder="Search challenges"/>
+          <i><mat-icon aria-hidden="true">search</mat-icon></i>
         </div>
       </div>
     </div>

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.scss
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.scss
@@ -96,6 +96,7 @@
   border-radius: 8px;
 }
 .facet-year,
+.facet-status,
 .facet-difficulty {
   width: 100%;
 }

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.scss
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.scss
@@ -1,0 +1,61 @@
+.row {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  width: 100%;
+}
+.col {
+  display: flex;
+  flex-direction: column;
+  flex-basis: 100%;
+}
+
+// INPUT FORMS
+.input {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  background-color: #fff;
+  height: 48px;
+  max-width: 100%;
+  width: 100%;
+  font-size: 14px;
+  color: #565678;
+  padding: 13px 16px;
+  border: solid #d2daf0 2px;
+  box-shadow: none;
+}
+.input::-webkit-input-placeholder {
+  color: #ababc9;
+}
+.input:-ms-input-placeholder {
+  color: #ababc9;
+}
+.input::-ms-input-placeholder {
+  color: #ababc9;
+}
+.input::placeholder {
+  color: #ababc9;
+}
+.input::-ms-input-placeholder {
+  color: #ababc9;
+}
+.input:-ms-input-placeholder {
+  color: #ababc9;
+}
+.input:hover {
+  border-color: #bfcaea;
+}
+.input:active,
+.input:focus {
+  outline: none;
+  border-color: #ababc9;
+}
+
+#top {
+  padding: 25px 32px 80px;
+  background-color: #F8F8F8;
+}
+
+#top h2 {
+  padding: 70px 0 12px;
+}

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.scss
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.scss
@@ -95,8 +95,15 @@
   border-width: 2px;
   border-radius: 8px;
 }
-.facet-year {
+.facet-year,
+.facet-difficulty {
   width: 100%;
+}
+.mat-expansion-panel-header {
+  padding: 0 18px 21px 0;
+}
+::ng-deep .mat-expansion-panel-body {
+  padding: 0 5px !important;
 }
 .main {
   margin: 18px;

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.scss
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.scss
@@ -29,7 +29,6 @@
     max-width: 1120px;
   }
 }
-
 .search-field {
   position: relative;
 }
@@ -97,12 +96,13 @@
   border-width: 2px;
   border-radius: 8px;
 }
+.facet-year {
+  width: 100%;
+}
 .main {
   margin: 18px;
 }
-.example-margin {
-  margin: 0 10px;
-}
+
 hr {
   border: 0;
   clear:both;

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.scss
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.scss
@@ -10,6 +10,22 @@
   flex-basis: 100%;
 }
 
+
+@media screen and (min-width: 800px) {
+  .col-1 {
+    flex: 1;
+  }
+  .col-2 {
+    flex: 2;
+  }
+  .col-10 {
+    flex: 10;
+  }
+  .col-11 {
+    flex: 11;
+  }
+}
+
 // INPUT FORMS
 input {
   -moz-appearance: none;
@@ -73,6 +89,23 @@ input:focus {
   background-color: #F8F8F8;
 }
 
-#top h2 {
-  padding: 70px 0 12px;
+#title {
+  padding: 70px 0 32px;
+}
+
+.stats-group {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  width: 100%;
+  justify-content: center;
+}
+.stat-item {
+  flex-direction: column;
+  flex: 1;
+  max-width: 120px;
+  padding: 18px 5px 8px;
+  border-style: solid;
+  border-width: 1px;
+  text-align: center;
 }

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.scss
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.scss
@@ -59,7 +59,6 @@
 .search-field > input:focus {
   outline: none;
 }
-
 #top {
   padding: 25px 32px 80px;
 }
@@ -102,7 +101,6 @@
 .main {
   margin: 18px;
 }
-
 hr {
   border: 0;
   clear:both;

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.scss
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.scss
@@ -9,8 +9,6 @@
   flex-direction: column;
   flex-basis: 100%;
 }
-
-
 @media screen and (min-width: 800px) {
   .col-1 {
     flex: 1;
@@ -24,48 +22,14 @@
   .col-11 {
     flex: 11;
   }
+  .facets {
+    max-width: 320px;
+  }
+  .main {
+    max-width: 1120px;
+  }
 }
 
-// INPUT FORMS
-input {
-  -moz-appearance: none;
-  -webkit-appearance: none;
-  background-color: #fff;
-  height: 48px;
-  max-width: 100%;
-  width: 100%;
-  font-size: 14px;
-  color: #565678;
-  padding: 13px 16px;
-  border: solid #d2daf0 2px;
-  box-shadow: none;
-}
-input::-webkit-input-placeholder {
-  color: #ababc9;
-}
-input:-ms-input-placeholder {
-  color: #ababc9;
-}
-input::-ms-input-placeholder {
-  color: #ababc9;
-}
-input::placeholder {
-  color: #ababc9;
-}
-input::-ms-input-placeholder {
-  color: #ababc9;
-}
-input:-ms-input-placeholder {
-  color: #ababc9;
-}
-input:hover {
-  border-color: #bfcaea;
-}
-input:active,
-input:focus {
-  outline: none;
-  border-color: #ababc9;
-}
 .search-field {
   position: relative;
 }
@@ -74,38 +38,76 @@ input:focus {
   display: block;
   transform: translate(0, -50%);
   top: 50%;
-  color: #ababc9;
   pointer-events: none;
   width: 45px;
   text-align: center;
   font-style: normal;
 }
 .search-field > input {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  height: 48px;
+  max-width: 100%;
+  width: 100%;
+  font-size: 14px;
+  padding: 13px 16px;
+  border-style: solid;
+  border-width: 2px;
+  box-shadow: none;
   padding: 0 45px;
+}
+.search-field > input:active,
+.search-field > input:focus {
+  outline: none;
 }
 
 #top {
   padding: 25px 32px 80px;
-  background-color: #F8F8F8;
 }
-
 #title {
   padding: 70px 0 32px;
 }
-
 .stats-group {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   width: 100%;
   justify-content: center;
+  // justify-content: flex-end;
 }
 .stat-item {
   flex-direction: column;
   flex: 1;
-  max-width: 120px;
+  max-width: 148px;
   padding: 18px 5px 8px;
   border-style: solid;
   border-width: 1px;
   text-align: center;
+}
+#bottom {
+  margin: 50px 0;
+}
+.facets {
+  margin: 18px;
+  padding: 48px 21px;
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  border-style: solid;
+  border-width: 2px;
+  border-radius: 8px;
+}
+.main {
+  margin: 18px;
+}
+.example-margin {
+  margin: 0 10px;
+}
+hr {
+  border: 0;
+  clear:both;
+  display:block;
+  width: 96%;               
+  height: 1px;
+  margin-bottom: 26px;
 }

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.scss
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.scss
@@ -11,7 +11,7 @@
 }
 
 // INPUT FORMS
-.input {
+input {
   -moz-appearance: none;
   -webkit-appearance: none;
   background-color: #fff;
@@ -24,31 +24,48 @@
   border: solid #d2daf0 2px;
   box-shadow: none;
 }
-.input::-webkit-input-placeholder {
+input::-webkit-input-placeholder {
   color: #ababc9;
 }
-.input:-ms-input-placeholder {
+input:-ms-input-placeholder {
   color: #ababc9;
 }
-.input::-ms-input-placeholder {
+input::-ms-input-placeholder {
   color: #ababc9;
 }
-.input::placeholder {
+input::placeholder {
   color: #ababc9;
 }
-.input::-ms-input-placeholder {
+input::-ms-input-placeholder {
   color: #ababc9;
 }
-.input:-ms-input-placeholder {
+input:-ms-input-placeholder {
   color: #ababc9;
 }
-.input:hover {
+input:hover {
   border-color: #bfcaea;
 }
-.input:active,
-.input:focus {
+input:active,
+input:focus {
   outline: none;
   border-color: #ababc9;
+}
+.search-field {
+  position: relative;
+}
+.search-field > i {
+  position: absolute;
+  display: block;
+  transform: translate(0, -50%);
+  top: 50%;
+  color: #ababc9;
+  pointer-events: none;
+  width: 45px;
+  text-align: center;
+  font-style: normal;
+}
+.search-field > input {
+  padding: 0 45px;
 }
 
 #top {

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.ts
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.ts
@@ -8,6 +8,7 @@ import { ConfigService } from '@sagebionetworks/challenge-registry/config';
 })
 export class ChallengeSearchComponent {
   public appVersion: string;
+  panelOpenState = true;
 
   constructor(private readonly configService: ConfigService) {
     this.appVersion = this.configService.config.appVersion;

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.ts
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.component.ts
@@ -8,6 +8,7 @@ import { ConfigService } from '@sagebionetworks/challenge-registry/config';
 })
 export class ChallengeSearchComponent {
   public appVersion: string;
+  yearSelect = 'all';
   panelOpenState = true;
 
   constructor(private readonly configService: ConfigService) {

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.module.ts
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.module.ts
@@ -4,6 +4,9 @@ import { RouterModule, Routes } from '@angular/router';
 import { UiModule } from '@sagebionetworks/challenge-registry/ui';
 import { MatIconModule } from '@angular/material/icon';
 import { ChallengeSearchComponent } from './challenge-search.component';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 
 const routes: Routes = [{ path: '', component: ChallengeSearchComponent }];
 
@@ -13,6 +16,9 @@ const routes: Routes = [{ path: '', component: ChallengeSearchComponent }];
     MatIconModule,
     RouterModule.forChild(routes),
     UiModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatCheckboxModule,
   ],
   declarations: [ChallengeSearchComponent],
   exports: [ChallengeSearchComponent],

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.module.ts
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.module.ts
@@ -2,12 +2,18 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Routes } from '@angular/router';
 import { UiModule } from '@sagebionetworks/challenge-registry/ui';
+import { MatIconModule } from '@angular/material/icon';
 import { ChallengeSearchComponent } from './challenge-search.component';
 
 const routes: Routes = [{ path: '', component: ChallengeSearchComponent }];
 
 @NgModule({
-  imports: [CommonModule, RouterModule.forChild(routes), UiModule],
+  imports: [
+    CommonModule,
+    MatIconModule,
+    RouterModule.forChild(routes),
+    UiModule,
+  ],
   declarations: [ChallengeSearchComponent],
   exports: [ChallengeSearchComponent],
 })

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.module.ts
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.module.ts
@@ -8,6 +8,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatExpansionModule } from '@angular/material/expansion';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 const routes: Routes = [{ path: '', component: ChallengeSearchComponent }];
 
@@ -21,6 +22,8 @@ const routes: Routes = [{ path: '', component: ChallengeSearchComponent }];
     MatSelectModule,
     MatCheckboxModule,
     MatExpansionModule,
+    FormsModule,
+    ReactiveFormsModule,
   ],
   declarations: [ChallengeSearchComponent],
   exports: [ChallengeSearchComponent],

--- a/libs/challenge-registry/challenge-search/src/lib/challenge-search.module.ts
+++ b/libs/challenge-registry/challenge-search/src/lib/challenge-search.module.ts
@@ -7,6 +7,7 @@ import { ChallengeSearchComponent } from './challenge-search.component';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatExpansionModule } from '@angular/material/expansion';
 
 const routes: Routes = [{ path: '', component: ChallengeSearchComponent }];
 
@@ -19,6 +20,7 @@ const routes: Routes = [{ path: '', component: ChallengeSearchComponent }];
     MatFormFieldModule,
     MatSelectModule,
     MatCheckboxModule,
+    MatExpansionModule,
   ],
   declarations: [ChallengeSearchComponent],
   exports: [ChallengeSearchComponent],

--- a/libs/challenge-registry/themes/src/_index.scss
+++ b/libs/challenge-registry/themes/src/_index.scss
@@ -4,6 +4,7 @@
 @use 'libs/challenge-registry/user-profile/src/lib-theme' as challenge-registry-user-profile;
 @use 'libs/challenge-registry/home/src/lib-theme' as challenge-registry-home;
 @use 'libs/challenge-registry/team/src/lib-theme' as challenge-registry-team;
+@use 'libs/challenge-registry/challenge-search/src/lib-theme' as challenge-search;
 
 @mixin theme($theme) {
   @include challenge-registry-org-profile.theme($theme);
@@ -12,4 +13,5 @@
   @include challenge-registry-ui.theme($theme);
   @include challenge-registry-home.theme($theme);
   @include challenge-registry-team.theme($theme);
+  @include challenge-search.theme($theme);
 }


### PR DESCRIPTION
Addresses #748:
![search-page](https://user-images.githubusercontent.com/9377970/202335729-d964624f-e30a-4264-bced-d791da675bb1.png)

Notes:
* Breadcrumbs still need some alignment adjustments but I figured we had enough to get the idea for now.
* The "Add Challenge" button is not added yet; will incorporate in 2023 Q1 when the service is ready.
* The "Sort by" is not added; I couldn't remember if this was an option with the pagination component already?
* For facets, I only listed 3 for now and get those working first.
* Not sure what's going on but the `mat-select-panel` is transparent and I wasn't able to adjust the background color:

    ![Screen Shot 2022-11-17 at 2 45 05 PM](https://user-images.githubusercontent.com/9377970/202576218-1bdec392-0784-41bc-9f06-f6e684d8124c.png)

    I found a related [SO post here](https://stackoverflow.com/questions/52988519/mat-select-options-became-transparent-after-updating-to-angular-material-v7) -- maybe this is our issue too?
* Couldn't get the `mat-checkbox` to respond..... 

TODOs (will finish in this PR):
- [x] Fix breadcrumb text and icon alignment
- ~[ ] Get `mat-checkbox` to be clickable~