### PR TITLE
feat: Enable to filter list of challenges returned by the Challenge service by status

### DIFF
--- a/apps/challenge-service/.openapi-generator-ignore
+++ b/apps/challenge-service/.openapi-generator-ignore
@@ -26,3 +26,6 @@ README.md
 **/application.properties
 **/model/dto/*AllOf*.java
 **/OpenApiGeneratorApplication.java
+
+# The template of this file has a bug: the Dto suffix is not included
+**/EnumConverterConfiguration.java

--- a/apps/challenge-service/.openapi-generator/FILES
+++ b/apps/challenge-service/.openapi-generator/FILES
@@ -4,11 +4,13 @@ src/main/java/org/sagebionetworks/challenge/api/ApiUtil.java
 src/main/java/org/sagebionetworks/challenge/api/ChallengeApi.java
 src/main/java/org/sagebionetworks/challenge/api/ChallengeApiController.java
 src/main/java/org/sagebionetworks/challenge/api/ChallengeApiDelegate.java
+src/main/java/org/sagebionetworks/challenge/configuration/EnumConverterConfiguration.java
 src/main/java/org/sagebionetworks/challenge/configuration/HomeController.java
 src/main/java/org/sagebionetworks/challenge/configuration/SpringDocConfiguration.java
 src/main/java/org/sagebionetworks/challenge/model/dto/BasicErrorDto.java
 src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeCreateRequestDto.java
 src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeDto.java
+src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeStatusDto.java
 src/main/java/org/sagebionetworks/challenge/model/dto/ChallengesPageDto.java
 src/main/java/org/sagebionetworks/challenge/model/dto/PageMetadataDto.java
 src/main/resources/openapi.yaml

--- a/apps/challenge-service/build.gradle
+++ b/apps/challenge-service/build.gradle
@@ -22,6 +22,14 @@ configurations {
 	}
 }
 
+sourceSets {
+  main {
+    java {
+      srcDirs = ['src/main/java', 'build/generated/sources/annotationProcessor/java/main']
+    }
+  }
+}
+
 repositories {
   mavenCentral()
   mavenLocal()

--- a/apps/challenge-service/build.gradle
+++ b/apps/challenge-service/build.gradle
@@ -13,6 +13,13 @@ plugins {
   id 'org.springframework.boot' version "${springBootVersion}"
   id "io.spring.dependency-management" version "${springDependencyManagementVersion}"
   id "org.flywaydb.flyway" version "${flywaydbVersion}"
+  id 'java-library' // QueryDSL must have
+}
+
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
 }
 
 repositories {
@@ -21,7 +28,13 @@ repositories {
 }
 
 dependencies {
+  api 'com.querydsl:querydsl-jpa:5.0.0' // QueryDSL must have
+
   annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+  annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jpa' // QueryDSL must have (exactly this way, including :jpa)
+  annotationProcessor 'javax.annotation:javax.annotation-api' // QueryDSL must have
+  annotationProcessor 'javax.persistence:javax.persistence-api' // QueryDSL must have
+
   compileOnly "org.projectlombok:lombok:${lombokVersion}"
   implementation 'com.google.code.findbugs:jsr305:3.0.2'
   implementation 'org.openapitools:jackson-databind-nullable:0.2.3'
@@ -34,7 +47,10 @@ dependencies {
   implementation "org.keycloak:keycloak-admin-client:${keycloakVersion}"
   implementation "org.keycloak:keycloak-spring-boot-starter:${keycloakVersion}"
   implementation "org.sagebionetworks.challenge:challenge-util:${challengeVersion}"
+
   implementation "org.springframework.boot:spring-boot-devtools:${springBootVersion}"
+  // developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
   implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
   implementation "org.springframework.boot:spring-boot-starter-data-jpa:${springBootVersion}"
   implementation "org.springframework.boot:spring-boot-starter-security:${springBootVersion}"

--- a/apps/challenge-service/gradle.properties
+++ b/apps/challenge-service/gradle.properties
@@ -3,6 +3,7 @@ fasterxmlVersion=2.13.4
 flywaydbVersion=9.4.0
 keycloakVersion=19.0.3
 lombokVersion=1.18.24
+queryDslVersion=4.4.0
 spotlessVersion=6.11.0
 springBootVersion=2.7.4
 springCloudVersion=3.1.4

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/api/ChallengeApi.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/api/ChallengeApi.java
@@ -10,10 +10,12 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import javax.annotation.Generated;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 import org.sagebionetworks.challenge.model.dto.BasicErrorDto;
+import org.sagebionetworks.challenge.model.dto.ChallengeStatusDto;
 import org.sagebionetworks.challenge.model.dto.ChallengesPageDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -33,6 +35,7 @@ public interface ChallengeApi {
    *
    * @param pageNumber The page number (optional, default to 0)
    * @param pageSize The number of items in a single page (optional, default to 100)
+   * @param status Array of challenge status used to filter the results. (optional)
    * @return Success (status code 200) or Invalid request (status code 400) or The request cannot be
    *     fulfilled due to an unexpected server error (status code 500)
    */
@@ -89,7 +92,13 @@ public interface ChallengeApi {
           @Parameter(name = "pageSize", description = "The number of items in a single page")
           @Valid
           @RequestParam(value = "pageSize", required = false, defaultValue = "100")
-          Integer pageSize) {
-    return getDelegate().listChallenges(pageNumber, pageSize);
+          Integer pageSize,
+      @Parameter(
+              name = "status",
+              description = "Array of challenge status used to filter the results.")
+          @Valid
+          @RequestParam(value = "status", required = false)
+          List<ChallengeStatusDto> status) {
+    return getDelegate().listChallenges(pageNumber, pageSize, status);
   }
 }

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/api/ChallengeApiDelegate.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/api/ChallengeApiDelegate.java
@@ -1,7 +1,9 @@
 package org.sagebionetworks.challenge.api;
 
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Generated;
+import org.sagebionetworks.challenge.model.dto.ChallengeStatusDto;
 import org.sagebionetworks.challenge.model.dto.ChallengesPageDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -24,11 +26,13 @@ public interface ChallengeApiDelegate {
    *
    * @param pageNumber The page number (optional, default to 0)
    * @param pageSize The number of items in a single page (optional, default to 100)
+   * @param status Array of challenge status used to filter the results. (optional)
    * @return Success (status code 200) or Invalid request (status code 400) or The request cannot be
    *     fulfilled due to an unexpected server error (status code 500)
    * @see ChallengeApi#listChallenges
    */
-  default ResponseEntity<ChallengesPageDto> listChallenges(Integer pageNumber, Integer pageSize) {
+  default ResponseEntity<ChallengesPageDto> listChallenges(
+      Integer pageNumber, Integer pageSize, List<ChallengeStatusDto> status) {
     getRequest()
         .ifPresent(
             request -> {

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/api/ChallengeApiDelegateImpl.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/api/ChallengeApiDelegateImpl.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.challenge.api;
 
+import java.util.List;
+import org.sagebionetworks.challenge.model.dto.ChallengeStatusDto;
 import org.sagebionetworks.challenge.model.dto.ChallengesPageDto;
 import org.sagebionetworks.challenge.service.ChallengeService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,8 +14,9 @@ public class ChallengeApiDelegateImpl implements ChallengeApiDelegate {
   @Autowired ChallengeService challengeService;
 
   @Override
-  public ResponseEntity<ChallengesPageDto> listChallenges(Integer pageNumber, Integer pageSize) {
-    return ResponseEntity.ok(challengeService.listChallenges(pageNumber, pageSize));
+  public ResponseEntity<ChallengesPageDto> listChallenges(
+      Integer pageNumber, Integer pageSize, List<ChallengeStatusDto> status) {
+    return ResponseEntity.ok(challengeService.listChallenges(pageNumber, pageSize, status));
   }
 
   // @Override

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/configuration/EnumConverterConfiguration.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/configuration/EnumConverterConfiguration.java
@@ -1,0 +1,20 @@
+package org.sagebionetworks.challenge.configuration;
+
+import org.sagebionetworks.challenge.model.dto.ChallengeStatusDto;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+
+@Configuration
+public class EnumConverterConfiguration {
+
+  @Bean
+  Converter<String, ChallengeStatusDto> challengeStatusConverter() {
+    return new Converter<String, ChallengeStatusDto>() {
+      @Override
+      public ChallengeStatusDto convert(String source) {
+        return ChallengeStatusDto.fromValue(source);
+      }
+    };
+  }
+}

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeCreateRequestDto.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeCreateRequestDto.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.*;
 import java.util.Objects;
 import javax.annotation.Generated;
+import javax.validation.Valid;
 import javax.validation.constraints.*;
 
 /** The information used to create a challenge */
@@ -17,6 +18,9 @@ public class ChallengeCreateRequestDto {
 
   @JsonProperty("name")
   private String name;
+
+  @JsonProperty("status")
+  private ChallengeStatusDto status;
 
   public ChallengeCreateRequestDto name(String name) {
     this.name = name;
@@ -39,6 +43,27 @@ public class ChallengeCreateRequestDto {
     this.name = name;
   }
 
+  public ChallengeCreateRequestDto status(ChallengeStatusDto status) {
+    this.status = status;
+    return this;
+  }
+
+  /**
+   * Get status
+   *
+   * @return status
+   */
+  @NotNull
+  @Valid
+  @Schema(name = "status", required = true)
+  public ChallengeStatusDto getStatus() {
+    return status;
+  }
+
+  public void setStatus(ChallengeStatusDto status) {
+    this.status = status;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -48,12 +73,13 @@ public class ChallengeCreateRequestDto {
       return false;
     }
     ChallengeCreateRequestDto challengeCreateRequest = (ChallengeCreateRequestDto) o;
-    return Objects.equals(this.name, challengeCreateRequest.name);
+    return Objects.equals(this.name, challengeCreateRequest.name)
+        && Objects.equals(this.status, challengeCreateRequest.status);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(name, status);
   }
 
   @Override
@@ -61,6 +87,7 @@ public class ChallengeCreateRequestDto {
     StringBuilder sb = new StringBuilder();
     sb.append("class ChallengeCreateRequestDto {\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeDto.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeDto.java
@@ -21,6 +21,9 @@ public class ChallengeDto {
   @JsonProperty("name")
   private String name;
 
+  @JsonProperty("status")
+  private ChallengeStatusDto status;
+
   @JsonProperty("id")
   private Long id;
 
@@ -51,6 +54,27 @@ public class ChallengeDto {
 
   public void setName(String name) {
     this.name = name;
+  }
+
+  public ChallengeDto status(ChallengeStatusDto status) {
+    this.status = status;
+    return this;
+  }
+
+  /**
+   * Get status
+   *
+   * @return status
+   */
+  @NotNull
+  @Valid
+  @Schema(name = "status", required = true)
+  public ChallengeStatusDto getStatus() {
+    return status;
+  }
+
+  public void setStatus(ChallengeStatusDto status) {
+    this.status = status;
   }
 
   public ChallengeDto id(Long id) {
@@ -129,6 +153,7 @@ public class ChallengeDto {
     }
     ChallengeDto challenge = (ChallengeDto) o;
     return Objects.equals(this.name, challenge.name)
+        && Objects.equals(this.status, challenge.status)
         && Objects.equals(this.id, challenge.id)
         && Objects.equals(this.createdAt, challenge.createdAt)
         && Objects.equals(this.updatedAt, challenge.updatedAt);
@@ -136,7 +161,7 @@ public class ChallengeDto {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, id, createdAt, updatedAt);
+    return Objects.hash(name, status, id, createdAt, updatedAt);
   }
 
   @Override
@@ -144,6 +169,7 @@ public class ChallengeDto {
     StringBuilder sb = new StringBuilder();
     sb.append("class ChallengeDto {\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeStatusDto.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeStatusDto.java
@@ -1,0 +1,43 @@
+package org.sagebionetworks.challenge.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.*;
+import javax.annotation.Generated;
+import javax.validation.constraints.*;
+
+/** The status of the challenge. */
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum ChallengeStatusDto {
+  UPCOMING("upcoming"),
+
+  ACTIVE("active"),
+
+  COMPLETED("completed");
+
+  private String value;
+
+  ChallengeStatusDto(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static ChallengeStatusDto fromValue(String value) {
+    for (ChallengeStatusDto b : ChallengeStatusDto.values()) {
+      if (b.value.equals(value)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+}

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/ChallengeEntity.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/ChallengeEntity.java
@@ -29,6 +29,9 @@ public class ChallengeEntity {
   @Column(nullable = false)
   private String name;
 
+  @Column(nullable = false)
+  private String status;
+
   // @Column(nullable = false)
   // private String email;
 

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/mapper/ChallengeMapper.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/mapper/ChallengeMapper.java
@@ -1,13 +1,17 @@
 package org.sagebionetworks.challenge.model.mapper;
 
+import lombok.extern.slf4j.Slf4j;
 import org.sagebionetworks.challenge.model.dto.ChallengeDto;
+import org.sagebionetworks.challenge.model.dto.ChallengeStatusDto;
 import org.sagebionetworks.challenge.model.entity.ChallengeEntity;
 import org.sagebionetworks.challenge.util.model.mapper.BaseMapper;
 import org.springframework.beans.BeanUtils;
 
+@Slf4j
 public class ChallengeMapper extends BaseMapper<ChallengeEntity, ChallengeDto> {
   @Override
   public ChallengeEntity convertToEntity(ChallengeDto dto, Object... args) {
+    log.info("DTO to Entity");
     ChallengeEntity ChallengeEntity = new ChallengeEntity();
     if (dto != null) {
       BeanUtils.copyProperties(dto, ChallengeEntity);
@@ -17,9 +21,11 @@ public class ChallengeMapper extends BaseMapper<ChallengeEntity, ChallengeDto> {
 
   @Override
   public ChallengeDto convertToDto(ChallengeEntity entity, Object... args) {
+    log.info("Entity to DTO");
     ChallengeDto user = new ChallengeDto();
     if (entity != null) {
       BeanUtils.copyProperties(entity, user);
+      user.setStatus(ChallengeStatusDto.fromValue(entity.getStatus()));
     }
     return user;
   }

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/mapper/ChallengeMapper.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/mapper/ChallengeMapper.java
@@ -1,17 +1,14 @@
 package org.sagebionetworks.challenge.model.mapper;
 
-import lombok.extern.slf4j.Slf4j;
 import org.sagebionetworks.challenge.model.dto.ChallengeDto;
 import org.sagebionetworks.challenge.model.dto.ChallengeStatusDto;
 import org.sagebionetworks.challenge.model.entity.ChallengeEntity;
 import org.sagebionetworks.challenge.util.model.mapper.BaseMapper;
 import org.springframework.beans.BeanUtils;
 
-@Slf4j
 public class ChallengeMapper extends BaseMapper<ChallengeEntity, ChallengeDto> {
   @Override
   public ChallengeEntity convertToEntity(ChallengeDto dto, Object... args) {
-    log.info("DTO to Entity");
     ChallengeEntity ChallengeEntity = new ChallengeEntity();
     if (dto != null) {
       BeanUtils.copyProperties(dto, ChallengeEntity);
@@ -21,7 +18,6 @@ public class ChallengeMapper extends BaseMapper<ChallengeEntity, ChallengeDto> {
 
   @Override
   public ChallengeDto convertToDto(ChallengeEntity entity, Object... args) {
-    log.info("Entity to DTO");
     ChallengeDto user = new ChallengeDto();
     if (entity != null) {
       BeanUtils.copyProperties(entity, user);

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepository.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepository.java
@@ -2,8 +2,10 @@ package org.sagebionetworks.challenge.model.repository;
 
 import org.sagebionetworks.challenge.model.entity.ChallengeEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
-public interface ChallengeRepository extends JpaRepository<ChallengeEntity, Long> {
+public interface ChallengeRepository
+    extends JpaRepository<ChallengeEntity, Long>, QuerydslPredicateExecutor<ChallengeEntity> {
 
   // Optional<ChallengeEntity> findByLogin(String login);
 }

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/service/ChallengeService.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/service/ChallengeService.java
@@ -1,7 +1,9 @@
 package org.sagebionetworks.challenge.service;
 
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.sagebionetworks.challenge.model.dto.ChallengeDto;
+import org.sagebionetworks.challenge.model.dto.ChallengeStatusDto;
 import org.sagebionetworks.challenge.model.dto.ChallengesPageDto;
 import org.sagebionetworks.challenge.model.entity.ChallengeEntity;
 import org.sagebionetworks.challenge.model.mapper.ChallengeMapper;
@@ -12,6 +14,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 public class ChallengeService {
 
@@ -20,7 +23,9 @@ public class ChallengeService {
   private ChallengeMapper challengeMapper = new ChallengeMapper();
 
   @Transactional(readOnly = true)
-  public ChallengesPageDto listChallenges(Integer pageNumber, Integer pageSize) {
+  public ChallengesPageDto listChallenges(
+      Integer pageNumber, Integer pageSize, List<ChallengeStatusDto> status) {
+    log.info("status {}", status);
     Page<ChallengeEntity> challengeEntitiesPage =
         challengeRepository.findAll(PageRequest.of(pageNumber, pageSize));
     List<ChallengeDto> challenges =

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/service/ChallengeService.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/service/ChallengeService.java
@@ -1,11 +1,13 @@
 package org.sagebionetworks.challenge.service;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.sagebionetworks.challenge.model.dto.ChallengeDto;
 import org.sagebionetworks.challenge.model.dto.ChallengeStatusDto;
 import org.sagebionetworks.challenge.model.dto.ChallengesPageDto;
 import org.sagebionetworks.challenge.model.entity.ChallengeEntity;
+import org.sagebionetworks.challenge.model.entity.QChallengeEntity;
 import org.sagebionetworks.challenge.model.mapper.ChallengeMapper;
 import org.sagebionetworks.challenge.model.repository.ChallengeRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,11 +27,17 @@ public class ChallengeService {
   @Transactional(readOnly = true)
   public ChallengesPageDto listChallenges(
       Integer pageNumber, Integer pageSize, List<ChallengeStatusDto> status) {
+
     log.info("status {}", status);
+    QChallengeEntity qChallenge = QChallengeEntity.challengeEntity;
+    BooleanExpression q = qChallenge.status.in(status.stream().map(s -> s.toString()).toList());
+
     Page<ChallengeEntity> challengeEntitiesPage =
-        challengeRepository.findAll(PageRequest.of(pageNumber, pageSize));
+        challengeRepository.findAll(q, PageRequest.of(pageNumber, pageSize));
+
     List<ChallengeDto> challenges =
         challengeMapper.convertToDtoList(challengeEntitiesPage.getContent());
+
     return ChallengesPageDto.builder()
         .challenges(challenges)
         .number(challengeEntitiesPage.getNumber())

--- a/apps/challenge-service/src/main/resources/db/migration/V1.0.0__create_challenge_table.sql
+++ b/apps/challenge-service/src/main/resources/db/migration/V1.0.0__create_challenge_table.sql
@@ -4,6 +4,7 @@ CREATE TABLE `challenge`
 (
     `id`                    bigint(20) NOT NULL AUTO_INCREMENT,
     `name`                  varchar(255) DEFAULT NULL,
+    `status`                ENUM('upcoming', 'active', 'completed'),
     -- `email`                 varchar(255) DEFAULT NULL,
     -- `login`                 varchar(255) UNIQUE,
     -- `avatar_url`            varchar(255) DEFAULT NULL,

--- a/apps/challenge-service/src/main/resources/db/migration/V1.0.1__temp_data.sql
+++ b/apps/challenge-service/src/main/resources/db/migration/V1.0.1__temp_data.sql
@@ -1,7 +1,12 @@
-INSERT INTO challenge (id, name)
+INSERT INTO challenge (id, name, status)
 VALUES (
     '1',
-    'The Digital Mammography DREAM Challenge'
+    'The Digital Mammography DREAM Challenge',
+    'upcoming'
   ),
-  ('2', 'Patient Mortality EHR DREAM Challenge'),
-  ('3', 'COVID-19 EHR DREAM Challenge');
+  (
+    '2',
+    'Patient Mortality EHR DREAM Challenge',
+    'active'
+  ),
+  ('3', 'COVID-19 EHR DREAM Challenge', 'completed');

--- a/apps/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-service/src/main/resources/openapi.yaml
@@ -148,6 +148,14 @@ components:
       - totalElements
       - totalPages
       type: object
+    ChallengeStatus:
+      description: The status of the challenge.
+      enum:
+      - upcoming
+      - active
+      - completed
+      example: active
+      type: string
     ChallengeCreateRequest:
       description: The information used to create a challenge
       properties:
@@ -156,8 +164,11 @@ components:
           maxLength: 60
           minLength: 3
           type: string
+        status:
+          $ref: '#/components/schemas/ChallengeStatus'
       required:
       - name
+      - status
       type: object
     ChallengeId:
       description: The unique identifier of a challenge.

--- a/apps/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-service/src/main/resources/openapi.yaml
@@ -43,6 +43,16 @@ paths:
           minimum: 1
           type: integer
         style: form
+      - description: Array of challenge status used to filter the results.
+        explode: true
+        in: query
+        name: status
+        required: false
+        schema:
+          items:
+            $ref: '#/components/schemas/ChallengeStatus'
+          type: array
+        style: form
       responses:
         "200":
           content:
@@ -95,6 +105,17 @@ components:
         minimum: 1
         type: integer
       style: form
+    status:
+      description: Array of challenge status used to filter the results.
+      explode: true
+      in: query
+      name: status
+      required: false
+      schema:
+        items:
+          $ref: '#/components/schemas/ChallengeStatus'
+        type: array
+      style: form
   responses:
     BadRequest:
       content:
@@ -109,6 +130,14 @@ components:
             $ref: '#/components/schemas/BasicError'
       description: The request cannot be fulfilled due to an unexpected server error
   schemas:
+    ChallengeStatus:
+      description: The status of the challenge.
+      enum:
+      - upcoming
+      - active
+      - completed
+      example: active
+      type: string
     PageMetadata:
       description: The metadata of a page.
       properties:
@@ -148,14 +177,6 @@ components:
       - totalElements
       - totalPages
       type: object
-    ChallengeStatus:
-      description: The status of the challenge.
-      enum:
-      - upcoming
-      - active
-      - completed
-      example: active
-      type: string
     ChallengeCreateRequest:
       description: The information used to create a challenge
       properties:

--- a/libs/api-spec/build/challenge.openapi.yaml
+++ b/libs/api-spec/build/challenge.openapi.yaml
@@ -97,6 +97,14 @@ components:
         - totalPages
         - hasNext
         - hasPrevious
+    ChallengeStatus:
+      description: The status of the challenge.
+      type: string
+      enum:
+        - upcoming
+        - active
+        - completed
+      example: active
     ChallengeCreateRequest:
       type: object
       description: The information used to create a challenge
@@ -106,8 +114,11 @@ components:
           minLength: 3
           maxLength: 60
           example: Example challenge
+        status:
+          $ref: '#/components/schemas/ChallengeStatus'
       required:
         - name
+        - status
     ChallengeId:
       description: The unique identifier of a challenge.
       type: integer

--- a/libs/api-spec/build/challenge.openapi.yaml
+++ b/libs/api-spec/build/challenge.openapi.yaml
@@ -26,6 +26,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/pageNumber'
         - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/status'
       responses:
         '200':
           content:
@@ -57,7 +58,24 @@ components:
         format: int32
         default: 100
         minimum: 1
+    status:
+      name: status
+      description: Array of challenge status used to filter the results.
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/ChallengeStatus'
   schemas:
+    ChallengeStatus:
+      description: The status of the challenge.
+      type: string
+      enum:
+        - upcoming
+        - active
+        - completed
+      example: active
     PageMetadata:
       type: object
       description: The metadata of a page.
@@ -97,14 +115,6 @@ components:
         - totalPages
         - hasNext
         - hasPrevious
-    ChallengeStatus:
-      description: The status of the challenge.
-      type: string
-      enum:
-        - upcoming
-        - active
-        - completed
-      example: active
     ChallengeCreateRequest:
       type: object
       description: The information used to create a challenge

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -207,6 +207,14 @@ components:
         - totalPages
         - hasNext
         - hasPrevious
+    ChallengeStatus:
+      description: The status of the challenge.
+      type: string
+      enum:
+        - upcoming
+        - active
+        - completed
+      example: active
     ChallengeCreateRequest:
       type: object
       description: The information used to create a challenge
@@ -216,8 +224,11 @@ components:
           minLength: 3
           maxLength: 60
           example: Example challenge
+        status:
+          $ref: '#/components/schemas/ChallengeStatus'
       required:
         - name
+        - status
     ChallengeId:
       description: The unique identifier of a challenge.
       type: integer

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -30,6 +30,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/pageNumber'
         - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/status'
       responses:
         '200':
           content:
@@ -168,6 +169,14 @@ paths:
           $ref: '#/components/responses/InternalServerError'
 components:
   schemas:
+    ChallengeStatus:
+      description: The status of the challenge.
+      type: string
+      enum:
+        - upcoming
+        - active
+        - completed
+      example: active
     PageMetadata:
       type: object
       description: The metadata of a page.
@@ -207,14 +216,6 @@ components:
         - totalPages
         - hasNext
         - hasPrevious
-    ChallengeStatus:
-      description: The status of the challenge.
-      type: string
-      enum:
-        - upcoming
-        - active
-        - completed
-      example: active
     ChallengeCreateRequest:
       type: object
       description: The information used to create a challenge
@@ -543,6 +544,15 @@ components:
         format: int32
         default: 100
         minimum: 1
+    status:
+      name: status
+      description: Array of challenge status used to filter the results.
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/ChallengeStatus'
     organizationLogin:
       name: organizationLogin
       in: path

--- a/libs/api-spec/src/components/parameters/query/challenge/status.yaml
+++ b/libs/api-spec/src/components/parameters/query/challenge/status.yaml
@@ -1,0 +1,8 @@
+name: status
+description: Array of challenge status used to filter the results.
+in: query
+required: false
+schema:
+  type: array
+  items:
+    $ref: ../../../schemas/ChallengeStatus.yaml

--- a/libs/api-spec/src/components/schemas/ChallengeCreateRequest.yaml
+++ b/libs/api-spec/src/components/schemas/ChallengeCreateRequest.yaml
@@ -6,20 +6,20 @@ properties:
     minLength: 3
     maxLength: 60
     example: Example challenge
-#   displayName:
-#     type: string
-#     minLength: 3
-#     maxLength: 60
-#   description:
-#     description: A short description of the challenge
-#     type: string
-#     nullable: true
-#     maxLength: 280
-#   websiteUrl:
-#     type: string
-#     format: url
-#   status:
-#     $ref: ChallengeStatus.yaml
+  #   displayName:
+  #     type: string
+  #     minLength: 3
+  #     maxLength: 60
+  #   description:
+  #     description: A short description of the challenge
+  #     type: string
+  #     nullable: true
+  #     maxLength: 280
+  #   websiteUrl:
+  #     type: string
+  #     format: url
+  status:
+    $ref: ChallengeStatus.yaml
 #   startDate:
 #     type: string
 #     format: date
@@ -65,6 +65,7 @@ properties:
 #     nullable: true
 required:
   - name
+  - status
 #   - description
 # example:
 #   name: awesome-challenge

--- a/libs/api-spec/src/components/schemas/ChallengeCreateResponse.yaml
+++ b/libs/api-spec/src/components/schemas/ChallengeCreateResponse.yaml
@@ -1,9 +1,0 @@
-type: object
-description: The unique identifier of the challenge created
-properties:
-  id:
-    $ref: ChallengeId.yaml
-required:
-  - id
-example:
-  id: 507f1f77bcf86cd799439011

--- a/libs/api-spec/src/components/schemas/ChallengeStatus.yaml
+++ b/libs/api-spec/src/components/schemas/ChallengeStatus.yaml
@@ -1,4 +1,4 @@
-description: The status of the challenge
+description: The status of the challenge.
 type: string
 enum:
   - upcoming

--- a/libs/api-spec/src/paths/challenges.yaml
+++ b/libs/api-spec/src/paths/challenges.yaml
@@ -44,7 +44,7 @@ get:
     # - $ref: parameters/searchTerms.yaml
     # - $ref: parameters/topics.yaml
     # - $ref: parameters/inputDataTypes.yaml
-    # - $ref: parameters/challenge/status.yaml
+    - $ref: ../components/parameters/query/challenge/status.yaml
     # - $ref: parameters/challenge/platformIds.yaml
     # - $ref: parameters/challenge/difficulty.yaml
     # - $ref: parameters/challenge/submissionTypes.yaml


### PR DESCRIPTION
Fixes #1027

## Changelog

- Update the OA description
  - Add the property `Challenge.status`
  - Enable to filter list of challenge by their status
- Update the Challenge service
  - List of challenges is filtered with querydsl.

## Limitation

- Getting the list of challenges will return an internal error if the query parameter `status` is missing from the `/challenges` query. This will be addressed in a following PR that adds more filters. I plan to adopt this [approach](https://samuel-mumo.medium.com/dynamic-queries-and-querydsl-jpa-support-in-spring-a1b4e233084b) which is suitable when we have many filters.

## Preview

```
http://localhost:8085/v1/challenges?pageNumber=0&pageSize=100&status=upcoming&status=active

{
  "number": 0,
  "size": 100,
  "totalElements": 2,
  "totalPages": 1,
  "hasNext": false,
  "hasPrevious": false,
  "challenges": [
    {
      "name": "The Digital Mammography DREAM Challenge",
      "status": "upcoming",
      "id": 1,
      "createdAt": "2022-12-20T17:47:22Z",
      "updatedAt": "2022-12-20T17:47:22Z"
    },
    {
      "name": "Patient Mortality EHR DREAM Challenge",
      "status": "active",
      "id": 2,
      "createdAt": "2022-12-20T17:47:22Z",
      "updatedAt": "2022-12-20T17:47:22Z"
    }
  ]
}
```

```
http://localhost:8085/v1/challenges?pageNumber=0&pageSize=100&status=

{
  "number": 0,
  "size": 100,
  "totalElements": 0,
  "totalPages": 0,
  "hasNext": false,
  "hasPrevious": false,
  "challenges": []
}
```