### PR TITLE
fix: Remove lombok VS Code extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,7 +33,6 @@
     "stkb.rewrap",
     "vscjava.vscode-gradle",
     "vscjava.vscode-java-pack",
-    "vscjava.vscode-lombok",
     "webhint.vscode-webhint"
   ],
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -22,7 +22,6 @@
     "stkb.rewrap",
     "vscjava.vscode-gradle",
     "vscjava.vscode-java-pack",
-    "vscjava.vscode-lombok",
     "webhint.vscode-webhint"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
   "java.checkstyle.configuration": "checkstyle.xml",
   "java.checkstyle.version": "10.3",
   "java.jdt.ls.java.home": "/usr/lib/jvm/java-17-openjdk-amd64",
-  "java.jdt.ls.lombokSupport.enabled": false,
   "python.linting.enabled": true,
   "python.linting.pylintEnabled": false,
   "python.linting.flake8Enabled": true,


### PR DESCRIPTION
Fixes #966

## Changelog

- Remove lombok VS Code extension, which is now part of Language Support for Java(TM) by Red Hat.
- Remove VS Code setting `java.jdt.ls.lombokSupport.enabled`, which is already true by default.