### PR TITLE
chore: Update dev container used in CI workflow

### DIFF
--- a/.github/workflows/build-devcontainer-image.yml
+++ b/.github/workflows/build-devcontainer-image.yml
@@ -5,11 +5,13 @@ on:
       - 'main'
     paths:
       - '.github/workflows/build-devcontainer-image.yml'
-      - 'tools/devcontainers/challenge/**/*'
+      - 'tools/devcontainers/challenge/**/devcontainer.json'
+      - 'tools/devcontainers/challenge/**/Dockerfile'
   pull_request:
     paths:
       - '.github/workflows/build-devcontainer-image.yml'
-      - 'tools/devcontainers/challenge/**/*'
+      - 'tools/devcontainers/challenge/**/devcontainer.json'
+      - 'tools/devcontainers/challenge/**/Dockerfile'
 
 env:
   IMAGE_REPOSITORY: sagebionetworks/challenge-devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   push:
     runs-on: ubuntu-latest
     container:
-      image: sagebionetworks/challenge-devcontainer:ff081d0a
+      image: sagebionetworks/challenge-devcontainer:3fcdecd
       options: --user root
     if: ${{ github.event_name != 'pull_request' }}
     # env:
@@ -97,7 +97,7 @@ jobs:
   pr:
     runs-on: ubuntu-latest
     container:
-      image: sagebionetworks/challenge-devcontainer:ff081d0a
+      image: sagebionetworks/challenge-devcontainer:3fcdecd
       options: --user root
     # Runs this job if triggered by a PR and if at least one of these conditions are true:
     # - the PR originate from a fork
@@ -106,8 +106,8 @@ jobs:
     if: |
       github.event_name == 'pull_request'
         && (
-          github.event.pull_request.head.repo.full_name != 
-            github.event.pull_request.base.repo.full_name 
+          github.event.pull_request.head.repo.full_name !=
+            github.event.pull_request.base.repo.full_name
           || !startsWith(github.head_ref, 'renovate/')
         )
     steps:

--- a/tools/devcontainers/challenge/.devcontainer/README.md
+++ b/tools/devcontainers/challenge/.devcontainer/README.md
@@ -1,8 +1,1 @@
 https://code.visualstudio.com/docs/remote/devcontainer-cli
-
-```console
-devcontainer build \
-  --image-name sagebionetworks/challenge-devcontainer \
-  --no-cache \
-  --disable-telemetry true
-```


### PR DESCRIPTION
## Changelog

- The CI workflow now uses the latest version of the dev container.
- The GH workflow only build a new dev container when its definition has changed (e.g. not when README.md has changed).