### PR TITLE
fix: Fix Keycloak undefined `window` when using SSR

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,8 +7,12 @@
   "python.linting.pylintEnabled": false,
   "python.linting.flake8Enabled": true,
   "python.formatting.provider": "black",
-  "eslint.format.enable": true,
   "editor.tabSize": 2,
+  "editor.formatOnSave": false,
+  "editor.codeActionsOnSave": {
+    // "source.fixAll": false,
+    "source.fixAll.eslint": true
+  },
   "python.formatting.blackArgs": [],
   "[python]": {
     "editor.formatOnSave": true,
@@ -18,13 +22,13 @@
     "editor.tabSize": 2
   },
   // "[typescript]": {
-  //   "editor.defaultFormatter": "vscode.typescript-language-features",
+  //   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  //   "editor.formatOnSave": false
+  // },
+  // "[javascript]": {
+  //   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
   //   "editor.formatOnSave": true
   // },
-  "[javascript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
-    "editor.formatOnSave": true
-  },
   "java.format.enabled": false,
   "[java]": {
     "editor.formatOnSave": false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,10 +17,10 @@
   "[json]": {
     "editor.tabSize": 2
   },
-  "[typescript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features",
-    "editor.formatOnSave": true
-  },
+  // "[typescript]": {
+  //   "editor.defaultFormatter": "vscode.typescript-language-features",
+  //   "editor.formatOnSave": true
+  // },
   "[javascript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint",
     "editor.formatOnSave": true

--- a/apps/challenge-registry/project.json
+++ b/apps/challenge-registry/project.json
@@ -178,6 +178,12 @@
         }
       },
       "defaultConfiguration": "development"
+      // "dependsOn": [
+      //   {
+      //     "target": "serve-detach",
+      //     "projects": "dependencies"
+      //   }
+      // ]
     },
     "prerender": {
       "executor": "@nguniversal/builders:prerender",

--- a/apps/challenge-registry/src/app/app.component.ts
+++ b/apps/challenge-registry/src/app/app.component.ts
@@ -72,9 +72,13 @@ export class AppComponent implements OnInit, OnDestroy {
       .isLoggedIn()
       .subscribe((isLoggedIn) => (this.isLoggedIn = isLoggedIn));
 
-    this.kauthService.getUserProfile().subscribe((userProfile) => {
-      this.userAvatar.name = userProfile.username ? userProfile.username : '';
-    });
+    // TODO Call getUserProfile() only if the user is logged in, other wise an error is generated
+    // when the page is rendered with SSR.
+    // https://github.com/Sage-Bionetworks/challenge-registry/issues/880#issuecomment-1318955348
+    // this.kauthService.getUserProfile().subscribe((userProfile) => {
+    //   this.userAvatar.name = userProfile.username ? userProfile.username : '';
+    // });
+    this.userAvatar.name = 'blank';
 
     this.pageTitleService.setTitle('Challenge Registry');
   }
@@ -94,6 +98,7 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   login(): void {
+    console.log('Clicked on log In');
     this.kauthService.login();
   }
 }

--- a/apps/challenge-registry/src/app/app.module.ts
+++ b/apps/challenge-registry/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { APP_INITIALIZER, NgModule } from '@angular/core';
+import { APP_INITIALIZER, NgModule, PLATFORM_ID } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
 import { ApiModule } from '@sagebionetworks/api-client-angular';
@@ -48,7 +48,7 @@ import { initializeKeycloakFactory } from './initialize-keycloak.factory';
       provide: APP_INITIALIZER,
       useFactory: initializeKeycloakFactory,
       multi: true,
-      deps: [ConfigService, KeycloakService],
+      deps: [ConfigService, KeycloakService, PLATFORM_ID],
     },
   ],
   bootstrap: [AppComponent],

--- a/apps/challenge-registry/src/app/initialize-keycloak.factory.ts
+++ b/apps/challenge-registry/src/app/initialize-keycloak.factory.ts
@@ -4,27 +4,33 @@ import { KeycloakService } from 'keycloak-angular';
 // import { fromPromise } from 'rxjs/internal-compatibility';
 import { ConfigService } from '@sagebionetworks/challenge-registry/config';
 // import { ConfigInitService } from './config-init.service';
+import { isPlatformBrowser } from '@angular/common';
 
 export function initializeKeycloakFactory(
   configService: ConfigService,
-  keycloak: KeycloakService
+  keycloak: KeycloakService,
+  platformId: Record<string, unknown>
 ) {
-  return () =>
-    keycloak.init({
-      config: {
-        url: 'http://localhost:8080',
-        realm: 'test', // configService.config.keycloakRealm,
-        clientId: 'test-client',
-        // url: config['KEYCLOAK_URL'] + '/auth',
-        // realm: config['KEYCLOAK_REALM'],
-        // clientId: config['KEYCLOAK_CLIENT_ID'],
-      },
-      initOptions: {
-        onLoad: 'check-sso',
-        silentCheckSsoRedirectUri:
-          window.location.origin + '/assets/silent-check-sso.html',
-        flow: 'standard',
-      },
-      bearerExcludedUrls: [],
-    });
+  return () => {
+    if (isPlatformBrowser(platformId)) {
+      keycloak.init({
+        config: {
+          url: 'http://localhost:8080',
+          realm: 'test', // configService.config.keycloakRealm,
+          clientId: 'test-client',
+          // url: config['KEYCLOAK_URL'] + '/auth',
+          // realm: config['KEYCLOAK_REALM'],
+          // clientId: config['KEYCLOAK_CLIENT_ID'],
+        },
+        initOptions: {
+          onLoad: 'check-sso',
+          silentCheckSsoRedirectUri:
+            'http://localhost:4200' + '/assets/silent-check-sso.html',
+          // window.location.origin + '/assets/silent-check-sso.html',
+          flow: 'standard',
+        },
+        bearerExcludedUrls: [],
+      });
+    }
+  };
 }

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -28,6 +28,9 @@ export PATH="$PATH:$CHALLENGE_DIR/node_modules/.bin"
 
 function challenge-install {
   yarn install --immutable
+  # TODO: Find a more efficient way than looping through all the Java project to execute the same
+  # task (download gradle), enough though caching already helps.
+  nx run-many --all --target=prepare-java --parallel=1
 }
 
 function challenge-prepare {

--- a/docs/linters-and-formatters.md
+++ b/docs/linters-and-formatters.md
@@ -4,14 +4,14 @@
 
 ## Linters
 
-| File type  | File extension  | Linter           |
-|------------|-----------------|------------------|
-| Dockerfile | `Dockerfile`    | [hadolint]       |
-| HTML       | `*.html`        | [Webhint]        |
-| Java       | `*.java`        | [Checkstyle]     |
-| SCSS       | `*.scss`        | [VS Code (SCSS)] |
-| TypeScript | `*.ts`          | [ESLint]         |
-| XML        | `*.xml`         | -                |
+| File type  | File extension | Linter           |
+| ---------- | -------------- | ---------------- |
+| Dockerfile | `Dockerfile`   | [hadolint]       |
+| HTML       | `*.html`       | [Webhint]        |
+| Java       | `*.java`       | [Checkstyle]     |
+| SCSS       | `*.scss`       | [VS Code (SCSS)] |
+| TypeScript | `*.ts`         | [ESLint]         |
+| XML        | `*.xml`        | -                |
 
 ### Webhint
 
@@ -26,7 +26,7 @@ Linter configuration:
 ## Formatters
 
 | File type  | File extension | Formatter            | Package type |
-|------------|----------------|----------------------|--------------|
+| ---------- | -------------- | -------------------- | ------------ |
 | Dockerfile | `Dockerfile`   | -                    |              |
 | HTML       | `*.html`       | [Prettier]           |              |
 | Java       | `*.java`       | [google-java-format] | npm          |
@@ -53,13 +53,48 @@ Formatter configuration:
 - Used by:
   - `.vscode/settings.json`
 
+## Auto Format Code On Save
+
+### Java
+
+- File type(s): `*.java`
+- On Save listener: [VS Code extension Run on Save] (see `.vscode/settings.json`)
+- Actions:
+  1. Run the task `format` for the affected projects (since last commit) identified by Nx.
+  2. The task `format` of Java projects runs `@nxrocks/nx-spring-boot:format`.
+  3. The project is formatted using Spotless plugin for Maven or Gradle (see `build.gradle`).
+
+### TypeScript
+
+- File type(s): `*.ts`
+- On Save listener: [VS Code extension ESLint]
+- Actions:
+  1. The VS Code extension ESLint formats the file according to the project config defined in
+     `.eslintrc.json`. The ESLint project config file references the ESLint workspace config file.
+  2. The rules defined in Prettier workspace config `.prettierrc` are read from ESLint workspace
+     config file `.eslintrc.json`.
+
+Notes:
+
+- The VS Code extension ESLint format files on save by default. This extension seems to ignore VS
+  Code settings like `"editor.formatOnSave": false`. To turn off the auto formatting for this
+  extension:
+  ```json
+  "editor.codeActionsOnSave": {
+    // "source.fixAll": false,
+    "source.fixAll.eslint": false
+  },
+  ```
+
 <!-- Links -->
 
-[Webhint]: https://marketplace.visualstudio.com/items?itemName=webhint.vscode-webhint
-[Prettier]: https://prettier.io
-[ESLint]: https://eslint.org
-[Checkstyle]: https://checkstyle.sourceforge.io/
-[Language Support for Java by Red Hat]: https://marketplace.visualstudio.com/items?itemName=redhat.java
+[webhint]: https://marketplace.visualstudio.com/items?itemName=webhint.vscode-webhint
+[prettier]: https://prettier.io
+[eslint]: https://eslint.org
+[checkstyle]: https://checkstyle.sourceforge.io/
+[language support for java by red hat]: https://marketplace.visualstudio.com/items?itemName=redhat.java
 [hadolint]: https://github.com/hadolint/hadolint
-[VS Code (SCSS)]: https://code.visualstudio.com/docs/languages/css
+[vs code (scss)]: https://code.visualstudio.com/docs/languages/css
 [google-java-format]: https://github.com/google/google-java-format
+[VS Code extension Run on Save]: https://marketplace.visualstudio.com/items?itemName=emeraldwalk.RunOnSave
+[VS Code extension ESLint]: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint


### PR DESCRIPTION
- Fixes #880
- Fixes #888 

## Changelog

- Keycloak is no longer initialized when when page is rendered on the server side.
  - First I tried providing a fake `window` to the server with the package [domino](https://www.npmjs.com/package/domino), but then the app wouldn't load.
- Tweaked the configuration of the VS Code extension ESLint related to formatting on save.
- Update the command `challenge-install` to install Gradle binary too.

## Notes

- Bumped into #888