### PR TITLE
feat: Add properties to Organization model

### DIFF
--- a/apps/challenge-organization-service/.openapi-generator/FILES
+++ b/apps/challenge-organization-service/.openapi-generator/FILES
@@ -7,6 +7,7 @@ src/main/java/org/sagebionetworks/challenge/api/OrganizationApiDelegate.java
 src/main/java/org/sagebionetworks/challenge/configuration/HomeController.java
 src/main/java/org/sagebionetworks/challenge/configuration/SpringDocConfiguration.java
 src/main/java/org/sagebionetworks/challenge/model/dto/BasicErrorDto.java
+src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
 src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
 src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationsPageDto.java
 src/main/java/org/sagebionetworks/challenge/model/dto/PageMetadataDto.java

--- a/apps/challenge-organization-service/openapitools.json
+++ b/apps/challenge-organization-service/openapitools.json
@@ -19,7 +19,8 @@
           "library": "spring-boot",
           "modelNameSuffix": "Dto",
           "modelPackage": "org.sagebionetworks.challenge.model.dto",
-          "useTags": true
+          "useTags": true,
+          "openApiNullable": false
         }
       }
     }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/ChallengeOrganizationServiceApplication.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/ChallengeOrganizationServiceApplication.java
@@ -1,13 +1,11 @@
 package org.sagebionetworks.challenge;
 
-import com.fasterxml.jackson.databind.Module;
-import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
+import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
 import org.springframework.context.annotation.ComponentScan;
 
-// @EnableEurekaClient
+@EnableEurekaClient
 @SpringBootApplication
 @ComponentScan(
     basePackages = {

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/ChallengeOrganizationServiceApplication.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/ChallengeOrganizationServiceApplication.java
@@ -21,8 +21,8 @@ public class ChallengeOrganizationServiceApplication {
     SpringApplication.run(ChallengeOrganizationServiceApplication.class, args);
   }
 
-  @Bean
-  public Module jsonNullableModule() {
-    return new JsonNullableModule();
-  }
+  // @Bean
+  // public Module jsonNullableModule() {
+  //   return new JsonNullableModule();
+  // }
 }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/api/OrganizationApiDelegate.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/api/OrganizationApiDelegate.java
@@ -34,7 +34,7 @@ public interface OrganizationApiDelegate {
             request -> {
               for (MediaType mediaType : MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                  String exampleString = "{ \"name\" : \"DREAM\" }";
+                  String exampleString = "null";
                   ApiUtil.setExampleResponse(request, "application/json", exampleString);
                   break;
                 }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
@@ -8,20 +8,19 @@ import java.util.Objects;
 import javax.annotation.Generated;
 import javax.validation.constraints.*;
 
-/** An organization */
-@Schema(name = "Organization", description = "An organization")
-@JsonTypeName("Organization")
+/** The information required to create an org account */
+@Schema(
+    name = "OrganizationCreateRequest",
+    description = "The information required to create an org account")
+@JsonTypeName("OrganizationCreateRequest")
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 // TODO Add x-java-class-annotations
-public class OrganizationDto {
+public class OrganizationCreateRequestDto {
 
   @JsonProperty("name")
   private String name;
 
-  @JsonProperty("id")
-  private Long id;
-
-  public OrganizationDto name(String name) {
+  public OrganizationCreateRequestDto name(String name) {
     this.name = name;
     return this;
   }
@@ -40,29 +39,6 @@ public class OrganizationDto {
     this.name = name;
   }
 
-  public OrganizationDto id(Long id) {
-    this.id = id;
-    return this;
-  }
-
-  /**
-   * The unique identifier of an organization
-   *
-   * @return id
-   */
-  @Schema(
-      name = "id",
-      example = "1",
-      description = "The unique identifier of an organization",
-      required = false)
-  public Long getId() {
-    return id;
-  }
-
-  public void setId(Long id) {
-    this.id = id;
-  }
-
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -71,21 +47,20 @@ public class OrganizationDto {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    OrganizationDto organization = (OrganizationDto) o;
-    return Objects.equals(this.name, organization.name) && Objects.equals(this.id, organization.id);
+    OrganizationCreateRequestDto organizationCreateRequest = (OrganizationCreateRequestDto) o;
+    return Objects.equals(this.name, organizationCreateRequest.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, id);
+    return Objects.hash(name);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class OrganizationDto {\n");
+    sb.append("class OrganizationCreateRequestDto {\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
@@ -69,7 +69,8 @@ public class OrganizationCreateRequestDto {
    *
    * @return login
    */
-  @Schema(name = "login", example = "example-organization", required = false)
+  @NotNull
+  @Schema(name = "login", example = "example-organization", required = true)
   public String getLogin() {
     return login;
   }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
@@ -17,8 +17,35 @@ import javax.validation.constraints.*;
 // TODO Add x-java-class-annotations
 public class OrganizationCreateRequestDto {
 
+  @JsonProperty("email")
+  private String email;
+
   @JsonProperty("name")
   private String name;
+
+  public OrganizationCreateRequestDto email(String email) {
+    this.email = email;
+    return this;
+  }
+
+  /**
+   * An email address.
+   *
+   * @return email
+   */
+  @Email
+  @Schema(
+      name = "email",
+      example = "john.smith@example.com",
+      description = "An email address.",
+      required = false)
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
 
   public OrganizationCreateRequestDto name(String name) {
     this.name = name;
@@ -48,18 +75,20 @@ public class OrganizationCreateRequestDto {
       return false;
     }
     OrganizationCreateRequestDto organizationCreateRequest = (OrganizationCreateRequestDto) o;
-    return Objects.equals(this.name, organizationCreateRequest.name);
+    return Objects.equals(this.email, organizationCreateRequest.email)
+        && Objects.equals(this.name, organizationCreateRequest.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(email, name);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class OrganizationCreateRequestDto {\n");
+    sb.append("    email: ").append(toIndentedString(email)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
@@ -26,6 +26,9 @@ public class OrganizationCreateRequestDto {
   @JsonProperty("name")
   private String name;
 
+  @JsonProperty("avatarUrl")
+  private String avatarUrl;
+
   public OrganizationCreateRequestDto email(String email) {
     this.email = email;
     return this;
@@ -88,6 +91,25 @@ public class OrganizationCreateRequestDto {
     this.name = name;
   }
 
+  public OrganizationCreateRequestDto avatarUrl(String avatarUrl) {
+    this.avatarUrl = avatarUrl;
+    return this;
+  }
+
+  /**
+   * Get avatarUrl
+   *
+   * @return avatarUrl
+   */
+  @Schema(name = "avatarUrl", example = "https://via.placeholder.com/300.png", required = false)
+  public String getAvatarUrl() {
+    return avatarUrl;
+  }
+
+  public void setAvatarUrl(String avatarUrl) {
+    this.avatarUrl = avatarUrl;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -99,12 +121,13 @@ public class OrganizationCreateRequestDto {
     OrganizationCreateRequestDto organizationCreateRequest = (OrganizationCreateRequestDto) o;
     return Objects.equals(this.email, organizationCreateRequest.email)
         && Objects.equals(this.login, organizationCreateRequest.login)
-        && Objects.equals(this.name, organizationCreateRequest.name);
+        && Objects.equals(this.name, organizationCreateRequest.name)
+        && Objects.equals(this.avatarUrl, organizationCreateRequest.avatarUrl);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(email, login, name);
+    return Objects.hash(email, login, name, avatarUrl);
   }
 
   @Override
@@ -114,6 +137,7 @@ public class OrganizationCreateRequestDto {
     sb.append("    email: ").append(toIndentedString(email)).append("\n");
     sb.append("    login: ").append(toIndentedString(login)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    avatarUrl: ").append(toIndentedString(avatarUrl)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
@@ -20,6 +20,9 @@ public class OrganizationCreateRequestDto {
   @JsonProperty("email")
   private String email;
 
+  @JsonProperty("login")
+  private String login;
+
   @JsonProperty("name")
   private String name;
 
@@ -45,6 +48,25 @@ public class OrganizationCreateRequestDto {
 
   public void setEmail(String email) {
     this.email = email;
+  }
+
+  public OrganizationCreateRequestDto login(String login) {
+    this.login = login;
+    return this;
+  }
+
+  /**
+   * Get login
+   *
+   * @return login
+   */
+  @Schema(name = "login", example = "example-organization", required = false)
+  public String getLogin() {
+    return login;
+  }
+
+  public void setLogin(String login) {
+    this.login = login;
   }
 
   public OrganizationCreateRequestDto name(String name) {
@@ -76,12 +98,13 @@ public class OrganizationCreateRequestDto {
     }
     OrganizationCreateRequestDto organizationCreateRequest = (OrganizationCreateRequestDto) o;
     return Objects.equals(this.email, organizationCreateRequest.email)
+        && Objects.equals(this.login, organizationCreateRequest.login)
         && Objects.equals(this.name, organizationCreateRequest.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(email, name);
+    return Objects.hash(email, login, name);
   }
 
   @Override
@@ -89,6 +112,7 @@ public class OrganizationCreateRequestDto {
     StringBuilder sb = new StringBuilder();
     sb.append("class OrganizationCreateRequestDto {\n");
     sb.append("    email: ").append(toIndentedString(email)).append("\n");
+    sb.append("    login: ").append(toIndentedString(login)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
@@ -27,7 +27,7 @@ public class OrganizationCreateRequestDto {
   private String name;
 
   @JsonProperty("avatarUrl")
-  private String avatarUrl;
+  private String avatarUrl = null;
 
   @JsonProperty("websiteUrl")
   private String websiteUrl;

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
@@ -27,7 +27,7 @@ public class OrganizationCreateRequestDto {
   private String name;
 
   @JsonProperty("avatarUrl")
-  private String avatarUrl;
+  private String avatarUrl = null;
 
   public OrganizationCreateRequestDto email(String email) {
     this.email = email;

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
@@ -30,7 +30,7 @@ public class OrganizationCreateRequestDto {
    *
    * @return name
    */
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", example = "Example organization", required = false)
   public String getName() {
     return name;
   }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
@@ -32,6 +32,9 @@ public class OrganizationCreateRequestDto {
   @JsonProperty("websiteUrl")
   private String websiteUrl;
 
+  @JsonProperty("description")
+  private String description;
+
   public OrganizationCreateRequestDto email(String email) {
     this.email = email;
     return this;
@@ -132,6 +135,28 @@ public class OrganizationCreateRequestDto {
     this.websiteUrl = websiteUrl;
   }
 
+  public OrganizationCreateRequestDto description(String description) {
+    this.description = description;
+    return this;
+  }
+
+  /**
+   * Get description
+   *
+   * @return description
+   */
+  @Schema(
+      name = "description",
+      example = "A short description of the organization.",
+      required = false)
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -145,12 +170,13 @@ public class OrganizationCreateRequestDto {
         && Objects.equals(this.login, organizationCreateRequest.login)
         && Objects.equals(this.name, organizationCreateRequest.name)
         && Objects.equals(this.avatarUrl, organizationCreateRequest.avatarUrl)
-        && Objects.equals(this.websiteUrl, organizationCreateRequest.websiteUrl);
+        && Objects.equals(this.websiteUrl, organizationCreateRequest.websiteUrl)
+        && Objects.equals(this.description, organizationCreateRequest.description);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(email, login, name, avatarUrl, websiteUrl);
+    return Objects.hash(email, login, name, avatarUrl, websiteUrl, description);
   }
 
   @Override
@@ -162,6 +188,7 @@ public class OrganizationCreateRequestDto {
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    avatarUrl: ").append(toIndentedString(avatarUrl)).append("\n");
     sb.append("    websiteUrl: ").append(toIndentedString(websiteUrl)).append("\n");
+    sb.append("    description: ").append(toIndentedString(description)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationCreateRequestDto.java
@@ -27,7 +27,10 @@ public class OrganizationCreateRequestDto {
   private String name;
 
   @JsonProperty("avatarUrl")
-  private String avatarUrl = null;
+  private String avatarUrl;
+
+  @JsonProperty("websiteUrl")
+  private String websiteUrl;
 
   public OrganizationCreateRequestDto email(String email) {
     this.email = email;
@@ -110,6 +113,25 @@ public class OrganizationCreateRequestDto {
     this.avatarUrl = avatarUrl;
   }
 
+  public OrganizationCreateRequestDto websiteUrl(String websiteUrl) {
+    this.websiteUrl = websiteUrl;
+    return this;
+  }
+
+  /**
+   * Get websiteUrl
+   *
+   * @return websiteUrl
+   */
+  @Schema(name = "websiteUrl", example = "https://example.com", required = false)
+  public String getWebsiteUrl() {
+    return websiteUrl;
+  }
+
+  public void setWebsiteUrl(String websiteUrl) {
+    this.websiteUrl = websiteUrl;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -122,12 +144,13 @@ public class OrganizationCreateRequestDto {
     return Objects.equals(this.email, organizationCreateRequest.email)
         && Objects.equals(this.login, organizationCreateRequest.login)
         && Objects.equals(this.name, organizationCreateRequest.name)
-        && Objects.equals(this.avatarUrl, organizationCreateRequest.avatarUrl);
+        && Objects.equals(this.avatarUrl, organizationCreateRequest.avatarUrl)
+        && Objects.equals(this.websiteUrl, organizationCreateRequest.websiteUrl);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(email, login, name, avatarUrl);
+    return Objects.hash(email, login, name, avatarUrl, websiteUrl);
   }
 
   @Override
@@ -138,6 +161,7 @@ public class OrganizationCreateRequestDto {
     sb.append("    login: ").append(toIndentedString(login)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    avatarUrl: ").append(toIndentedString(avatarUrl)).append("\n");
+    sb.append("    websiteUrl: ").append(toIndentedString(websiteUrl)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
@@ -3,10 +3,13 @@ package org.sagebionetworks.challenge.model.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.validation.Valid;
 import javax.validation.constraints.*;
+import org.springframework.format.annotation.DateTimeFormat;
 
 /** An organization */
 @Schema(name = "Organization", description = "An organization")
@@ -35,6 +38,10 @@ public class OrganizationDto {
 
   @JsonProperty("id")
   private Long id;
+
+  @JsonProperty("createdAt")
+  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+  private OffsetDateTime createdAt;
 
   public OrganizationDto email(String email) {
     this.email = email;
@@ -182,6 +189,26 @@ public class OrganizationDto {
     this.id = id;
   }
 
+  public OrganizationDto createdAt(OffsetDateTime createdAt) {
+    this.createdAt = createdAt;
+    return this;
+  }
+
+  /**
+   * Get createdAt
+   *
+   * @return createdAt
+   */
+  @Valid
+  @Schema(name = "createdAt", example = "2022-07-04T22:19:11Z", required = false)
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public void setCreatedAt(OffsetDateTime createdAt) {
+    this.createdAt = createdAt;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -197,12 +224,13 @@ public class OrganizationDto {
         && Objects.equals(this.avatarUrl, organization.avatarUrl)
         && Objects.equals(this.websiteUrl, organization.websiteUrl)
         && Objects.equals(this.description, organization.description)
-        && Objects.equals(this.id, organization.id);
+        && Objects.equals(this.id, organization.id)
+        && Objects.equals(this.createdAt, organization.createdAt);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(email, login, name, avatarUrl, websiteUrl, description, id);
+    return Objects.hash(email, login, name, avatarUrl, websiteUrl, description, id, createdAt);
   }
 
   @Override
@@ -216,6 +244,7 @@ public class OrganizationDto {
     sb.append("    websiteUrl: ").append(toIndentedString(websiteUrl)).append("\n");
     sb.append("    description: ").append(toIndentedString(description)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
+    sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
@@ -43,6 +43,10 @@ public class OrganizationDto {
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
   private OffsetDateTime createdAt;
 
+  @JsonProperty("updatedAt")
+  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+  private OffsetDateTime updatedAt;
+
   public OrganizationDto email(String email) {
     this.email = email;
     return this;
@@ -209,6 +213,26 @@ public class OrganizationDto {
     this.createdAt = createdAt;
   }
 
+  public OrganizationDto updatedAt(OffsetDateTime updatedAt) {
+    this.updatedAt = updatedAt;
+    return this;
+  }
+
+  /**
+   * Get updatedAt
+   *
+   * @return updatedAt
+   */
+  @Valid
+  @Schema(name = "updatedAt", example = "2022-07-04T22:19:11Z", required = false)
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void setUpdatedAt(OffsetDateTime updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -225,12 +249,14 @@ public class OrganizationDto {
         && Objects.equals(this.websiteUrl, organization.websiteUrl)
         && Objects.equals(this.description, organization.description)
         && Objects.equals(this.id, organization.id)
-        && Objects.equals(this.createdAt, organization.createdAt);
+        && Objects.equals(this.createdAt, organization.createdAt)
+        && Objects.equals(this.updatedAt, organization.updatedAt);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(email, login, name, avatarUrl, websiteUrl, description, id, createdAt);
+    return Objects.hash(
+        email, login, name, avatarUrl, websiteUrl, description, id, createdAt, updatedAt);
   }
 
   @Override
@@ -245,6 +271,7 @@ public class OrganizationDto {
     sb.append("    description: ").append(toIndentedString(description)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
+    sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
@@ -28,7 +28,7 @@ public class OrganizationDto {
   private String name;
 
   @JsonProperty("avatarUrl")
-  private String avatarUrl;
+  private String avatarUrl = null;
 
   @JsonProperty("websiteUrl")
   private String websiteUrl;

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
@@ -30,6 +30,9 @@ public class OrganizationDto {
   @JsonProperty("websiteUrl")
   private String websiteUrl;
 
+  @JsonProperty("description")
+  private String description;
+
   @JsonProperty("id")
   private Long id;
 
@@ -133,6 +136,28 @@ public class OrganizationDto {
     this.websiteUrl = websiteUrl;
   }
 
+  public OrganizationDto description(String description) {
+    this.description = description;
+    return this;
+  }
+
+  /**
+   * Get description
+   *
+   * @return description
+   */
+  @Schema(
+      name = "description",
+      example = "A short description of the organization.",
+      required = false)
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
   public OrganizationDto id(Long id) {
     this.id = id;
     return this;
@@ -171,12 +196,13 @@ public class OrganizationDto {
         && Objects.equals(this.name, organization.name)
         && Objects.equals(this.avatarUrl, organization.avatarUrl)
         && Objects.equals(this.websiteUrl, organization.websiteUrl)
+        && Objects.equals(this.description, organization.description)
         && Objects.equals(this.id, organization.id);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(email, login, name, avatarUrl, websiteUrl, id);
+    return Objects.hash(email, login, name, avatarUrl, websiteUrl, description, id);
   }
 
   @Override
@@ -188,6 +214,7 @@ public class OrganizationDto {
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    avatarUrl: ").append(toIndentedString(avatarUrl)).append("\n");
     sb.append("    websiteUrl: ").append(toIndentedString(websiteUrl)).append("\n");
+    sb.append("    description: ").append(toIndentedString(description)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
@@ -24,6 +24,9 @@ public class OrganizationDto {
   @JsonProperty("name")
   private String name;
 
+  @JsonProperty("avatarUrl")
+  private String avatarUrl;
+
   @JsonProperty("id")
   private Long id;
 
@@ -89,6 +92,25 @@ public class OrganizationDto {
     this.name = name;
   }
 
+  public OrganizationDto avatarUrl(String avatarUrl) {
+    this.avatarUrl = avatarUrl;
+    return this;
+  }
+
+  /**
+   * Get avatarUrl
+   *
+   * @return avatarUrl
+   */
+  @Schema(name = "avatarUrl", example = "https://via.placeholder.com/300.png", required = false)
+  public String getAvatarUrl() {
+    return avatarUrl;
+  }
+
+  public void setAvatarUrl(String avatarUrl) {
+    this.avatarUrl = avatarUrl;
+  }
+
   public OrganizationDto id(Long id) {
     this.id = id;
     return this;
@@ -125,12 +147,13 @@ public class OrganizationDto {
     return Objects.equals(this.email, organization.email)
         && Objects.equals(this.login, organization.login)
         && Objects.equals(this.name, organization.name)
+        && Objects.equals(this.avatarUrl, organization.avatarUrl)
         && Objects.equals(this.id, organization.id);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(email, login, name, id);
+    return Objects.hash(email, login, name, avatarUrl, id);
   }
 
   @Override
@@ -140,6 +163,7 @@ public class OrganizationDto {
     sb.append("    email: ").append(toIndentedString(email)).append("\n");
     sb.append("    login: ").append(toIndentedString(login)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    avatarUrl: ").append(toIndentedString(avatarUrl)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
@@ -18,6 +18,9 @@ public class OrganizationDto {
   @JsonProperty("email")
   private String email;
 
+  @JsonProperty("login")
+  private String login;
+
   @JsonProperty("name")
   private String name;
 
@@ -46,6 +49,25 @@ public class OrganizationDto {
 
   public void setEmail(String email) {
     this.email = email;
+  }
+
+  public OrganizationDto login(String login) {
+    this.login = login;
+    return this;
+  }
+
+  /**
+   * Get login
+   *
+   * @return login
+   */
+  @Schema(name = "login", example = "example-organization", required = false)
+  public String getLogin() {
+    return login;
+  }
+
+  public void setLogin(String login) {
+    this.login = login;
   }
 
   public OrganizationDto name(String name) {
@@ -101,13 +123,14 @@ public class OrganizationDto {
     }
     OrganizationDto organization = (OrganizationDto) o;
     return Objects.equals(this.email, organization.email)
+        && Objects.equals(this.login, organization.login)
         && Objects.equals(this.name, organization.name)
         && Objects.equals(this.id, organization.id);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(email, name, id);
+    return Objects.hash(email, login, name, id);
   }
 
   @Override
@@ -115,6 +138,7 @@ public class OrganizationDto {
     StringBuilder sb = new StringBuilder();
     sb.append("class OrganizationDto {\n");
     sb.append("    email: ").append(toIndentedString(email)).append("\n");
+    sb.append("    login: ").append(toIndentedString(login)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("}");

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
@@ -25,7 +25,7 @@ public class OrganizationDto {
   private String name;
 
   @JsonProperty("avatarUrl")
-  private String avatarUrl;
+  private String avatarUrl = null;
 
   @JsonProperty("id")
   private Long id;

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
@@ -31,7 +31,7 @@ public class OrganizationDto {
    *
    * @return name
    */
-  @Schema(name = "name", required = false)
+  @Schema(name = "name", example = "Example organization", required = false)
   public String getName() {
     return name;
   }
@@ -50,11 +50,12 @@ public class OrganizationDto {
    *
    * @return id
    */
+  @NotNull
   @Schema(
       name = "id",
       example = "1",
       description = "The unique identifier of an organization",
-      required = false)
+      required = true)
   public Long getId() {
     return id;
   }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
@@ -203,8 +203,9 @@ public class OrganizationDto {
    *
    * @return createdAt
    */
+  @NotNull
   @Valid
-  @Schema(name = "createdAt", example = "2022-07-04T22:19:11Z", required = false)
+  @Schema(name = "createdAt", example = "2022-07-04T22:19:11Z", required = true)
   public OffsetDateTime getCreatedAt() {
     return createdAt;
   }
@@ -223,8 +224,9 @@ public class OrganizationDto {
    *
    * @return updatedAt
    */
+  @NotNull
   @Valid
-  @Schema(name = "updatedAt", example = "2022-07-04T22:19:11Z", required = false)
+  @Schema(name = "updatedAt", example = "2022-07-04T22:19:11Z", required = true)
   public OffsetDateTime getUpdatedAt() {
     return updatedAt;
   }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
@@ -25,7 +25,10 @@ public class OrganizationDto {
   private String name;
 
   @JsonProperty("avatarUrl")
-  private String avatarUrl = null;
+  private String avatarUrl;
+
+  @JsonProperty("websiteUrl")
+  private String websiteUrl;
 
   @JsonProperty("id")
   private Long id;
@@ -111,6 +114,25 @@ public class OrganizationDto {
     this.avatarUrl = avatarUrl;
   }
 
+  public OrganizationDto websiteUrl(String websiteUrl) {
+    this.websiteUrl = websiteUrl;
+    return this;
+  }
+
+  /**
+   * Get websiteUrl
+   *
+   * @return websiteUrl
+   */
+  @Schema(name = "websiteUrl", example = "https://example.com", required = false)
+  public String getWebsiteUrl() {
+    return websiteUrl;
+  }
+
+  public void setWebsiteUrl(String websiteUrl) {
+    this.websiteUrl = websiteUrl;
+  }
+
   public OrganizationDto id(Long id) {
     this.id = id;
     return this;
@@ -148,12 +170,13 @@ public class OrganizationDto {
         && Objects.equals(this.login, organization.login)
         && Objects.equals(this.name, organization.name)
         && Objects.equals(this.avatarUrl, organization.avatarUrl)
+        && Objects.equals(this.websiteUrl, organization.websiteUrl)
         && Objects.equals(this.id, organization.id);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(email, login, name, avatarUrl, id);
+    return Objects.hash(email, login, name, avatarUrl, websiteUrl, id);
   }
 
   @Override
@@ -164,6 +187,7 @@ public class OrganizationDto {
     sb.append("    login: ").append(toIndentedString(login)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    avatarUrl: ").append(toIndentedString(avatarUrl)).append("\n");
+    sb.append("    websiteUrl: ").append(toIndentedString(websiteUrl)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
@@ -81,7 +81,8 @@ public class OrganizationDto {
    *
    * @return login
    */
-  @Schema(name = "login", example = "example-organization", required = false)
+  @NotNull
+  @Schema(name = "login", example = "example-organization", required = true)
   public String getLogin() {
     return login;
   }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationDto.java
@@ -15,11 +15,38 @@ import javax.validation.constraints.*;
 // TODO Add x-java-class-annotations
 public class OrganizationDto {
 
+  @JsonProperty("email")
+  private String email;
+
   @JsonProperty("name")
   private String name;
 
   @JsonProperty("id")
   private Long id;
+
+  public OrganizationDto email(String email) {
+    this.email = email;
+    return this;
+  }
+
+  /**
+   * An email address.
+   *
+   * @return email
+   */
+  @Email
+  @Schema(
+      name = "email",
+      example = "john.smith@example.com",
+      description = "An email address.",
+      required = false)
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
 
   public OrganizationDto name(String name) {
     this.name = name;
@@ -73,18 +100,21 @@ public class OrganizationDto {
       return false;
     }
     OrganizationDto organization = (OrganizationDto) o;
-    return Objects.equals(this.name, organization.name) && Objects.equals(this.id, organization.id);
+    return Objects.equals(this.email, organization.email)
+        && Objects.equals(this.name, organization.name)
+        && Objects.equals(this.id, organization.id);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, id);
+    return Objects.hash(email, name, id);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class OrganizationDto {\n");
+    sb.append("    email: ").append(toIndentedString(email)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("}");

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationsPageDto.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/dto/OrganizationsPageDto.java
@@ -78,6 +78,9 @@ public class OrganizationsPageDto {
   }
 
   public OrganizationsPageDto addOrganizationsItem(OrganizationDto organizationsItem) {
+    if (this.organizations == null) {
+      this.organizations = new ArrayList<>();
+    }
     this.organizations.add(organizationsItem);
     return this;
   }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
@@ -31,4 +31,7 @@ public class OrganizationEntity {
 
   @Column(nullable = false)
   private String name;
+
+  @Column(nullable = false)
+  private String email;
 }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
@@ -43,4 +43,6 @@ public class OrganizationEntity {
 
   @Column(name = "website_url")
   private String websiteUrl;
+
+  @Column() private String description;
 }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
@@ -49,4 +49,7 @@ public class OrganizationEntity {
 
   @Column(name = "created_at")
   private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at")
+  private OffsetDateTime updatedAt;
 }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
@@ -34,4 +34,7 @@ public class OrganizationEntity {
 
   @Column(nullable = false)
   private String email;
+
+  @Column(nullable = false)
+  private String login;
 }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
@@ -37,4 +37,7 @@ public class OrganizationEntity {
 
   @Column(nullable = false)
   private String login;
+
+  @Column(name = "avatar_url", nullable = false)
+  private String avatarUrl;
 }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
@@ -39,7 +39,7 @@ public class OrganizationEntity {
   @Column(nullable = false)
   private String login;
 
-  @Column(name = "avatar_url")
+  @Column(name = "avatar_url", nullable = true)
   private String avatarUrl;
 
   @Column(name = "website_url")

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.challenge.model.entity;
 
+import java.time.OffsetDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -45,4 +46,7 @@ public class OrganizationEntity {
   private String websiteUrl;
 
   @Column() private String description;
+
+  @Column(name = "created_at")
+  private OffsetDateTime createdAt;
 }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
@@ -38,6 +38,9 @@ public class OrganizationEntity {
   @Column(nullable = false)
   private String login;
 
-  @Column(name = "avatar_url", nullable = true)
+  @Column(name = "avatar_url")
   private String avatarUrl;
+
+  @Column(name = "website_url")
+  private String websiteUrl;
 }

--- a/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
+++ b/apps/challenge-organization-service/src/main/java/org/sagebionetworks/challenge/model/entity/OrganizationEntity.java
@@ -38,6 +38,6 @@ public class OrganizationEntity {
   @Column(nullable = false)
   private String login;
 
-  @Column(name = "avatar_url", nullable = false)
+  @Column(name = "avatar_url", nullable = true)
   private String avatarUrl;
 }

--- a/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.0__create_organization_table.sql
+++ b/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.0__create_organization_table.sql
@@ -8,6 +8,7 @@ CREATE TABLE `challenge_organization`
     `login`                 varchar(255) DEFAULT NULL,
     `avatar_url`            varchar(255) DEFAULT NULL,
     `website_url`           varchar(255) DEFAULT NULL,
+    `description`           varchar(255) DEFAULT NULL,
     PRIMARY KEY (`id`)
 );
 

--- a/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.0__create_organization_table.sql
+++ b/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.0__create_organization_table.sql
@@ -9,6 +9,7 @@ CREATE TABLE `challenge_organization`
     `avatar_url`            varchar(255) DEFAULT NULL,
     `website_url`           varchar(255) DEFAULT NULL,
     `description`           varchar(255) DEFAULT NULL,
+    `created_at`            DATETIME DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (`id`)
 );
 

--- a/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.0__create_organization_table.sql
+++ b/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.0__create_organization_table.sql
@@ -7,6 +7,7 @@ CREATE TABLE `challenge_organization`
     `email`                 varchar(255) DEFAULT NULL,
     `login`                 varchar(255) DEFAULT NULL,
     `avatar_url`            varchar(255) DEFAULT NULL,
+    `website_url`           varchar(255) DEFAULT NULL,
     PRIMARY KEY (`id`)
 );
 

--- a/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.0__create_organization_table.sql
+++ b/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.0__create_organization_table.sql
@@ -10,6 +10,7 @@ CREATE TABLE `challenge_organization`
     `website_url`           varchar(255) DEFAULT NULL,
     `description`           varchar(255) DEFAULT NULL,
     `created_at`            DATETIME DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`            DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (`id`)
 );
 

--- a/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.0__create_organization_table.sql
+++ b/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.0__create_organization_table.sql
@@ -5,6 +5,7 @@ CREATE TABLE `challenge_organization`
     `id`                    bigint(20) NOT NULL AUTO_INCREMENT,
     `name`                  varchar(255) DEFAULT NULL,
     `email`                 varchar(255) DEFAULT NULL,
+    `login`                 varchar(255) DEFAULT NULL,
     PRIMARY KEY (`id`)
 );
 

--- a/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.0__create_organization_table.sql
+++ b/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.0__create_organization_table.sql
@@ -4,6 +4,7 @@ CREATE TABLE `challenge_organization`
 (
     `id`                    bigint(20) NOT NULL AUTO_INCREMENT,
     `name`                  varchar(255) DEFAULT NULL,
+    `email`                 varchar(255) DEFAULT NULL,
     PRIMARY KEY (`id`)
 );
 

--- a/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.0__create_organization_table.sql
+++ b/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.0__create_organization_table.sql
@@ -6,6 +6,7 @@ CREATE TABLE `challenge_organization`
     `name`                  varchar(255) DEFAULT NULL,
     `email`                 varchar(255) DEFAULT NULL,
     `login`                 varchar(255) DEFAULT NULL,
+    `avatar_url`            varchar(255) DEFAULT NULL,
     PRIMARY KEY (`id`)
 );
 

--- a/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.1__temp_data.sql
+++ b/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.1__temp_data.sql
@@ -1,7 +1,7 @@
 INSERT INTO challenge_organization
-  (id, name, email)
-VALUES ('1', 'DREAM', 'dream@sagebionetworks.org'),
-  ('2', 'MICCAI', ''),
-  ('3', 'OpenEBench', ''),
-  ('4', 'precisionFDA', ''),
-  ('5', 'CodaLab', '');
+  (id, name, email, login)
+VALUES ('1', 'DREAM', 'dream@sagebionetworks.org', 'dream'),
+  ('2', 'MICCAI', '', 'miccai'),
+  ('3', 'OpenEBench', '', 'openebench'),
+  ('4', 'precisionFDA', '', 'precisionfda'),
+  ('5', 'CodaLab', '', 'codalab');

--- a/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.1__temp_data.sql
+++ b/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.1__temp_data.sql
@@ -1,7 +1,30 @@
-INSERT INTO challenge_organization
-  (id, name, email, login, avatar_url, website_url)
-VALUES ('1', 'DREAM', 'dream@sagebionetworks.org', 'dream', 'https://via.placeholder.com/300.png', 'https://dreamchallenges.org'),
-  ('2', 'MICCAI', '', 'miccai', '', ''),
-  ('3', 'OpenEBench', '', 'openebench', '', ''),
-  ('4', 'precisionFDA', '', 'precisionfda', '', ''),
-  ('5', 'CodaLab', '', 'codalab', '', '');
+INSERT INTO challenge_organization (
+    id,
+    name,
+    email,
+    login,
+    avatar_url,
+    website_url,
+    description
+  )
+VALUES (
+    '1',
+    'DREAM',
+    'dream@sagebionetworks.org',
+    'dream',
+    'https://via.placeholder.com/300.png',
+    'https://dreamchallenges.org',
+    'Together, we share a vision to enable individuals and groups to collaborate openly so that the “wisdom of the crowd” provides the greatest impact on science and human health.'
+  ),
+  ('2', 'MICCAI', '', 'miccai', '', '', ''),
+  ('3', 'OpenEBench', '', 'openebench', '', '', ''),
+  (
+    '4',
+    'precisionFDA',
+    '',
+    'precisionfda',
+    '',
+    '',
+    ''
+  ),
+  ('5', 'CodaLab', '', 'codalab', '', '', '');

--- a/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.1__temp_data.sql
+++ b/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.1__temp_data.sql
@@ -1,7 +1,7 @@
 INSERT INTO challenge_organization
-  (id, name, email, login, avatar_url)
-VALUES ('1', 'DREAM', 'dream@sagebionetworks.org', 'dream', 'https://via.placeholder.com/300.png'),
-  ('2', 'MICCAI', '', 'miccai', ''),
-  ('3', 'OpenEBench', '', 'openebench', ''),
-  ('4', 'precisionFDA', '', 'precisionfda', ''),
-  ('5', 'CodaLab', '', 'codalab', '');
+  (id, name, email, login, avatar_url, website_url)
+VALUES ('1', 'DREAM', 'dream@sagebionetworks.org', 'dream', 'https://via.placeholder.com/300.png', 'https://dreamchallenges.org'),
+  ('2', 'MICCAI', '', 'miccai', '', ''),
+  ('3', 'OpenEBench', '', 'openebench', '', ''),
+  ('4', 'precisionFDA', '', 'precisionfda', '', ''),
+  ('5', 'CodaLab', '', 'codalab', '', '');

--- a/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.1__temp_data.sql
+++ b/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.1__temp_data.sql
@@ -1,7 +1,7 @@
 INSERT INTO challenge_organization
-  (id, name)
-VALUES ('1', 'DREAM'),
-  ('2', 'MICCAI'),
-  ('3', 'OpenEBench'),
-  ('4', 'precisionFDA'),
-  ('5', 'CodaLab');
+  (id, name, email)
+VALUES ('1', 'DREAM', 'dream@sagebionetworks.org'),
+  ('2', 'MICCAI', ''),
+  ('3', 'OpenEBench', ''),
+  ('4', 'precisionFDA', ''),
+  ('5', 'CodaLab', '');

--- a/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.1__temp_data.sql
+++ b/apps/challenge-organization-service/src/main/resources/db/migration/V1.0.1__temp_data.sql
@@ -1,7 +1,7 @@
 INSERT INTO challenge_organization
-  (id, name, email, login)
-VALUES ('1', 'DREAM', 'dream@sagebionetworks.org', 'dream'),
-  ('2', 'MICCAI', '', 'miccai'),
-  ('3', 'OpenEBench', '', 'openebench'),
-  ('4', 'precisionFDA', '', 'precisionfda'),
-  ('5', 'CodaLab', '', 'codalab');
+  (id, name, email, login, avatar_url)
+VALUES ('1', 'DREAM', 'dream@sagebionetworks.org', 'dream', 'https://via.placeholder.com/300.png'),
+  ('2', 'MICCAI', '', 'miccai', ''),
+  ('3', 'OpenEBench', '', 'openebench', ''),
+  ('4', 'precisionFDA', '', 'precisionfda', ''),
+  ('5', 'CodaLab', '', 'codalab', '');

--- a/apps/challenge-organization-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-organization-service/src/main/resources/openapi.yaml
@@ -266,6 +266,10 @@ components:
           example: 2022-07-04T22:19:11Z
           format: date-time
           type: string
+        updatedAt:
+          example: 2022-07-04T22:19:11Z
+          format: date-time
+          type: string
       required:
       - id
       type: object

--- a/apps/challenge-organization-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-organization-service/src/main/resources/openapi.yaml
@@ -197,6 +197,7 @@ components:
         avatarUrl:
           example: https://via.placeholder.com/300.png
           format: url
+          nullable: true
           type: string
       type: object
     OrganizationId:

--- a/apps/challenge-organization-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-organization-service/src/main/resources/openapi.yaml
@@ -175,25 +175,24 @@ components:
       - paging
       - totalResults
       type: object
+    OrganizationCreateRequest:
+      description: The information required to create an org account
+      example:
+        name: Awesome Org
+      properties:
+        name:
+          type: string
+      type: object
     OrganizationId:
       description: The unique identifier of an organization
       example: 1
       format: int64
       type: integer
     Organization:
+      allOf:
+      - $ref: '#/components/schemas/OrganizationCreateRequest'
+      - $ref: '#/components/schemas/Organization_allOf'
       description: An organization
-      example:
-        name: DREAM
-      properties:
-        id:
-          description: The unique identifier of an organization
-          example: 1
-          format: int64
-          type: integer
-        name:
-          type: string
-      required:
-      - name
       type: object
     OrganizationsPage:
       allOf:
@@ -232,6 +231,14 @@ components:
           description: Link to the next page of results
           format: url
           type: string
+      type: object
+    Organization_allOf:
+      properties:
+        id:
+          description: The unique identifier of an organization
+          example: 1
+          format: int64
+          type: integer
       type: object
     OrganizationsPage_allOf:
       properties:

--- a/apps/challenge-organization-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-organization-service/src/main/resources/openapi.yaml
@@ -175,9 +175,19 @@ components:
       - paging
       - totalResults
       type: object
+    Email:
+      description: An email address.
+      example: john.smith@example.com
+      format: email
+      type: string
     OrganizationCreateRequest:
       description: The information required to create an org account
       properties:
+        email:
+          description: An email address.
+          example: john.smith@example.com
+          format: email
+          type: string
         name:
           example: Example organization
           type: string

--- a/apps/challenge-organization-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-organization-service/src/main/resources/openapi.yaml
@@ -205,6 +205,8 @@ components:
         description:
           example: A short description of the organization.
           type: string
+      required:
+      - login
       type: object
     OrganizationId:
       description: The unique identifier of an organization

--- a/apps/challenge-organization-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-organization-service/src/main/resources/openapi.yaml
@@ -271,7 +271,9 @@ components:
           format: date-time
           type: string
       required:
+      - createdAt
       - id
+      - updatedAt
       type: object
     OrganizationsPage_allOf:
       properties:

--- a/apps/challenge-organization-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-organization-service/src/main/resources/openapi.yaml
@@ -177,10 +177,9 @@ components:
       type: object
     OrganizationCreateRequest:
       description: The information required to create an org account
-      example:
-        name: Awesome Org
       properties:
         name:
+          example: Example organization
           type: string
       type: object
     OrganizationId:
@@ -239,6 +238,8 @@ components:
           example: 1
           format: int64
           type: integer
+      required:
+      - id
       type: object
     OrganizationsPage_allOf:
       properties:

--- a/apps/challenge-organization-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-organization-service/src/main/resources/openapi.yaml
@@ -202,6 +202,9 @@ components:
           example: https://example.com
           format: url
           type: string
+        description:
+          example: A short description of the organization.
+          type: string
       type: object
     OrganizationId:
       description: The unique identifier of an organization

--- a/apps/challenge-organization-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-organization-service/src/main/resources/openapi.yaml
@@ -197,6 +197,7 @@ components:
         avatarUrl:
           example: https://via.placeholder.com/300.png
           format: url
+          nullable: true
           type: string
         websiteUrl:
           example: https://example.com

--- a/apps/challenge-organization-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-organization-service/src/main/resources/openapi.yaml
@@ -262,6 +262,10 @@ components:
           example: 1
           format: int64
           type: integer
+        createdAt:
+          example: 2022-07-04T22:19:11Z
+          format: date-time
+          type: string
       required:
       - id
       type: object

--- a/apps/challenge-organization-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-organization-service/src/main/resources/openapi.yaml
@@ -194,6 +194,10 @@ components:
         name:
           example: Example organization
           type: string
+        avatarUrl:
+          example: https://via.placeholder.com/300.png
+          format: url
+          type: string
       type: object
     OrganizationId:
       description: The unique identifier of an organization

--- a/apps/challenge-organization-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-organization-service/src/main/resources/openapi.yaml
@@ -188,6 +188,9 @@ components:
           example: john.smith@example.com
           format: email
           type: string
+        login:
+          example: example-organization
+          type: string
         name:
           example: Example organization
           type: string

--- a/apps/challenge-organization-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-organization-service/src/main/resources/openapi.yaml
@@ -197,7 +197,10 @@ components:
         avatarUrl:
           example: https://via.placeholder.com/300.png
           format: url
-          nullable: true
+          type: string
+        websiteUrl:
+          example: https://example.com
+          format: url
           type: string
       type: object
     OrganizationId:

--- a/libs/api-client-angular/src/lib/.openapi-generator/FILES
+++ b/libs/api-client-angular/src/lib/.openapi-generator/FILES
@@ -11,6 +11,8 @@ index.ts
 model/basicError.ts
 model/models.ts
 model/organization.ts
+model/organizationAllOf.ts
+model/organizationCreateRequest.ts
 model/organizationsPage.ts
 model/organizationsPageAllOf.ts
 model/pageMetadata.ts

--- a/libs/api-client-angular/src/lib/model/models.ts
+++ b/libs/api-client-angular/src/lib/model/models.ts
@@ -1,5 +1,7 @@
 export * from './basicError';
 export * from './organization';
+export * from './organizationAllOf';
+export * from './organizationCreateRequest';
 export * from './organizationsPage';
 export * from './organizationsPageAllOf';
 export * from './pageMetadata';

--- a/libs/api-client-angular/src/lib/model/organization.ts
+++ b/libs/api-client-angular/src/lib/model/organization.ts
@@ -21,7 +21,7 @@ export interface Organization {
     email?: string;
     login: string;
     name?: string;
-    avatarUrl?: string;
+    avatarUrl?: string | null;
     websiteUrl?: string;
     description?: string;
     /**

--- a/libs/api-client-angular/src/lib/model/organization.ts
+++ b/libs/api-client-angular/src/lib/model/organization.ts
@@ -19,7 +19,7 @@ export interface Organization {
      * An email address.
      */
     email?: string;
-    login?: string;
+    login: string;
     name?: string;
     avatarUrl?: string;
     websiteUrl?: string;

--- a/libs/api-client-angular/src/lib/model/organization.ts
+++ b/libs/api-client-angular/src/lib/model/organization.ts
@@ -16,9 +16,19 @@
  */
 export interface Organization { 
     /**
+     * An email address.
+     */
+    email?: string;
+    login?: string;
+    name?: string;
+    avatarUrl?: string;
+    websiteUrl?: string;
+    description?: string;
+    /**
      * The unique identifier of an organization
      */
-    id?: number;
-    name: string;
+    id: number;
+    createdAt: string;
+    updatedAt: string;
 }
 

--- a/libs/api-client-angular/src/lib/model/organizationAllOf.ts
+++ b/libs/api-client-angular/src/lib/model/organizationAllOf.ts
@@ -11,18 +11,12 @@
  */
 
 
-/**
- * The information required to create a user account
- */
-export interface UserCreateRequest { 
-    login: string;
+export interface OrganizationAllOf { 
     /**
-     * An email address.
+     * The unique identifier of an organization
      */
-    email: string;
-    password: string;
-    name?: string | null;
-    avatarUrl?: string | null;
-    bio?: string | null;
+    id: number;
+    createdAt: string;
+    updatedAt: string;
 }
 

--- a/libs/api-client-angular/src/lib/model/organizationCreateRequest.ts
+++ b/libs/api-client-angular/src/lib/model/organizationCreateRequest.ts
@@ -12,17 +12,17 @@
 
 
 /**
- * The information required to create a user account
+ * The information required to create an org account
  */
-export interface UserCreateRequest { 
-    login: string;
+export interface OrganizationCreateRequest { 
     /**
      * An email address.
      */
-    email: string;
-    password: string;
-    name?: string | null;
-    avatarUrl?: string | null;
-    bio?: string | null;
+    email?: string;
+    login?: string;
+    name?: string;
+    avatarUrl?: string;
+    websiteUrl?: string;
+    description?: string;
 }
 

--- a/libs/api-client-angular/src/lib/model/organizationCreateRequest.ts
+++ b/libs/api-client-angular/src/lib/model/organizationCreateRequest.ts
@@ -21,7 +21,7 @@ export interface OrganizationCreateRequest {
     email?: string;
     login: string;
     name?: string;
-    avatarUrl?: string;
+    avatarUrl?: string | null;
     websiteUrl?: string;
     description?: string;
 }

--- a/libs/api-client-angular/src/lib/model/organizationCreateRequest.ts
+++ b/libs/api-client-angular/src/lib/model/organizationCreateRequest.ts
@@ -19,7 +19,7 @@ export interface OrganizationCreateRequest {
      * An email address.
      */
     email?: string;
-    login?: string;
+    login: string;
     name?: string;
     avatarUrl?: string;
     websiteUrl?: string;

--- a/libs/api-client-angular/src/lib/model/user.ts
+++ b/libs/api-client-angular/src/lib/model/user.ts
@@ -22,7 +22,7 @@ export interface User {
     id?: number;
     login: string;
     /**
-     * An email address
+     * An email address.
      */
     email: string;
     name?: string | null;

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -174,6 +174,9 @@ components:
       properties:
         email:
           $ref: '#/components/schemas/Email'
+        login:
+          type: string
+          example: example-organization
         name:
           type: string
           example: Example organization

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -191,6 +191,8 @@ components:
         description:
           type: string
           example: A short description of the organization.
+      required:
+        - login
     OrganizationId:
       description: The unique identifier of an organization
       type: integer

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -163,56 +163,28 @@ components:
       required:
         - paging
         - totalResults
+    OrganizationCreateRequest:
+      type: object
+      description: The information required to create an org account
+      properties:
+        name:
+          type: string
+      example:
+        name: Awesome Org
     OrganizationId:
       description: The unique identifier of an organization
       type: integer
       format: int64
       example: 1
-    Email:
-      description: An email address
-      type: string
-      format: email
-      example: john.smith@example.com
-    OrganizationCreateRequest:
-      type: object
-      description: The information required to create an org account
-      properties:
-        login:
-          type: string
-        email:
-          $ref: '#/components/schemas/Email'
-        name:
-          type: string
-          nullable: true
-        avatarUrl:
-          type: string
-          format: url
-          example: 'https://example.com/awesome-avatar.png'
-          nullable: true
-        websiteUrl:
-          type: string
-          format: url
-          example: 'https://example.com'
-          nullable: true
-        description:
-          type: string
-          nullable: true
-      required:
-        - login
-        - email
-      example:
-        login: awesome-org
-        email: contact@example.org
-        name: Awesome Org
-        avatarUrl: 'https://example.com/awesome-avatar.png'
-        websiteUrl: 'https://example.com'
-        description: A great organization
     Organization:
       type: object
       description: An organization
       allOf:
-        - $ref: '#/components/schemas/OrganizationId'
         - $ref: '#/components/schemas/OrganizationCreateRequest'
+        - type: object
+          properties:
+            id:
+              $ref: '#/components/schemas/OrganizationId'
     OrganizationsPage:
       type: object
       description: A page of organizations
@@ -252,6 +224,11 @@ components:
         - status
       x-java-class-annotations:
         - '@lombok.Builder'
+    Email:
+      description: An email address
+      type: string
+      format: email
+      example: john.smith@example.com
     UserCreateRequest:
       type: object
       description: The information required to create a user account

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -180,6 +180,10 @@ components:
         name:
           type: string
           example: Example organization
+        avatarUrl:
+          type: string
+          format: url
+          example: 'https://via.placeholder.com/300.png'
     OrganizationId:
       description: The unique identifier of an organization
       type: integer

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -169,8 +169,7 @@ components:
       properties:
         name:
           type: string
-      example:
-        name: Awesome Org
+          example: Example organization
     OrganizationId:
       description: The unique identifier of an organization
       type: integer
@@ -185,6 +184,8 @@ components:
           properties:
             id:
               $ref: '#/components/schemas/OrganizationId'
+          required:
+            - id
     OrganizationsPage:
       type: object
       description: A page of organizations

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -168,18 +168,51 @@ components:
       type: integer
       format: int64
       example: 1
+    Email:
+      description: An email address
+      type: string
+      format: email
+      example: john.smith@example.com
+    OrganizationCreateRequest:
+      type: object
+      description: The information required to create an org account
+      properties:
+        login:
+          type: string
+        email:
+          $ref: '#/components/schemas/Email'
+        name:
+          type: string
+          nullable: true
+        avatarUrl:
+          type: string
+          format: url
+          example: 'https://example.com/awesome-avatar.png'
+          nullable: true
+        websiteUrl:
+          type: string
+          format: url
+          example: 'https://example.com'
+          nullable: true
+        description:
+          type: string
+          nullable: true
+      required:
+        - login
+        - email
+      example:
+        login: awesome-org
+        email: contact@example.org
+        name: Awesome Org
+        avatarUrl: 'https://example.com/awesome-avatar.png'
+        websiteUrl: 'https://example.com'
+        description: A great organization
     Organization:
       type: object
       description: An organization
-      properties:
-        id:
-          $ref: '#/components/schemas/OrganizationId'
-        name:
-          type: string
-      required:
-        - name
-      example:
-        name: DREAM
+      allOf:
+        - $ref: '#/components/schemas/OrganizationId'
+        - $ref: '#/components/schemas/OrganizationCreateRequest'
     OrganizationsPage:
       type: object
       description: A page of organizations
@@ -219,11 +252,6 @@ components:
         - status
       x-java-class-annotations:
         - '@lombok.Builder'
-    Email:
-      description: An email address
-      type: string
-      format: email
-      example: john.smith@example.com
     UserCreateRequest:
       type: object
       description: The information required to create a user account

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -184,6 +184,7 @@ components:
           type: string
           format: url
           example: 'https://via.placeholder.com/300.png'
+          nullable: true
         websiteUrl:
           type: string
           format: url

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -188,6 +188,9 @@ components:
           type: string
           format: url
           example: 'https://example.com'
+        description:
+          type: string
+          example: A short description of the organization.
     OrganizationId:
       description: The unique identifier of an organization
       type: integer

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -184,6 +184,7 @@ components:
           type: string
           format: url
           example: 'https://via.placeholder.com/300.png'
+          nullable: true
     OrganizationId:
       description: The unique identifier of an organization
       type: integer

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -184,7 +184,10 @@ components:
           type: string
           format: url
           example: 'https://via.placeholder.com/300.png'
-          nullable: true
+        websiteUrl:
+          type: string
+          format: url
+          example: 'https://example.com'
     OrganizationId:
       description: The unique identifier of an organization
       type: integer

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -209,6 +209,10 @@ components:
               type: string
               format: date-time
               example: '2022-07-04T22:19:11Z'
+            updatedAt:
+              type: string
+              format: date-time
+              example: '2022-07-04T22:19:11Z'
           required:
             - id
     OrganizationsPage:

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -215,6 +215,8 @@ components:
               example: '2022-07-04T22:19:11Z'
           required:
             - id
+            - createdAt
+            - updatedAt
     OrganizationsPage:
       type: object
       description: A page of organizations

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -163,10 +163,17 @@ components:
       required:
         - paging
         - totalResults
+    Email:
+      description: An email address.
+      type: string
+      format: email
+      example: john.smith@example.com
     OrganizationCreateRequest:
       type: object
       description: The information required to create an org account
       properties:
+        email:
+          $ref: '#/components/schemas/Email'
         name:
           type: string
           example: Example organization
@@ -225,11 +232,6 @@ components:
         - status
       x-java-class-annotations:
         - '@lombok.Builder'
-    Email:
-      description: An email address
-      type: string
-      format: email
-      example: john.smith@example.com
     UserCreateRequest:
       type: object
       description: The information required to create a user account

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -205,6 +205,10 @@ components:
           properties:
             id:
               $ref: '#/components/schemas/OrganizationId'
+            createdAt:
+              type: string
+              format: date-time
+              example: '2022-07-04T22:19:11Z'
           required:
             - id
     OrganizationsPage:

--- a/libs/api-spec/build/organization.openapi.yaml
+++ b/libs/api-spec/build/organization.openapi.yaml
@@ -120,6 +120,10 @@ components:
         name:
           type: string
           example: Example organization
+        avatarUrl:
+          type: string
+          format: url
+          example: https://via.placeholder.com/300.png
     OrganizationId:
       description: The unique identifier of an organization
       type: integer

--- a/libs/api-spec/build/organization.openapi.yaml
+++ b/libs/api-spec/build/organization.openapi.yaml
@@ -109,8 +109,7 @@ components:
       properties:
         name:
           type: string
-      example:
-        name: Awesome Org
+          example: Example organization
     OrganizationId:
       description: The unique identifier of an organization
       type: integer
@@ -125,6 +124,8 @@ components:
           properties:
             id:
               $ref: '#/components/schemas/OrganizationId'
+          required:
+            - id
     OrganizationsPage:
       type: object
       description: A page of organizations

--- a/libs/api-spec/build/organization.openapi.yaml
+++ b/libs/api-spec/build/organization.openapi.yaml
@@ -124,7 +124,10 @@ components:
           type: string
           format: url
           example: https://via.placeholder.com/300.png
-          nullable: true
+        websiteUrl:
+          type: string
+          format: url
+          example: https://example.com
     OrganizationId:
       description: The unique identifier of an organization
       type: integer

--- a/libs/api-spec/build/organization.openapi.yaml
+++ b/libs/api-spec/build/organization.openapi.yaml
@@ -155,6 +155,8 @@ components:
               example: '2022-07-04T22:19:11Z'
           required:
             - id
+            - createdAt
+            - updatedAt
     OrganizationsPage:
       type: object
       description: A page of organizations

--- a/libs/api-spec/build/organization.openapi.yaml
+++ b/libs/api-spec/build/organization.openapi.yaml
@@ -145,6 +145,10 @@ components:
           properties:
             id:
               $ref: '#/components/schemas/OrganizationId'
+            createdAt:
+              type: string
+              format: date-time
+              example: '2022-07-04T22:19:11Z'
           required:
             - id
     OrganizationsPage:

--- a/libs/api-spec/build/organization.openapi.yaml
+++ b/libs/api-spec/build/organization.openapi.yaml
@@ -124,6 +124,7 @@ components:
           type: string
           format: url
           example: https://via.placeholder.com/300.png
+          nullable: true
     OrganizationId:
       description: The unique identifier of an organization
       type: integer

--- a/libs/api-spec/build/organization.openapi.yaml
+++ b/libs/api-spec/build/organization.openapi.yaml
@@ -103,10 +103,17 @@ components:
       required:
         - paging
         - totalResults
+    Email:
+      description: An email address.
+      type: string
+      format: email
+      example: john.smith@example.com
     OrganizationCreateRequest:
       type: object
       description: The information required to create an org account
       properties:
+        email:
+          $ref: '#/components/schemas/Email'
         name:
           type: string
           example: Example organization

--- a/libs/api-spec/build/organization.openapi.yaml
+++ b/libs/api-spec/build/organization.openapi.yaml
@@ -149,6 +149,10 @@ components:
               type: string
               format: date-time
               example: '2022-07-04T22:19:11Z'
+            updatedAt:
+              type: string
+              format: date-time
+              example: '2022-07-04T22:19:11Z'
           required:
             - id
     OrganizationsPage:

--- a/libs/api-spec/build/organization.openapi.yaml
+++ b/libs/api-spec/build/organization.openapi.yaml
@@ -128,6 +128,9 @@ components:
           type: string
           format: url
           example: https://example.com
+        description:
+          type: string
+          example: A short description of the organization.
     OrganizationId:
       description: The unique identifier of an organization
       type: integer

--- a/libs/api-spec/build/organization.openapi.yaml
+++ b/libs/api-spec/build/organization.openapi.yaml
@@ -114,6 +114,9 @@ components:
       properties:
         email:
           $ref: '#/components/schemas/Email'
+        login:
+          type: string
+          example: example-organization
         name:
           type: string
           example: Example organization

--- a/libs/api-spec/build/organization.openapi.yaml
+++ b/libs/api-spec/build/organization.openapi.yaml
@@ -124,6 +124,7 @@ components:
           type: string
           format: url
           example: https://via.placeholder.com/300.png
+          nullable: true
         websiteUrl:
           type: string
           format: url

--- a/libs/api-spec/build/organization.openapi.yaml
+++ b/libs/api-spec/build/organization.openapi.yaml
@@ -108,18 +108,51 @@ components:
       type: integer
       format: int64
       example: 1
+    Email:
+      description: An email address
+      type: string
+      format: email
+      example: john.smith@example.com
+    OrganizationCreateRequest:
+      type: object
+      description: The information required to create an org account
+      properties:
+        login:
+          type: string
+        email:
+          $ref: '#/components/schemas/Email'
+        name:
+          type: string
+          nullable: true
+        avatarUrl:
+          type: string
+          format: url
+          example: https://example.com/awesome-avatar.png
+          nullable: true
+        websiteUrl:
+          type: string
+          format: url
+          example: https://example.com
+          nullable: true
+        description:
+          type: string
+          nullable: true
+      required:
+        - login
+        - email
+      example:
+        login: awesome-org
+        email: contact@example.org
+        name: Awesome Org
+        avatarUrl: https://example.com/awesome-avatar.png
+        websiteUrl: https://example.com
+        description: A great organization
     Organization:
       type: object
       description: An organization
-      properties:
-        id:
-          $ref: '#/components/schemas/OrganizationId'
-        name:
-          type: string
-      required:
-        - name
-      example:
-        name: DREAM
+      allOf:
+        - $ref: '#/components/schemas/OrganizationId'
+        - $ref: '#/components/schemas/OrganizationCreateRequest'
     OrganizationsPage:
       type: object
       description: A page of organizations

--- a/libs/api-spec/build/organization.openapi.yaml
+++ b/libs/api-spec/build/organization.openapi.yaml
@@ -103,56 +103,28 @@ components:
       required:
         - paging
         - totalResults
+    OrganizationCreateRequest:
+      type: object
+      description: The information required to create an org account
+      properties:
+        name:
+          type: string
+      example:
+        name: Awesome Org
     OrganizationId:
       description: The unique identifier of an organization
       type: integer
       format: int64
       example: 1
-    Email:
-      description: An email address
-      type: string
-      format: email
-      example: john.smith@example.com
-    OrganizationCreateRequest:
-      type: object
-      description: The information required to create an org account
-      properties:
-        login:
-          type: string
-        email:
-          $ref: '#/components/schemas/Email'
-        name:
-          type: string
-          nullable: true
-        avatarUrl:
-          type: string
-          format: url
-          example: https://example.com/awesome-avatar.png
-          nullable: true
-        websiteUrl:
-          type: string
-          format: url
-          example: https://example.com
-          nullable: true
-        description:
-          type: string
-          nullable: true
-      required:
-        - login
-        - email
-      example:
-        login: awesome-org
-        email: contact@example.org
-        name: Awesome Org
-        avatarUrl: https://example.com/awesome-avatar.png
-        websiteUrl: https://example.com
-        description: A great organization
     Organization:
       type: object
       description: An organization
       allOf:
-        - $ref: '#/components/schemas/OrganizationId'
         - $ref: '#/components/schemas/OrganizationCreateRequest'
+        - type: object
+          properties:
+            id:
+              $ref: '#/components/schemas/OrganizationId'
     OrganizationsPage:
       type: object
       description: A page of organizations

--- a/libs/api-spec/build/organization.openapi.yaml
+++ b/libs/api-spec/build/organization.openapi.yaml
@@ -131,6 +131,8 @@ components:
         description:
           type: string
           example: A short description of the organization.
+      required:
+        - login
     OrganizationId:
       description: The unique identifier of an organization
       type: integer

--- a/libs/api-spec/build/user.openapi.yaml
+++ b/libs/api-spec/build/user.openapi.yaml
@@ -103,7 +103,7 @@ paths:
 components:
   schemas:
     Email:
-      description: An email address
+      description: An email address.
       type: string
       format: email
       example: john.smith@example.com

--- a/libs/api-spec/project.json
+++ b/libs/api-spec/project.json
@@ -35,7 +35,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "lint-openapi --config .validaterc --ruleset .spectral.yaml --verbose build/user.openapi.yaml",
+        "command": "lint-openapi --config .validaterc --ruleset .spectral.yaml --verbose build/openapi.yaml build/organization.openapi.yaml build/user.openapi.yaml",
         "cwd": "libs/api-spec"
       }
     },

--- a/libs/api-spec/src/components/schemas/Email.yaml
+++ b/libs/api-spec/src/components/schemas/Email.yaml
@@ -1,4 +1,4 @@
-description: An email address
+description: An email address.
 type: string
 format: email
 example: john.smith@example.com

--- a/libs/api-spec/src/components/schemas/Organization.yaml
+++ b/libs/api-spec/src/components/schemas/Organization.yaml
@@ -1,8 +1,12 @@
 type: object
 description: An organization
 allOf:
-  - $ref: OrganizationId.yaml
+  # - $ref: OrganizationId.yaml
   - $ref: OrganizationCreateRequest.yaml
+  - type: object
+    properties:
+      id:
+        $ref: OrganizationId.yaml
 # properties:
 #   id:
 #     $ref: OrganizationId.yaml

--- a/libs/api-spec/src/components/schemas/Organization.yaml
+++ b/libs/api-spec/src/components/schemas/Organization.yaml
@@ -7,6 +7,10 @@ allOf:
     properties:
       id:
         $ref: OrganizationId.yaml
+      createdAt:
+        type: string
+        format: date-time
+        example: '2022-07-04T22:19:11Z'
     required:
       - id
 # properties:

--- a/libs/api-spec/src/components/schemas/Organization.yaml
+++ b/libs/api-spec/src/components/schemas/Organization.yaml
@@ -11,6 +11,10 @@ allOf:
         type: string
         format: date-time
         example: '2022-07-04T22:19:11Z'
+      updatedAt:
+        type: string
+        format: date-time
+        example: '2022-07-04T22:19:11Z'
     required:
       - id
 # properties:

--- a/libs/api-spec/src/components/schemas/Organization.yaml
+++ b/libs/api-spec/src/components/schemas/Organization.yaml
@@ -7,6 +7,8 @@ allOf:
     properties:
       id:
         $ref: OrganizationId.yaml
+    required:
+      - id
 # properties:
 #   id:
 #     $ref: OrganizationId.yaml

--- a/libs/api-spec/src/components/schemas/Organization.yaml
+++ b/libs/api-spec/src/components/schemas/Organization.yaml
@@ -17,34 +17,5 @@ allOf:
         example: '2022-07-04T22:19:11Z'
     required:
       - id
-# properties:
-#   id:
-#     $ref: OrganizationId.yaml
-#   name:
-#     type: string
-# required:
-#   - name
-# example:
-#   name: DREAM
-# allOf:
-#   - $ref: OrganizationCreateResponse.yaml
-#   - $ref: OrganizationCreateRequest.yaml
-#   - type: object
-#     properties:
-#       createdAt:
-#         type: string
-#         format: date-time
-#       updatedAt:
-#         type: string
-#         format: date-time
-#       type:
-#         type: string
-#         example: Organization
-#     required:
-#       - createdAt
-#       - updatedAt
-#       - type
-#     example:
-#       createdAt: '2017-07-08T16:18:44-04:00'
-#       updatedAt: '2017-07-08T16:18:44-04:00'
-#       type: Organization
+      - createdAt
+      - updatedAt

--- a/libs/api-spec/src/components/schemas/Organization.yaml
+++ b/libs/api-spec/src/components/schemas/Organization.yaml
@@ -1,14 +1,17 @@
 type: object
 description: An organization
-properties:
-  id:
-    $ref: OrganizationId.yaml
-  name:
-    type: string
-required:
-  - name
-example:
-  name: DREAM
+allOf:
+  - $ref: OrganizationId.yaml
+  - $ref: OrganizationCreateRequest.yaml
+# properties:
+#   id:
+#     $ref: OrganizationId.yaml
+#   name:
+#     type: string
+# required:
+#   - name
+# example:
+#   name: DREAM
 # allOf:
 #   - $ref: OrganizationCreateResponse.yaml
 #   - $ref: OrganizationCreateRequest.yaml

--- a/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
+++ b/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
@@ -9,11 +9,11 @@ properties:
   name:
     type: string
     example: Example organization
-  # avatarUrl:
-  #   type: string
-  #   format: url
-  #   example: https://example.com/awesome-avatar.png
-  #   nullable: true
+  avatarUrl:
+    type: string
+    format: url
+    example: https://via.placeholder.com/300.png
+    # nullable: true
   # websiteUrl:
   #   type: string
   #   format: url

--- a/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
+++ b/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
@@ -1,33 +1,33 @@
 type: object
 description: The information required to create an org account
 properties:
-  login:
-    type: string
-  email:
-    $ref: Email.yaml
+  # login:
+  #   type: string
+  # email:
+  #   $ref: Email.yaml
   name:
     type: string
     nullable: true
-  avatarUrl:
-    type: string
-    format: url
-    example: https://example.com/awesome-avatar.png
-    nullable: true
-  websiteUrl:
-    type: string
-    format: url
-    example: https://example.com
-    nullable: true
-  description:
-    type: string
-    nullable: true
-required:
-  - login
-  - email
+  # avatarUrl:
+  #   type: string
+  #   format: url
+  #   example: https://example.com/awesome-avatar.png
+  #   nullable: true
+  # websiteUrl:
+  #   type: string
+  #   format: url
+  #   example: https://example.com
+  #   nullable: true
+  # description:
+  #   type: string
+  #   nullable: true
+# required:
+#   - login
+#   - email
 example:
-  login: awesome-org
-  email: contact@example.org
+  # login: awesome-org
+  # email: contact@example.org
   name: Awesome Org
-  avatarUrl: https://example.com/awesome-avatar.png
-  websiteUrl: https://example.com
-  description: A great organization
+  # avatarUrl: https://example.com/awesome-avatar.png
+  # websiteUrl: https://example.com
+  # description: A great organization

--- a/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
+++ b/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
@@ -3,8 +3,8 @@ description: The information required to create an org account
 properties:
   # login:
   #   type: string
-  # email:
-  #   $ref: Email.yaml
+  email:
+    $ref: Email.yaml
   name:
     type: string
     example: Example organization

--- a/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
+++ b/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
@@ -7,6 +7,7 @@ properties:
   #   $ref: Email.yaml
   name:
     type: string
+    example: Example organization
   # avatarUrl:
   #   type: string
   #   format: url
@@ -23,10 +24,10 @@ properties:
 # required:
 #   - login
 #   - email
-example:
-  # login: awesome-org
-  # email: contact@example.org
-  name: Awesome Org
-  # avatarUrl: https://example.com/awesome-avatar.png
-  # websiteUrl: https://example.com
-  # description: A great organization
+# example:
+# login: awesome-org
+# email: contact@example.org
+# name: Awesome Org
+# avatarUrl: https://example.com/awesome-avatar.png
+# websiteUrl: https://example.com
+# description: A great organization

--- a/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
+++ b/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
@@ -7,7 +7,6 @@ properties:
   #   $ref: Email.yaml
   name:
     type: string
-    nullable: true
   # avatarUrl:
   #   type: string
   #   format: url

--- a/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
+++ b/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
@@ -13,7 +13,7 @@ properties:
     type: string
     format: url
     example: https://via.placeholder.com/300.png
-    # nullable: true
+    nullable: true
   # websiteUrl:
   #   type: string
   #   format: url

--- a/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
+++ b/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
@@ -1,10 +1,11 @@
 type: object
 description: The information required to create an org account
 properties:
-  # login:
-  #   type: string
   email:
     $ref: Email.yaml
+  login:
+    type: string
+    example: example-organization
   name:
     type: string
     example: Example organization

--- a/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
+++ b/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
@@ -20,3 +20,5 @@ properties:
   description:
     type: string
     example: A short description of the organization.
+required:
+  - login

--- a/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
+++ b/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
@@ -17,16 +17,6 @@ properties:
     type: string
     format: url
     example: https://example.com
-  # description:
-  #   type: string
-  #   nullable: true
-# required:
-#   - login
-#   - email
-# example:
-# login: awesome-org
-# email: contact@example.org
-# name: Awesome Org
-# avatarUrl: https://example.com/awesome-avatar.png
-# websiteUrl: https://example.com
-# description: A great organization
+  description:
+    type: string
+    example: A short description of the organization.

--- a/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
+++ b/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
@@ -13,6 +13,7 @@ properties:
     type: string
     format: url
     example: https://via.placeholder.com/300.png
+    nullable: true
   websiteUrl:
     type: string
     format: url

--- a/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
+++ b/libs/api-spec/src/components/schemas/OrganizationCreateRequest.yaml
@@ -13,12 +13,10 @@ properties:
     type: string
     format: url
     example: https://via.placeholder.com/300.png
-    nullable: true
-  # websiteUrl:
-  #   type: string
-  #   format: url
-  #   example: https://example.com
-  #   nullable: true
+  websiteUrl:
+    type: string
+    format: url
+    example: https://example.com
   # description:
   #   type: string
   #   nullable: true

--- a/libs/challenge-registry/challenge/src/lib/challenge-details/challenge-details.component.ts
+++ b/libs/challenge-registry/challenge/src/lib/challenge-details/challenge-details.component.ts
@@ -2,8 +2,9 @@ import { Component, Input } from '@angular/core';
 import {
   Challenge,
   // ChallengePlatform,
-  Organization,
+  // Organization,
 } from '@sagebionetworks/api-client-angular-deprecated';
+import { Organization } from '@sagebionetworks/api-client-angular';
 import { MOCK_ORGANIZATIONS } from '@sagebionetworks/challenge-registry/ui';
 
 @Component({

--- a/libs/challenge-registry/challenge/src/lib/challenge-overview/challenge-overview.component.ts
+++ b/libs/challenge-registry/challenge/src/lib/challenge-overview/challenge-overview.component.ts
@@ -1,8 +1,6 @@
 import { Component, Input } from '@angular/core';
-import {
-  Challenge,
-  Organization,
-} from '@sagebionetworks/api-client-angular-deprecated';
+import { Challenge } from '@sagebionetworks/api-client-angular-deprecated';
+import { Organization } from '@sagebionetworks/api-client-angular';
 import { MOCK_ORGANIZATIONS } from '@sagebionetworks/challenge-registry/ui';
 
 @Component({

--- a/libs/challenge-registry/org-profile/src/lib/org-profile-challenges/org-profile-challenges.component.ts
+++ b/libs/challenge-registry/org-profile/src/lib/org-profile-challenges/org-profile-challenges.component.ts
@@ -1,9 +1,9 @@
 import { Component, Input } from '@angular/core';
 import {
   Challenge,
-  Organization,
   UserService,
 } from '@sagebionetworks/api-client-angular-deprecated';
+import { Organization } from '@sagebionetworks/api-client-angular';
 import { MOCK_CHALLENGES } from '@sagebionetworks/challenge-registry/ui';
 // import { map, Observable } from 'rxjs';
 

--- a/libs/challenge-registry/org-profile/src/lib/org-profile-members/org-profile-members.component.ts
+++ b/libs/challenge-registry/org-profile/src/lib/org-profile-members/org-profile-members.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { Organization } from '@sagebionetworks/api-client-angular-deprecated';
+import { Organization } from '@sagebionetworks/api-client-angular';
 import { MOCK_ORG_MEMBERS } from '@sagebionetworks/challenge-registry/ui';
 
 @Component({

--- a/libs/challenge-registry/org-profile/src/lib/org-profile-overview/org-profile-overview.component.ts
+++ b/libs/challenge-registry/org-profile/src/lib/org-profile-overview/org-profile-overview.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { Organization } from '@sagebionetworks/api-client-angular-deprecated';
+import { Organization } from '@sagebionetworks/api-client-angular';
 import { MOCK_ORGANIZATIONS } from '@sagebionetworks/challenge-registry/ui';
 
 @Component({

--- a/libs/challenge-registry/org-profile/src/lib/org-profile.component.ts
+++ b/libs/challenge-registry/org-profile/src/lib/org-profile.component.ts
@@ -1,9 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
-import {
-  Account,
-  Organization,
-} from '@sagebionetworks/api-client-angular-deprecated';
+import { Account } from '@sagebionetworks/api-client-angular-deprecated';
 import { map, Observable, of, Subscription } from 'rxjs';
 import { Tab } from './tab.model';
 import { ORG_PROFILE_TABS } from './org-profile-tabs';
@@ -13,6 +10,7 @@ import {
 } from '@sagebionetworks/challenge-registry/ui';
 import { ConfigService } from '@sagebionetworks/challenge-registry/config';
 import {
+  Organization,
   OrganizationService,
   OrganizationsPage,
 } from '@sagebionetworks/api-client-angular';

--- a/libs/challenge-registry/org-profile/src/lib/org-profile.component.ts
+++ b/libs/challenge-registry/org-profile/src/lib/org-profile.component.ts
@@ -30,6 +30,7 @@ export class OrgProfileComponent implements OnInit {
   tabKeys: string[] = Object.keys(this.tabs);
   activeTab: Tab = this.tabs['overview'];
   private subscriptions: Subscription[] = [];
+  // private useLocalOrganizationMock = true;
 
   constructor(
     private activatedRoute: ActivatedRoute,

--- a/libs/challenge-registry/ui/src/lib/organization-card/mock-organizations.ts
+++ b/libs/challenge-registry/ui/src/lib/organization-card/mock-organizations.ts
@@ -1,8 +1,8 @@
-import { Organization } from '@sagebionetworks/api-client-angular-deprecated';
+import { Organization } from '@sagebionetworks/api-client-angular';
 
 export const MOCK_ORGANIZATIONS: Organization[] = [
   {
-    id: '613931b5ae0267da3f0275c7',
+    id: 1,
     name: 'Awesome Org',
     description: 'This is an awesome organization',
     email: 'contact@example.org',
@@ -11,6 +11,5 @@ export const MOCK_ORGANIZATIONS: Organization[] = [
     avatarUrl: '',
     createdAt: '',
     updatedAt: '',
-    type: '',
   },
 ];

--- a/libs/challenge-registry/ui/src/lib/organization-card/organization-card.component.spec.ts
+++ b/libs/challenge-registry/ui/src/lib/organization-card/organization-card.component.spec.ts
@@ -52,7 +52,7 @@ describe('OrganizationCardComponent', () => {
   });
 
   it('login property of org should be used for orgAvatar name', () => {
-    component.organization.name = null;
+    component.organization.name = '';
     fixture.detectChanges();
     expect(component.organizationAvatar).toEqual({
       name: MOCK_ORGANIZATIONS[0].login.replace(/-/g, ' '),

--- a/libs/challenge-registry/ui/src/lib/organization-card/organization-card.component.ts
+++ b/libs/challenge-registry/ui/src/lib/organization-card/organization-card.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { Organization } from '@sagebionetworks/api-client-angular-deprecated';
+import { Organization } from '@sagebionetworks/api-client-angular';
 import { Avatar } from '../avatar/avatar';
 
 @Component({

--- a/libs/challenge-registry/user-profile/src/lib/user-profile-overview/user-profile-overview.component.ts
+++ b/libs/challenge-registry/user-profile/src/lib/user-profile-overview/user-profile-overview.component.ts
@@ -1,8 +1,6 @@
 import { Component, Input } from '@angular/core';
-import {
-  Organization,
-  User,
-} from '@sagebionetworks/api-client-angular-deprecated';
+import { User } from '@sagebionetworks/api-client-angular-deprecated';
+import { Organization } from '@sagebionetworks/api-client-angular';
 import { MOCK_ORGANIZATIONS } from '@sagebionetworks/challenge-registry/ui';
 
 @Component({

--- a/libs/challenge-registry/user-profile/src/lib/user-profile-starred/user-profile-starred.component.ts
+++ b/libs/challenge-registry/user-profile/src/lib/user-profile-starred/user-profile-starred.component.ts
@@ -2,9 +2,9 @@ import { Component, Input, OnInit } from '@angular/core';
 // import { Challenge, Organization, User } from '@sagebionetworks/api-angular';
 import {
   Challenge,
-  Organization,
   User,
 } from '@sagebionetworks/api-client-angular-deprecated';
+import { Organization } from '@sagebionetworks/api-client-angular';
 import { Tab } from '../tab.model';
 import { USER_PROFILE_STARRED_TABS } from './user-profile-starred-tabs';
 import {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@typescript-eslint/eslint-plugin": "5.40.0",
     "@typescript-eslint/parser": "5.40.0",
     "babel-jest": "29.1.2",
+    "canvas": "^2.10.2",
     "colors": "1.4.0",
     "coveralls": "3.1.1",
     "cypress": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11366,6 +11366,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"canvas@npm:^2.10.2":
+  version: 2.10.2
+  resolution: "canvas@npm:2.10.2"
+  dependencies:
+    "@mapbox/node-pre-gyp": ^1.0.0
+    nan: ^2.17.0
+    node-gyp: latest
+    simple-get: ^3.0.3
+  checksum: b2e3eb4c3635fa2f67857619621c3d314f935a9e51904536dadf4908ab580dff4f5bcbaafe6eb0255247fa027ca494d5cd97c33376a49a0f994997263fa9944b
+  languageName: node
+  linkType: hard
+
 "canvas@npm:^2.9.1":
   version: 2.10.1
   resolution: "canvas@npm:2.10.1"
@@ -11506,6 +11518,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": 5.40.0
     "@typescript-eslint/parser": 5.40.0
     babel-jest: 29.1.2
+    canvas: ^2.10.2
     colors: 1.4.0
     commander: 9.4.1
     core-js: 3.25.5
@@ -21354,6 +21367,15 @@ __metadata:
   dependencies:
     node-gyp: latest
   checksum: cb16937273ea55b01ea47df244094c12297ce6b29b36e845d349f1f7c268b8d7c5abd126a102c5678a1e1afd0d36bba35ea0cc959e364928ce60561c9306064a
+  languageName: node
+  linkType: hard
+
+"nan@npm:^2.17.0":
+  version: 2.17.0
+  resolution: "nan@npm:2.17.0"
+  dependencies:
+    node-gyp: latest
+  checksum: ec609aeaf7e68b76592a3ba96b372aa7f5df5b056c1e37410b0f1deefbab5a57a922061e2c5b369bae9c7c6b5e6eecf4ad2dac8833a1a7d3a751e0a7c7f849ed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #990

## Changelog

- Add all the legacy properties back to the new Organization model, with the exception of `type` (account type) that is no longer needed to distinguish user from organization account (basically there is no longer such thing as an org account).
- Update the OpenAPI (OA) description of the Organization service.
- Update the Organization service (server).
- Update the project `api-client-angular`.
- The challenge registry is now using the new Organization model everywhere.

## Preview

1. Start the challenge registry: `nx serve challenge-registry`
2. Go to the page http://localhost:4200/org/awesome-org
3. Look at the browser console to see the first page of organizations (demo)

## Next

- Create a method to get an organization by its login, which is required to the Organization object on an organization profile page (`/org/{orgLogin}`). This work will be done in another PR.