### PR TITLE
feat: Add `servers` properties to OA description

### DIFF
--- a/apps/challenge-organization-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-organization-service/src/main/resources/openapi.yaml
@@ -11,7 +11,7 @@ info:
   x-logo:
     url: https://Sage-Bionetworks.github.io/rocc-schemas/logo.png
 servers:
-- url: /
+- url: http://localhost
 tags:
 - description: Operations about organizations
   name: Organization

--- a/apps/challenge-user-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-user-service/src/main/resources/openapi.yaml
@@ -11,7 +11,7 @@ info:
   x-logo:
     url: https://Sage-Bionetworks.github.io/rocc-schemas/logo.png
 servers:
-- url: /
+- url: http://localhost
 tags:
 - description: Operations about users
   name: User

--- a/libs/api-client-angular/openapitools.json
+++ b/libs/api-client-angular/openapitools.json
@@ -10,7 +10,9 @@
         "inputSpec": "#{cwd}/../../libs/api-spec/build/openapi.yaml",
         "output": "#{cwd}/src/lib/",
         "templateDir": "templates",
-        "additionalProperties": {}
+        "additionalProperties": {
+          "ngVersion": "14.2.11"
+        }
       }
     }
   }

--- a/libs/api-client-angular/project.json
+++ b/libs/api-client-angular/project.json
@@ -45,7 +45,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "rm -fr src/lib",
+          "rm -fr src/lib/*",
           "openapi-generator-cli generate",
           "echo 'TODO Format generated code'"
         ],

--- a/libs/api-client-angular/src/lib/.openapi-generator/FILES
+++ b/libs/api-client-angular/src/lib/.openapi-generator/FILES
@@ -1,5 +1,4 @@
 .gitignore
-.openapi-generator-ignore
 README.md
 api.module.ts
 api/api.ts

--- a/libs/api-spec/build/base.openapi.yaml
+++ b/libs/api-spec/build/base.openapi.yaml
@@ -10,4 +10,6 @@ info:
     url: https://github.com/Sage-Bionetworks/challenge-registry
   x-logo:
     url: https://Sage-Bionetworks.github.io/rocc-schemas/logo.png
+servers:
+  - url: http://localhost
 components: {}

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -10,6 +10,8 @@ info:
     url: 'https://github.com/Sage-Bionetworks/challenge-registry'
   x-logo:
     url: 'https://Sage-Bionetworks.github.io/rocc-schemas/logo.png'
+servers:
+  - url: 'http://localhost'
 tags:
   - name: Organization
     description: Operations about organizations

--- a/libs/api-spec/build/organization.openapi.yaml
+++ b/libs/api-spec/build/organization.openapi.yaml
@@ -10,6 +10,8 @@ info:
     url: https://github.com/Sage-Bionetworks/challenge-registry
   x-logo:
     url: https://Sage-Bionetworks.github.io/rocc-schemas/logo.png
+servers:
+  - url: http://localhost
 tags:
   - name: Organization
     description: Operations about organizations

--- a/libs/api-spec/build/user.openapi.yaml
+++ b/libs/api-spec/build/user.openapi.yaml
@@ -10,6 +10,8 @@ info:
     url: https://github.com/Sage-Bionetworks/challenge-registry
   x-logo:
     url: https://Sage-Bionetworks.github.io/rocc-schemas/logo.png
+servers:
+  - url: http://localhost
 tags:
   - name: User
     description: Operations about users

--- a/libs/api-spec/src/base.openapi.yaml
+++ b/libs/api-spec/src/base.openapi.yaml
@@ -10,3 +10,5 @@ info:
     url: https://github.com/Sage-Bionetworks/challenge-registry
   x-logo:
     url: https://Sage-Bionetworks.github.io/rocc-schemas/logo.png
+servers:
+  - url: http://localhost

--- a/libs/api-spec/src/organization.openapi.yaml
+++ b/libs/api-spec/src/organization.openapi.yaml
@@ -10,6 +10,8 @@ info:
     url: https://github.com/Sage-Bionetworks/challenge-registry
   x-logo:
     url: https://Sage-Bionetworks.github.io/rocc-schemas/logo.png
+servers:
+  - url: http://localhost
 tags:
   - name: Organization
     description: Operations about organizations

--- a/libs/api-spec/src/user.openapi.yaml
+++ b/libs/api-spec/src/user.openapi.yaml
@@ -10,6 +10,8 @@ info:
     url: https://github.com/Sage-Bionetworks/challenge-registry
   x-logo:
     url: https://Sage-Bionetworks.github.io/rocc-schemas/logo.png
+servers:
+  - url: http://localhost
 tags:
   - name: User
     description: Operations about users


### PR DESCRIPTION
Fixes #986

## Changelog

- Add the property `servers` to the OA definition
- Specify the Angular version that the OA generator must use to generate the client.