### PR TITLE
feat: Update the organization service to get org by ID

### DIFF
--- a/apps/challenge-api-gateway/src/main/java/org/sagebionetworks/challenge/configuration/SecurityConfiguration.java
+++ b/apps/challenge-api-gateway/src/main/java/org/sagebionetworks/challenge/configuration/SecurityConfiguration.java
@@ -14,7 +14,7 @@ public class SecurityConfiguration {
     http.authorizeExchange()
         // ALLOWING REGISTER API FOR DIRECT ACCESS
         .pathMatchers("/api/v1/users/register").permitAll().pathMatchers("/api/v1/auth/login")
-        .permitAll().pathMatchers("/api/v1/organizations")
+        .permitAll().pathMatchers("/api/v1/organizations/**")
         .permitAll()
         // ALL OTHER APIS ARE AUTHENTICATED
         .anyExchange().authenticated().and().csrf().disable().oauth2Login().and()

--- a/apps/challenge-organization-service/requests.http
+++ b/apps/challenge-organization-service/requests.http
@@ -1,10 +1,14 @@
 @apiGatewayHost = http://challenge-api-gateway:8082
-@userServiceHost = http://challenge-organization-service:8084
+@organizationServiceHost = http://challenge-organization-service:8084
 
 ### List all the organizations
 
-GET {{userServiceHost}}/organizations
+GET {{organizationServiceHost}}/organizations
 
 ### List all the organizations (via API gateway)
 
 GET {{apiGatewayHost}}/api/v1/organizations
+
+### Get an organization by ID
+
+GET {{organizationServiceHost}}/organizations/1

--- a/apps/challenge-organization-service/requests.http
+++ b/apps/challenge-organization-service/requests.http
@@ -5,10 +5,14 @@
 
 GET {{organizationServiceHost}}/organizations
 
-### List all the organizations (via API gateway)
+### List all the organizations (via the API gateway)
 
 GET {{apiGatewayHost}}/api/v1/organizations
 
 ### Get an organization by ID
 
 GET {{organizationServiceHost}}/organizations/1
+
+### Get an organization by ID (via the API gateway)
+
+GET {{apiGatewayHost}}/api/v1/organizations/1

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/api/OrganizationApi.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/api/OrganizationApi.java
@@ -14,6 +14,7 @@ import javax.annotation.Generated;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 import org.sagebionetworks.challenge.model.dto.ErrorDto;
+import org.sagebionetworks.challenge.model.dto.OrganizationDto;
 import org.sagebionetworks.challenge.model.dto.OrganizationsPageDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -27,6 +28,57 @@ public interface OrganizationApi {
 
   default OrganizationApiDelegate getDelegate() {
     return new OrganizationApiDelegate() {};
+  }
+
+  /**
+   * GET /organizations/{organizationId} : Get an organization Returns the organization specified
+   *
+   * @param organizationId The unique identifier of the organization (required)
+   * @return An organization (status code 200) or The specified resource was not found (status code
+   *     404) or The request cannot be fulfilled due to an unexpected server error (status code 500)
+   */
+  @Operation(
+      operationId = "getOrganization",
+      summary = "Get an organization",
+      tags = {"Organization"},
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "An organization",
+            content = {
+              @Content(
+                  mediaType = "application/json",
+                  schema = @Schema(implementation = OrganizationDto.class))
+            }),
+        @ApiResponse(
+            responseCode = "404",
+            description = "The specified resource was not found",
+            content = {
+              @Content(
+                  mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorDto.class))
+            }),
+        @ApiResponse(
+            responseCode = "500",
+            description = "The request cannot be fulfilled due to an unexpected server error",
+            content = {
+              @Content(
+                  mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorDto.class))
+            })
+      })
+  @RequestMapping(
+      method = RequestMethod.GET,
+      value = "/organizations/{organizationId}",
+      produces = {"application/json"})
+  default ResponseEntity<OrganizationDto> getOrganization(
+      @Parameter(
+              name = "organizationId",
+              description = "The unique identifier of the organization",
+              required = true)
+          @PathVariable("organizationId")
+          Long organizationId) {
+    return getDelegate().getOrganization(organizationId);
   }
 
   /**

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/api/OrganizationApiDelegate.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/api/OrganizationApiDelegate.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.challenge.api;
 
 import java.util.Optional;
 import javax.annotation.Generated;
+import org.sagebionetworks.challenge.model.dto.OrganizationDto;
 import org.sagebionetworks.challenge.model.dto.OrganizationsPageDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -17,6 +18,29 @@ public interface OrganizationApiDelegate {
 
   default Optional<NativeWebRequest> getRequest() {
     return Optional.empty();
+  }
+
+  /**
+   * GET /organizations/{organizationId} : Get an organization Returns the organization specified
+   *
+   * @param organizationId The unique identifier of the organization (required)
+   * @return An organization (status code 200) or The specified resource was not found (status code
+   *     404) or The request cannot be fulfilled due to an unexpected server error (status code 500)
+   * @see OrganizationApi#getOrganization
+   */
+  default ResponseEntity<OrganizationDto> getOrganization(Long organizationId) {
+    getRequest()
+        .ifPresent(
+            request -> {
+              for (MediaType mediaType : MediaType.parseMediaTypes(request.getHeader("Accept"))) {
+                if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
+                  String exampleString = "{ \"name\" : \"DREAM\" }";
+                  ApiUtil.setExampleResponse(request, "application/json", exampleString);
+                  break;
+                }
+              }
+            });
+    return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
   }
 
   /**

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/api/OrganizationApiDelegateImpl.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/api/OrganizationApiDelegateImpl.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.challenge.api;
 
+import org.sagebionetworks.challenge.model.dto.OrganizationDto;
 import org.sagebionetworks.challenge.model.dto.OrganizationsPageDto;
 import org.sagebionetworks.challenge.service.OrganizationService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,5 +16,10 @@ public class OrganizationApiDelegateImpl implements OrganizationApiDelegate {
   public ResponseEntity<OrganizationsPageDto> listOrganizations(
       Integer pageNumber, Integer pageSize) {
     return ResponseEntity.ok(organizationService.listOrganizations(pageNumber, pageSize));
+  }
+
+  @Override
+  public ResponseEntity<OrganizationDto> getOrganization(Long organizationId) {
+    return ResponseEntity.ok(organizationService.getOrganization(organizationId));
   }
 }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/exception/GlobalErrorCode.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/exception/GlobalErrorCode.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.challenge.exception;
 
 public class GlobalErrorCode {
-  public static final String ERROR_ENTITY_NOT_FOUND = "CHALLENGE-USER-SERVICE-1000";
-  public static final String ERROR_USERNAME_REGISTERED = "CHALLENGE-USER-SERVICE-1001";
-  public static final String ERROR_INVALID_EMAIL = "CHALLENGE-USER-SERVICE-1002";
-  public static final String ERROR_INVALID_USER = "CHALLENGE-USER-SERVICE-1003";
+  public static final String ERROR_ENTITY_NOT_FOUND = "CHALLENGE-ORGANIZATION-SERVICE-1000";
+  public static final String ERROR_ORGANIZATION_ALREADY_EXISTS =
+      "CHALLENGE-ORGANIZATION-SERVICE-1001";
+  public static final String ERROR_INVALID_ORGANIZATION = "CHALLENGE-ORGANIZATION-SERVICE-1002";
 }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/exception/GlobalExceptionHandler.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/exception/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package org.sagebionetworks.challenge.exception;
+
+import java.util.Locale;
+import org.sagebionetworks.challenge.util.exception.ErrorResponse;
+import org.sagebionetworks.challenge.util.exception.SimpleChallengeGlobalException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+  @ExceptionHandler(SimpleChallengeGlobalException.class)
+  protected ResponseEntity<ErrorResponse> handleGlobalException(
+      SimpleChallengeGlobalException simpleChallengeGlobalException, Locale locale) {
+    return ResponseEntity.badRequest()
+        .body(
+            ErrorResponse.builder()
+                .code(simpleChallengeGlobalException.getCode())
+                .message(simpleChallengeGlobalException.getMessage())
+                .build());
+  }
+
+  @ExceptionHandler({Exception.class})
+  protected ResponseEntity<String> handleException(Exception e, Locale locale) {
+    return ResponseEntity.badRequest().body("Exception occur inside API " + e);
+  }
+}

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/exception/InvalidEmailException.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/exception/InvalidEmailException.java
@@ -1,9 +1,0 @@
-package org.sagebionetworks.challenge.exception;
-
-import org.sagebionetworks.challenge.util.exception.SimpleChallengeGlobalException;
-
-public class InvalidEmailException extends SimpleChallengeGlobalException {
-  public InvalidEmailException(String message, String code) {
-    super(message, code);
-  }
-}

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/exception/InvalidOrganizationException.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/exception/InvalidOrganizationException.java
@@ -2,8 +2,8 @@ package org.sagebionetworks.challenge.exception;
 
 import org.sagebionetworks.challenge.util.exception.SimpleChallengeGlobalException;
 
-public class UserAlreadyRegisteredException extends SimpleChallengeGlobalException {
-  public UserAlreadyRegisteredException(String message, String code) {
+public class InvalidOrganizationException extends SimpleChallengeGlobalException {
+  public InvalidOrganizationException(String message, String code) {
     super(message, code);
   }
 }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/exception/OrganizationAlreadyExistsException.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/exception/OrganizationAlreadyExistsException.java
@@ -2,8 +2,8 @@ package org.sagebionetworks.challenge.exception;
 
 import org.sagebionetworks.challenge.util.exception.SimpleChallengeGlobalException;
 
-public class InvalidUserException extends SimpleChallengeGlobalException {
-  public InvalidUserException(String message, String code) {
+public class OrganizationAlreadyExistsException extends SimpleChallengeGlobalException {
+  public OrganizationAlreadyExistsException(String message, String code) {
     super(message, code);
   }
 }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/service/OrganizationService.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/service/OrganizationService.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.challenge.service;
 
 import java.util.List;
+import javax.persistence.EntityNotFoundException;
 import org.sagebionetworks.challenge.model.dto.OrganizationDto;
 import org.sagebionetworks.challenge.model.dto.OrganizationsPageDto;
 import org.sagebionetworks.challenge.model.entity.OrganizationEntity;
@@ -30,5 +31,13 @@ public class OrganizationService {
         .totalResults(0)
         .paging(null)
         .build();
+  }
+
+  @Transactional(readOnly = true)
+  public OrganizationDto getOrganization(Long organizationId) {
+    OrganizationEntity organizationEntity =
+        organizationRepository.findById(organizationId).orElseThrow(EntityNotFoundException::new);
+    OrganizationDto organization = organizationMapper.convertToDto(organizationEntity);
+    return organization;
   }
 }

--- a/apps/challenge-organization-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-organization-service/src/main/resources/openapi.yaml
@@ -69,6 +69,45 @@ paths:
       x-accepts: application/json
       x-tags:
       - tag: Organization
+  /organizations/{organizationId}:
+    get:
+      description: Returns the organization specified
+      operationId: getOrganization
+      parameters:
+      - description: The unique identifier of the organization
+        explode: false
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          $ref: '#/components/schemas/OrganizationId'
+        style: simple
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+          description: An organization
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The specified resource was not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The request cannot be fulfilled due to an unexpected server
+            error
+      summary: Get an organization
+      tags:
+      - Organization
+      x-accepts: application/json
+      x-tags:
+      - tag: Organization
 components:
   parameters:
     pageNumber:
@@ -95,6 +134,15 @@ components:
         minimum: 10
         type: integer
       style: form
+    organizationId:
+      description: The unique identifier of the organization
+      explode: false
+      in: path
+      name: organizationId
+      required: true
+      schema:
+        $ref: '#/components/schemas/OrganizationId'
+      style: simple
   responses:
     BadRequest:
       content:
@@ -108,6 +156,12 @@ components:
           schema:
             $ref: '#/components/schemas/Error'
       description: The request cannot be fulfilled due to an unexpected server error
+    NotFound:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: The specified resource was not found
   schemas:
     PageMetadata:
       description: The metadata of a page

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -37,6 +37,26 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  '/organizations/{organizationId}':
+    parameters:
+      - $ref: '#/components/parameters/organizationId'
+    get:
+      tags:
+        - Organization
+      summary: Get an organization
+      description: Returns the organization specified
+      operationId: getOrganization
+      responses:
+        '200':
+          description: An organization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /users/register:
     post:
       tags:
@@ -339,14 +359,14 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-    Conflict:
-      description: The request conflicts with current state of the target resource
+    NotFound:
+      description: The specified resource was not found
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-    NotFound:
-      description: The specified resource was not found
+    Conflict:
+      description: The request conflicts with current state of the target resource
       content:
         application/json:
           schema:
@@ -370,6 +390,13 @@ components:
         format: int32
         default: 100
         minimum: 10
+    organizationId:
+      name: organizationId
+      in: path
+      description: The unique identifier of the organization
+      required: true
+      schema:
+        $ref: '#/components/schemas/OrganizationId'
     userId:
       name: userId
       in: path

--- a/libs/api-spec/build/organization.openapi.yaml
+++ b/libs/api-spec/build/organization.openapi.yaml
@@ -35,6 +35,26 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /organizations/{organizationId}:
+    parameters:
+      - $ref: '#/components/parameters/organizationId'
+    get:
+      tags:
+        - Organization
+      summary: Get an organization
+      description: Returns the organization specified
+      operationId: getOrganization
+      responses:
+        '200':
+          description: An organization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   parameters:
     pageNumber:
@@ -55,6 +75,13 @@ components:
         format: int32
         default: 100
         minimum: 10
+    organizationId:
+      name: organizationId
+      in: path
+      description: The unique identifier of the organization
+      required: true
+      schema:
+        $ref: '#/components/schemas/OrganizationId'
   schemas:
     PageMetadata:
       type: object
@@ -135,6 +162,12 @@ components:
             $ref: '#/components/schemas/Error'
     InternalServerError:
       description: The request cannot be fulfilled due to an unexpected server error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: The specified resource was not found
       content:
         application/json:
           schema:

--- a/libs/api-spec/src/components/parameters/path/organizationId.yaml
+++ b/libs/api-spec/src/components/parameters/path/organizationId.yaml
@@ -1,0 +1,6 @@
+name: organizationId
+in: path
+description: The unique identifier of the organization
+required: true
+schema:
+  $ref: ../../schemas/OrganizationId.yaml

--- a/libs/api-spec/src/organization.openapi.yaml
+++ b/libs/api-spec/src/organization.openapi.yaml
@@ -16,5 +16,5 @@ tags:
 paths:
   /organizations:
     $ref: paths/organizations.yaml
-  # /organizations/{organizationId}:
-  #   $ref: paths/organizations@{organizationId}.yaml
+  /organizations/{organizationId}:
+    $ref: paths/organizations/@{organizationId}.yaml

--- a/libs/api-spec/src/paths/organizations/@{organizationId}.yaml
+++ b/libs/api-spec/src/paths/organizations/@{organizationId}.yaml
@@ -1,0 +1,36 @@
+parameters:
+  - $ref: ../../components/parameters/path/organizationId.yaml
+get:
+  tags:
+    - Organization
+  summary: Get an organization
+  description: Returns the organization specified
+  operationId: getOrganization
+  responses:
+    '200':
+      description: An organization
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/Organization.yaml
+    '404':
+      $ref: ../../components/responses/NotFound.yaml
+    '500':
+      $ref: ../../components/responses/InternalServerError.yaml
+# delete:
+#   tags:
+#     - User
+#   summary: Delete a user
+#   description: Deletes the user specified
+#   operationId: deleteUser
+#   responses:
+#     '200':
+#       description: Deleted
+#       content:
+#         application/json:
+#           schema:
+#             $ref: ../../components/schemas/EmptyObject.yaml
+#     '400':
+#       $ref: ../../components/responses/NotFound.yaml
+#     '500':
+#       $ref: ../../components/responses/InternalServerError.yaml


### PR DESCRIPTION
Fixes #976 

## Changelog

- Added path to the Organization service to get an org by ID.
- Configured the API gateway security to allow public access to the new path.
- Added example requests to `requests.http`.

## Limitation

- The error returned by the paths of this service do not match the Error schema. I now have a better understanding of how to handle error in the context of microservices. This work will be implemented in a separate PR.

## Preview

`requests.http`:

```console
### Get an organization by ID

GET {{organizationServiceHost}}/organizations/1

### Get an organization by ID (via the API gateway)

GET {{apiGatewayHost}}/api/v1/organizations/1
```

Output:

```console
HTTP/1.1 200 OK
transfer-encoding: chunked
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Content-Type: application/json
Date: Mon, 05 Dec 2022 23:38:56 GMT
Referrer-Policy: no-referrer
Set-Cookie: SESSION=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax
connection: close

{
  "id": 1,
  "name": "DREAM"
}
```
