### PR TITLE
feat: Add error handling to the User service

### DIFF
--- a/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/ErrorConstants.java
+++ b/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/ErrorConstants.java
@@ -1,0 +1,19 @@
+package org.sagebionetworks.challenge.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorConstants {
+  ENTITY_NOT_FOUND("CHALLENGE-USER-SERVICE-1000", "Entity not found", HttpStatus.NOT_FOUND),
+  USERNAME_ALREADY_EXISTS(
+      "CHALLENGE-USER-SERVICE-1001", "Username already exists", HttpStatus.CONFLICT),
+  INVALID_EMAIL("CHALLENGE-USER-SERVICE-1002", "Invalid email", HttpStatus.BAD_REQUEST),
+  INVALID_USER("CHALLENGE-USER-SERVICE-1003", "Invalid user", HttpStatus.BAD_REQUEST);
+
+  private String type;
+  private String title;
+  private HttpStatus status;
+}

--- a/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/GlobalErrorCode.java
+++ b/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/GlobalErrorCode.java
@@ -1,8 +1,0 @@
-package org.sagebionetworks.challenge.exception;
-
-public class GlobalErrorCode {
-  public static final String ERROR_ENTITY_NOT_FOUND = "CHALLENGE-USER-SERVICE-1000";
-  public static final String ERROR_USERNAME_REGISTERED = "CHALLENGE-USER-SERVICE-1001";
-  public static final String ERROR_INVALID_EMAIL = "CHALLENGE-USER-SERVICE-1002";
-  public static final String ERROR_INVALID_USER = "CHALLENGE-USER-SERVICE-1003";
-}

--- a/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/GlobalExceptionHandler.java
+++ b/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package org.sagebionetworks.challenge.exception;
+
+import java.util.Locale;
+import org.sagebionetworks.challenge.model.dto.BasicErrorDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+  @ExceptionHandler(SimpleChallengeGlobalException.class)
+  protected ResponseEntity<BasicErrorDto> handleGlobalException(
+      SimpleChallengeGlobalException simpleChallengeGlobalException, Locale locale) {
+    return new ResponseEntity<>(
+        BasicErrorDto.builder()
+            .type(simpleChallengeGlobalException.getType())
+            .title(simpleChallengeGlobalException.getTitle())
+            .status(simpleChallengeGlobalException.getStatus().value())
+            .detail(simpleChallengeGlobalException.getDetail())
+            .build(),
+        simpleChallengeGlobalException.getStatus());
+  }
+
+  @ExceptionHandler({Exception.class})
+  protected ResponseEntity<BasicErrorDto> handleException(Exception e, Locale locale) {
+    return ResponseEntity.internalServerError()
+        .body(
+            BasicErrorDto.builder()
+                .title("An exception occured")
+                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .build());
+  }
+}

--- a/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/InvalidEmailException.java
+++ b/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/InvalidEmailException.java
@@ -1,9 +1,11 @@
 package org.sagebionetworks.challenge.exception;
 
-import org.sagebionetworks.challenge.util.exception.SimpleChallengeGlobalException;
-
 public class InvalidEmailException extends SimpleChallengeGlobalException {
-  public InvalidEmailException(String message, String code) {
-    super(message, code);
+  public InvalidEmailException(String detail) {
+    super(
+        ErrorConstants.INVALID_EMAIL.getType(),
+        ErrorConstants.INVALID_EMAIL.getTitle(),
+        ErrorConstants.INVALID_EMAIL.getStatus(),
+        detail);
   }
 }

--- a/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/InvalidUserException.java
+++ b/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/InvalidUserException.java
@@ -1,9 +1,11 @@
 package org.sagebionetworks.challenge.exception;
 
-import org.sagebionetworks.challenge.util.exception.SimpleChallengeGlobalException;
-
 public class InvalidUserException extends SimpleChallengeGlobalException {
-  public InvalidUserException(String message, String code) {
-    super(message, code);
+  public InvalidUserException(String detail) {
+    super(
+        ErrorConstants.INVALID_USER.getType(),
+        ErrorConstants.INVALID_USER.getTitle(),
+        ErrorConstants.INVALID_USER.getStatus(),
+        detail);
   }
 }

--- a/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/SimpleChallengeGlobalException.java
+++ b/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/SimpleChallengeGlobalException.java
@@ -1,0 +1,23 @@
+package org.sagebionetworks.challenge.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SimpleChallengeGlobalException extends RuntimeException {
+
+  private String type;
+  private String title;
+  private HttpStatus status;
+  private String detail;
+
+  public SimpleChallengeGlobalException(String details) {
+    super(details);
+  }
+}

--- a/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/UserAlreadyRegisteredException.java
+++ b/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/UserAlreadyRegisteredException.java
@@ -1,9 +1,0 @@
-package org.sagebionetworks.challenge.exception;
-
-import org.sagebionetworks.challenge.util.exception.SimpleChallengeGlobalException;
-
-public class UserAlreadyRegisteredException extends SimpleChallengeGlobalException {
-  public UserAlreadyRegisteredException(String message, String code) {
-    super(message, code);
-  }
-}

--- a/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/UserNotFoundException.java
+++ b/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/UserNotFoundException.java
@@ -1,0 +1,11 @@
+package org.sagebionetworks.challenge.exception;
+
+public class UserNotFoundException extends SimpleChallengeGlobalException {
+  public UserNotFoundException(String detail) {
+    super(
+        ErrorConstants.ENTITY_NOT_FOUND.getType(),
+        ErrorConstants.ENTITY_NOT_FOUND.getTitle(),
+        ErrorConstants.ENTITY_NOT_FOUND.getStatus(),
+        detail);
+  }
+}

--- a/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/UsernameAlreadyExistsException.java
+++ b/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/exception/UsernameAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package org.sagebionetworks.challenge.exception;
+
+public class UsernameAlreadyExistsException extends SimpleChallengeGlobalException {
+  public UsernameAlreadyExistsException(String detail) {
+    super(
+        ErrorConstants.USERNAME_ALREADY_EXISTS.getType(),
+        ErrorConstants.USERNAME_ALREADY_EXISTS.getTitle(),
+        ErrorConstants.USERNAME_ALREADY_EXISTS.getStatus(),
+        detail);
+  }
+}

--- a/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/service/UserService.java
+++ b/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/service/UserService.java
@@ -4,11 +4,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import javax.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.sagebionetworks.challenge.exception.InvalidUserException;
+import org.sagebionetworks.challenge.exception.UserNotFoundException;
 import org.sagebionetworks.challenge.exception.UsernameAlreadyExistsException;
 import org.sagebionetworks.challenge.model.dto.UserCreateRequestDto;
 import org.sagebionetworks.challenge.model.dto.UserCreateResponseDto;
@@ -88,7 +88,13 @@ public class UserService {
   @Transactional(readOnly = true)
   public UserDto getUser(Long userId) {
     UserEntity userEntity =
-        userRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
+        userRepository
+            .findById(userId)
+            .orElseThrow(
+                () ->
+                    new UserNotFoundException(
+                        String.format("The user with ID %s does not exist.", userId)));
+
     UserRepresentation userRepresentation = keycloakUserService.getUser(userEntity.getAuthId());
     UserDto user = userMapper.convertToDto(userEntity);
     user.setEmail(userRepresentation.getEmail());

--- a/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/service/UserService.java
+++ b/apps/challenge-user-service/src/main/java/org/sagebionetworks/challenge/service/UserService.java
@@ -8,9 +8,8 @@ import javax.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
-import org.sagebionetworks.challenge.exception.GlobalErrorCode;
 import org.sagebionetworks.challenge.exception.InvalidUserException;
-import org.sagebionetworks.challenge.exception.UserAlreadyRegisteredException;
+import org.sagebionetworks.challenge.exception.UsernameAlreadyExistsException;
 import org.sagebionetworks.challenge.model.dto.UserCreateRequestDto;
 import org.sagebionetworks.challenge.model.dto.UserCreateResponseDto;
 import org.sagebionetworks.challenge.model.dto.UserDto;
@@ -38,8 +37,8 @@ public class UserService {
   @Transactional
   public UserCreateResponseDto createUser(UserCreateRequestDto userCreateRequest) {
     if (keycloakUserService.getUserByUsername(userCreateRequest.getLogin()).isPresent()) {
-      throw new UserAlreadyRegisteredException(
-          "This username is already registered.", GlobalErrorCode.ERROR_USERNAME_REGISTERED);
+      throw new UsernameAlreadyExistsException(
+          String.format("The username %s already exist.", userCreateRequest.getLogin()));
     }
 
     UserRepresentation userRepresentation = new UserRepresentation();
@@ -65,8 +64,7 @@ public class UserService {
       return UserCreateResponseDto.builder().id(savedUser.getId()).build();
     }
 
-    throw new InvalidUserException(
-        "Unable to create the new user", GlobalErrorCode.ERROR_INVALID_USER);
+    throw new InvalidUserException(null);
   }
 
   @Transactional(readOnly = true)


### PR DESCRIPTION
Fixes #980

## Changelog

- The errors returned are now meeting the BasicError schema.
  - Code reused from the Organization service.
- Fix issues with listing users and getting user by ID work.

> **Warning**
> This update requires the developer to re-import the Keycloak data. The container of Keycloak must be stopped before running the following command.

```console
rm -fr apps/challenge-keycloak/data/h2/*
nx import-dev-data challenge-keycloak
```

## TODO

- [x] Return User Not Found when no user found for a given ID
- [x] Fix issue about user with ID == 2 (tschaffter)
  - Needed to update the `auth_id` value in the SQL seed data
- [x] Remove users from KC data who are no longer needed