### PR TITLE
feat: Populate the Organization page with data from the backend

### DIFF
--- a/apps/challenge-registry/project.json
+++ b/apps/challenge-registry/project.json
@@ -207,6 +207,7 @@
   "implicitDependencies": [
     "challenge-api-gateway",
     "challenge-keycloak",
+    "challenge-organization-service",
     "challenge-registry-styles",
     "challenge-registry-themes",
     "shared-assets"

--- a/apps/challenge-registry/src/app/app.component.ts
+++ b/apps/challenge-registry/src/app/app.component.ts
@@ -17,7 +17,6 @@ import {
 import { ActivatedRoute, Router } from '@angular/router';
 import { KeycloakService } from 'keycloak-angular';
 import { User } from '@sagebionetworks/api-client-angular-deprecated';
-import { OrganizationService } from '@sagebionetworks/api-client-angular';
 
 @Component({
   selector: 'challenge-registry-root',
@@ -40,8 +39,7 @@ export class AppComponent implements OnInit, OnDestroy {
     private kauthService: KAuthService,
     private authService: AuthService,
     private keycloakService: KeycloakService,
-    private activatedRoute: ActivatedRoute,
-    private organizationService: OrganizationService
+    private activatedRoute: ActivatedRoute
   ) {}
 
   ngOnInit() {
@@ -58,11 +56,6 @@ export class AppComponent implements OnInit, OnDestroy {
     this.userAvatar.name = 'blank';
 
     this.pageTitleService.setTitle('Challenge Registry');
-
-    // demo: get list of organizations from the new backend.
-    this.organizationService
-      .listOrganizations()
-      .subscribe((page) => console.log('Organizations page', page));
   }
 
   ngOnDestroy(): void {

--- a/apps/challenge-registry/src/app/app.component.ts
+++ b/apps/challenge-registry/src/app/app.component.ts
@@ -17,6 +17,7 @@ import {
 import { ActivatedRoute, Router } from '@angular/router';
 import { KeycloakService } from 'keycloak-angular';
 import { User } from '@sagebionetworks/api-client-angular-deprecated';
+import { OrganizationService } from '@sagebionetworks/api-client-angular';
 
 @Component({
   selector: 'challenge-registry-root',
@@ -39,7 +40,8 @@ export class AppComponent implements OnInit, OnDestroy {
     private kauthService: KAuthService,
     private authService: AuthService,
     private keycloakService: KeycloakService,
-    private activatedRoute: ActivatedRoute
+    private activatedRoute: ActivatedRoute,
+    private organizationService: OrganizationService
   ) {}
 
   ngOnInit() {
@@ -56,6 +58,11 @@ export class AppComponent implements OnInit, OnDestroy {
     this.userAvatar.name = 'blank';
 
     this.pageTitleService.setTitle('Challenge Registry');
+
+    // demo: get list of organizations from the new backend.
+    this.organizationService
+      .listOrganizations()
+      .subscribe((page) => console.log('Organizations page', page));
   }
 
   ngOnDestroy(): void {

--- a/apps/challenge-registry/src/app/app.module.ts
+++ b/apps/challenge-registry/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { APP_INITIALIZER, NgModule, PLATFORM_ID } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
-import { ApiModule } from '@sagebionetworks/api-client-angular';
+import { ApiModule, BASE_PATH } from '@sagebionetworks/api-client-angular';
 import { AppRoutingModule } from './app-routing.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CountUpModule } from 'ngx-countup';
@@ -50,6 +50,7 @@ import { initializeKeycloakFactory } from './initialize-keycloak.factory';
       multi: true,
       deps: [ConfigService, KeycloakService, PLATFORM_ID],
     },
+    { provide: BASE_PATH, useValue: 'http://localhost:8082/api/v1' },
   ],
   bootstrap: [AppComponent],
 })

--- a/apps/challenge-registry/src/app/app.module.ts
+++ b/apps/challenge-registry/src/app/app.module.ts
@@ -53,7 +53,11 @@ import { initializeKeycloakFactory } from './initialize-keycloak.factory';
       multi: true,
       deps: [ConfigService, KeycloakService, PLATFORM_ID],
     },
-    { provide: API_CLIENT_BASE_PATH, useValue: 'http://localhost:4200/api' },
+    {
+      provide: API_CLIENT_BASE_PATH,
+      useFactory: (configService: ConfigService) => configService.config.apiUrl,
+      deps: [ConfigService],
+    },
   ],
   bootstrap: [AppComponent],
 })

--- a/apps/challenge-registry/src/app/app.module.ts
+++ b/apps/challenge-registry/src/app/app.module.ts
@@ -1,7 +1,10 @@
 import { APP_INITIALIZER, NgModule, PLATFORM_ID } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
-import { ApiModule, BASE_PATH } from '@sagebionetworks/api-client-angular';
+import {
+  ApiModule,
+  BASE_PATH as API_CLIENT_BASE_PATH,
+} from '@sagebionetworks/api-client-angular';
 import { AppRoutingModule } from './app-routing.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CountUpModule } from 'ngx-countup';
@@ -50,7 +53,7 @@ import { initializeKeycloakFactory } from './initialize-keycloak.factory';
       multi: true,
       deps: [ConfigService, KeycloakService, PLATFORM_ID],
     },
-    { provide: BASE_PATH, useValue: 'http://localhost:8082/api/v1' },
+    { provide: API_CLIENT_BASE_PATH, useValue: 'http://localhost:4200/api' },
   ],
   bootstrap: [AppComponent],
 })

--- a/apps/challenge-registry/src/proxy.conf.json
+++ b/apps/challenge-registry/src/proxy.conf.json
@@ -1,17 +1,11 @@
 {
   "/api": {
-    "target": "http://localhost:9999/api/v1",
+    "target": "http://localhost:8082/api/v1",
     "secure": false,
     "changeOrigin": true,
     "pathRewrite": {
       "^/api": ""
     },
     "logLevel": "debug"
-  },
-  "/movies": {
-    "target": "http://localhost:9000",
-    "secure": false,
-    "logLevel": "debug",
-    "changeOrigin": true
   }
 }

--- a/libs/challenge-registry/org-profile/src/lib/org-profile.component.ts
+++ b/libs/challenge-registry/org-profile/src/lib/org-profile.component.ts
@@ -12,6 +12,7 @@ import {
   Avatar,
 } from '@sagebionetworks/challenge-registry/ui';
 import { ConfigService } from '@sagebionetworks/challenge-registry/config';
+import { OrganizationService } from '@sagebionetworks/api-client-angular';
 
 @Component({
   selector: 'challenge-registry-org-profile',
@@ -33,7 +34,8 @@ export class OrgProfileComponent implements OnInit {
     private activatedRoute: ActivatedRoute,
     private router: Router,
     private route: ActivatedRoute,
-    private readonly configService: ConfigService
+    private readonly configService: ConfigService,
+    private organizationService: OrganizationService
   ) {
     this.appVersion = this.configService.config.appVersion;
   }
@@ -64,5 +66,10 @@ export class OrgProfileComponent implements OnInit {
     });
 
     this.subscriptions.push(activeTabSub);
+
+    // demo: get list of organizations from the new backend.
+    this.organizationService
+      .listOrganizations()
+      .subscribe((page) => console.log('Organizations page', page));
   }
 }

--- a/libs/challenge-registry/org-profile/src/lib/org-profile.component.ts
+++ b/libs/challenge-registry/org-profile/src/lib/org-profile.component.ts
@@ -12,7 +12,10 @@ import {
   Avatar,
 } from '@sagebionetworks/challenge-registry/ui';
 import { ConfigService } from '@sagebionetworks/challenge-registry/config';
-import { OrganizationService } from '@sagebionetworks/api-client-angular';
+import {
+  OrganizationService,
+  OrganizationsPage,
+} from '@sagebionetworks/api-client-angular';
 
 @Component({
   selector: 'challenge-registry-org-profile',
@@ -70,6 +73,8 @@ export class OrgProfileComponent implements OnInit {
     // demo: get list of organizations from the new backend.
     this.organizationService
       .listOrganizations()
-      .subscribe((page) => console.log('Organizations page', page));
+      .subscribe((page: OrganizationsPage) =>
+        console.log('Organizations page', page)
+      );
   }
 }


### PR DESCRIPTION
Fixes #984 

## Changelog

- Get list of organizations from the backend on any org profile page (demo).
- Configure API client in `app.module.ts` of the challenge registry app.
- Add the project `challenge-organization-service` to the dependencies of the registry app.

## Preview

- `nx serve challenge-registry`
- Check that the data can be retrieved:
  - Directly from the microservice: http://localhost:8084/organizations
    > **Note**
    > This url will likely be changed in the future to include "/api" in the base url. This change will be transparent to everyone because the web app is sending requests to the API gateway (see below).
  - From the API gateway:  http://localhost:8082/api/v1/organizations
  - From any org profile page (displayed in browser console): http://localhost:4200/org/awesome-org