### PR TITLE
feat: Update backend to filter challenges by difficulty

### DIFF
--- a/apps/challenge-service/.openapi-generator-ignore
+++ b/apps/challenge-service/.openapi-generator-ignore
@@ -28,4 +28,4 @@ README.md
 **/OpenApiGeneratorApplication.java
 
 # The template of this file has a bug: the Dto suffix is not included
-**/EnumConverterConfiguration.java
+# **/EnumConverterConfiguration.java

--- a/apps/challenge-service/.openapi-generator-ignore
+++ b/apps/challenge-service/.openapi-generator-ignore
@@ -26,6 +26,3 @@ README.md
 **/application.properties
 **/model/dto/*AllOf*.java
 **/OpenApiGeneratorApplication.java
-
-# The template of this file has a bug: the Dto suffix is not included
-# **/EnumConverterConfiguration.java

--- a/apps/challenge-service/.openapi-generator/FILES
+++ b/apps/challenge-service/.openapi-generator/FILES
@@ -9,6 +9,7 @@ src/main/java/org/sagebionetworks/challenge/configuration/HomeController.java
 src/main/java/org/sagebionetworks/challenge/configuration/SpringDocConfiguration.java
 src/main/java/org/sagebionetworks/challenge/model/dto/BasicErrorDto.java
 src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeCreateRequestDto.java
+src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeDifficultyDto.java
 src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeDto.java
 src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeStatusDto.java
 src/main/java/org/sagebionetworks/challenge/model/dto/ChallengesPageDto.java

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/api/ChallengeApi.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/api/ChallengeApi.java
@@ -15,6 +15,7 @@ import javax.annotation.Generated;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 import org.sagebionetworks.challenge.model.dto.BasicErrorDto;
+import org.sagebionetworks.challenge.model.dto.ChallengeDifficultyDto;
 import org.sagebionetworks.challenge.model.dto.ChallengeStatusDto;
 import org.sagebionetworks.challenge.model.dto.ChallengesPageDto;
 import org.springframework.http.ResponseEntity;
@@ -36,6 +37,7 @@ public interface ChallengeApi {
    * @param pageNumber The page number (optional, default to 0)
    * @param pageSize The number of items in a single page (optional, default to 100)
    * @param status Array of challenge status used to filter the results. (optional)
+   * @param difficulty Array of challenge difficulty levels used to filter the results. (optional)
    * @return Success (status code 200) or Invalid request (status code 400) or The request cannot be
    *     fulfilled due to an unexpected server error (status code 500)
    */
@@ -98,7 +100,13 @@ public interface ChallengeApi {
               description = "Array of challenge status used to filter the results.")
           @Valid
           @RequestParam(value = "status", required = false)
-          List<ChallengeStatusDto> status) {
-    return getDelegate().listChallenges(pageNumber, pageSize, status);
+          List<ChallengeStatusDto> status,
+      @Parameter(
+              name = "difficulty",
+              description = "Array of challenge difficulty levels used to filter the results.")
+          @Valid
+          @RequestParam(value = "difficulty", required = false)
+          List<ChallengeDifficultyDto> difficulty) {
+    return getDelegate().listChallenges(pageNumber, pageSize, status, difficulty);
   }
 }

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/api/ChallengeApi.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/api/ChallengeApi.java
@@ -36,8 +36,9 @@ public interface ChallengeApi {
    *
    * @param pageNumber The page number (optional, default to 0)
    * @param pageSize The number of items in a single page (optional, default to 100)
-   * @param status Array of challenge status used to filter the results. (optional)
-   * @param difficulty Array of challenge difficulty levels used to filter the results. (optional)
+   * @param status An array of challenge status used to filter the results. (optional)
+   * @param difficulty An array of challenge difficulty levels used to filter the results.
+   *     (optional)
    * @return Success (status code 200) or Invalid request (status code 400) or The request cannot be
    *     fulfilled due to an unexpected server error (status code 500)
    */
@@ -97,13 +98,13 @@ public interface ChallengeApi {
           Integer pageSize,
       @Parameter(
               name = "status",
-              description = "Array of challenge status used to filter the results.")
+              description = "An array of challenge status used to filter the results.")
           @Valid
           @RequestParam(value = "status", required = false)
           List<ChallengeStatusDto> status,
       @Parameter(
               name = "difficulty",
-              description = "Array of challenge difficulty levels used to filter the results.")
+              description = "An array of challenge difficulty levels used to filter the results.")
           @Valid
           @RequestParam(value = "difficulty", required = false)
           List<ChallengeDifficultyDto> difficulty) {

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/api/ChallengeApiDelegate.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/api/ChallengeApiDelegate.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.challenge.api;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Generated;
+import org.sagebionetworks.challenge.model.dto.ChallengeDifficultyDto;
 import org.sagebionetworks.challenge.model.dto.ChallengeStatusDto;
 import org.sagebionetworks.challenge.model.dto.ChallengesPageDto;
 import org.springframework.http.HttpStatus;
@@ -27,12 +28,16 @@ public interface ChallengeApiDelegate {
    * @param pageNumber The page number (optional, default to 0)
    * @param pageSize The number of items in a single page (optional, default to 100)
    * @param status Array of challenge status used to filter the results. (optional)
+   * @param difficulty Array of challenge difficulty levels used to filter the results. (optional)
    * @return Success (status code 200) or Invalid request (status code 400) or The request cannot be
    *     fulfilled due to an unexpected server error (status code 500)
    * @see ChallengeApi#listChallenges
    */
   default ResponseEntity<ChallengesPageDto> listChallenges(
-      Integer pageNumber, Integer pageSize, List<ChallengeStatusDto> status) {
+      Integer pageNumber,
+      Integer pageSize,
+      List<ChallengeStatusDto> status,
+      List<ChallengeDifficultyDto> difficulty) {
     getRequest()
         .ifPresent(
             request -> {

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/api/ChallengeApiDelegate.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/api/ChallengeApiDelegate.java
@@ -27,8 +27,9 @@ public interface ChallengeApiDelegate {
    *
    * @param pageNumber The page number (optional, default to 0)
    * @param pageSize The number of items in a single page (optional, default to 100)
-   * @param status Array of challenge status used to filter the results. (optional)
-   * @param difficulty Array of challenge difficulty levels used to filter the results. (optional)
+   * @param status An array of challenge status used to filter the results. (optional)
+   * @param difficulty An array of challenge difficulty levels used to filter the results.
+   *     (optional)
    * @return Success (status code 200) or Invalid request (status code 400) or The request cannot be
    *     fulfilled due to an unexpected server error (status code 500)
    * @see ChallengeApi#listChallenges

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/api/ChallengeApiDelegateImpl.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/api/ChallengeApiDelegateImpl.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.challenge.api;
 
 import java.util.List;
+import org.sagebionetworks.challenge.model.dto.ChallengeDifficultyDto;
 import org.sagebionetworks.challenge.model.dto.ChallengeStatusDto;
 import org.sagebionetworks.challenge.model.dto.ChallengesPageDto;
 import org.sagebionetworks.challenge.service.ChallengeService;
@@ -15,8 +16,12 @@ public class ChallengeApiDelegateImpl implements ChallengeApiDelegate {
 
   @Override
   public ResponseEntity<ChallengesPageDto> listChallenges(
-      Integer pageNumber, Integer pageSize, List<ChallengeStatusDto> status) {
-    return ResponseEntity.ok(challengeService.listChallenges(pageNumber, pageSize, status));
+      Integer pageNumber,
+      Integer pageSize,
+      List<ChallengeStatusDto> status,
+      List<ChallengeDifficultyDto> difficulty) {
+    return ResponseEntity.ok(
+        challengeService.listChallenges(pageNumber, pageSize, status, difficulty));
   }
 
   // @Override

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/configuration/EnumConverterConfiguration.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/configuration/EnumConverterConfiguration.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.challenge.configuration;
 
+import org.sagebionetworks.challenge.model.dto.ChallengeDifficultyDto;
 import org.sagebionetworks.challenge.model.dto.ChallengeStatusDto;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -7,6 +8,16 @@ import org.springframework.core.convert.converter.Converter;
 
 @Configuration
 public class EnumConverterConfiguration {
+
+  @Bean
+  Converter<String, ChallengeDifficultyDto> challengeDifficultyConverter() {
+    return new Converter<String, ChallengeDifficultyDto>() {
+      @Override
+      public ChallengeDifficultyDto convert(String source) {
+        return ChallengeDifficultyDto.fromValue(source);
+      }
+    };
+  }
 
   @Bean
   Converter<String, ChallengeStatusDto> challengeStatusConverter() {

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeCreateRequestDto.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeCreateRequestDto.java
@@ -22,6 +22,9 @@ public class ChallengeCreateRequestDto {
   @JsonProperty("status")
   private ChallengeStatusDto status;
 
+  @JsonProperty("difficulty")
+  private ChallengeDifficultyDto difficulty;
+
   public ChallengeCreateRequestDto name(String name) {
     this.name = name;
     return this;
@@ -64,6 +67,26 @@ public class ChallengeCreateRequestDto {
     this.status = status;
   }
 
+  public ChallengeCreateRequestDto difficulty(ChallengeDifficultyDto difficulty) {
+    this.difficulty = difficulty;
+    return this;
+  }
+
+  /**
+   * Get difficulty
+   *
+   * @return difficulty
+   */
+  @Valid
+  @Schema(name = "difficulty", required = false)
+  public ChallengeDifficultyDto getDifficulty() {
+    return difficulty;
+  }
+
+  public void setDifficulty(ChallengeDifficultyDto difficulty) {
+    this.difficulty = difficulty;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -74,12 +97,13 @@ public class ChallengeCreateRequestDto {
     }
     ChallengeCreateRequestDto challengeCreateRequest = (ChallengeCreateRequestDto) o;
     return Objects.equals(this.name, challengeCreateRequest.name)
-        && Objects.equals(this.status, challengeCreateRequest.status);
+        && Objects.equals(this.status, challengeCreateRequest.status)
+        && Objects.equals(this.difficulty, challengeCreateRequest.difficulty);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, status);
+    return Objects.hash(name, status, difficulty);
   }
 
   @Override
@@ -88,6 +112,7 @@ public class ChallengeCreateRequestDto {
     sb.append("class ChallengeCreateRequestDto {\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("    difficulty: ").append(toIndentedString(difficulty)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeDifficultyDto.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeDifficultyDto.java
@@ -1,0 +1,43 @@
+package org.sagebionetworks.challenge.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.*;
+import javax.annotation.Generated;
+import javax.validation.constraints.*;
+
+/** The difficulty level of a challenge. */
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum ChallengeDifficultyDto {
+  GOOD_FOR_BEGINNERS("good_for_beginners"),
+
+  INTERMEDIATE("intermediate"),
+
+  ADVANCED("advanced");
+
+  private String value;
+
+  ChallengeDifficultyDto(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static ChallengeDifficultyDto fromValue(String value) {
+    for (ChallengeDifficultyDto b : ChallengeDifficultyDto.values()) {
+      if (b.value.equals(value)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+}

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeDto.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeDto.java
@@ -24,6 +24,9 @@ public class ChallengeDto {
   @JsonProperty("status")
   private ChallengeStatusDto status;
 
+  @JsonProperty("difficulty")
+  private ChallengeDifficultyDto difficulty;
+
   @JsonProperty("id")
   private Long id;
 
@@ -75,6 +78,26 @@ public class ChallengeDto {
 
   public void setStatus(ChallengeStatusDto status) {
     this.status = status;
+  }
+
+  public ChallengeDto difficulty(ChallengeDifficultyDto difficulty) {
+    this.difficulty = difficulty;
+    return this;
+  }
+
+  /**
+   * Get difficulty
+   *
+   * @return difficulty
+   */
+  @Valid
+  @Schema(name = "difficulty", required = false)
+  public ChallengeDifficultyDto getDifficulty() {
+    return difficulty;
+  }
+
+  public void setDifficulty(ChallengeDifficultyDto difficulty) {
+    this.difficulty = difficulty;
   }
 
   public ChallengeDto id(Long id) {
@@ -154,6 +177,7 @@ public class ChallengeDto {
     ChallengeDto challenge = (ChallengeDto) o;
     return Objects.equals(this.name, challenge.name)
         && Objects.equals(this.status, challenge.status)
+        && Objects.equals(this.difficulty, challenge.difficulty)
         && Objects.equals(this.id, challenge.id)
         && Objects.equals(this.createdAt, challenge.createdAt)
         && Objects.equals(this.updatedAt, challenge.updatedAt);
@@ -161,7 +185,7 @@ public class ChallengeDto {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, status, id, createdAt, updatedAt);
+    return Objects.hash(name, status, difficulty, id, createdAt, updatedAt);
   }
 
   @Override
@@ -170,6 +194,7 @@ public class ChallengeDto {
     sb.append("class ChallengeDto {\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("    difficulty: ").append(toIndentedString(difficulty)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/ChallengeEntity.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/ChallengeEntity.java
@@ -32,6 +32,9 @@ public class ChallengeEntity {
   @Column(nullable = false)
   private String status;
 
+  @Column(nullable = false)
+  private String difficulty;
+
   // @Column(nullable = false)
   // private String email;
 

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/mapper/ChallengeMapper.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/mapper/ChallengeMapper.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.challenge.model.mapper;
 
+import org.sagebionetworks.challenge.model.dto.ChallengeDifficultyDto;
 import org.sagebionetworks.challenge.model.dto.ChallengeDto;
 import org.sagebionetworks.challenge.model.dto.ChallengeStatusDto;
 import org.sagebionetworks.challenge.model.entity.ChallengeEntity;
@@ -22,6 +23,7 @@ public class ChallengeMapper extends BaseMapper<ChallengeEntity, ChallengeDto> {
     if (entity != null) {
       BeanUtils.copyProperties(entity, user);
       user.setStatus(ChallengeStatusDto.fromValue(entity.getStatus()));
+      user.setDifficulty(ChallengeDifficultyDto.fromValue(entity.getDifficulty()));
     }
     return user;
   }

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeFilter.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeFilter.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.challenge.model.repository;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,6 +11,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChallengeFilter {
-  private String status;
-  private String difficulty;
+  private List<String> status;
+  private List<String> difficulty;
 }

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeFilter.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeFilter.java
@@ -1,0 +1,15 @@
+package org.sagebionetworks.challenge.model.repository;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeFilter {
+  private String status;
+  private String difficulty;
+}

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepository.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepository.java
@@ -5,7 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
 public interface ChallengeRepository
-    extends JpaRepository<ChallengeEntity, Long>, QuerydslPredicateExecutor<ChallengeEntity> {
-
-  // Optional<ChallengeEntity> findByLogin(String login);
-}
+    extends JpaRepository<ChallengeEntity, Long>, QuerydslPredicateExecutor<ChallengeEntity> {}

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepositoryCustom.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepositoryCustom.java
@@ -1,10 +1,10 @@
 package org.sagebionetworks.challenge.model.repository;
 
-import java.util.List;
 import org.sagebionetworks.challenge.model.entity.ChallengeEntity;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ChallengeRepositoryCustom {
 
-  List<ChallengeEntity> findAll(Pageable pageable, ChallengeFilter filter);
+  Page<ChallengeEntity> findAll(Pageable pageable, ChallengeFilter filter);
 }

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepositoryCustom.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepositoryCustom.java
@@ -1,0 +1,9 @@
+package org.sagebionetworks.challenge.model.repository;
+
+import java.util.List;
+import org.sagebionetworks.challenge.model.entity.ChallengeEntity;
+
+public interface ChallengeRepositoryCustom {
+
+  List<ChallengeEntity> findAll(ChallengeFilter filter);
+}

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepositoryCustom.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepositoryCustom.java
@@ -2,8 +2,9 @@ package org.sagebionetworks.challenge.model.repository;
 
 import java.util.List;
 import org.sagebionetworks.challenge.model.entity.ChallengeEntity;
+import org.springframework.data.domain.Pageable;
 
 public interface ChallengeRepositoryCustom {
 
-  List<ChallengeEntity> findAll(ChallengeFilter filter);
+  List<ChallengeEntity> findAll(Pageable pageable, ChallengeFilter filter);
 }

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepositoryCustomImpl.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepositoryCustomImpl.java
@@ -1,8 +1,10 @@
 package org.sagebionetworks.challenge.model.repository;
 
-import java.util.ArrayList;
+import com.querydsl.jpa.JPQLQuery;
 import java.util.List;
 import org.sagebionetworks.challenge.model.entity.ChallengeEntity;
+import org.sagebionetworks.challenge.model.entity.QChallengeEntity;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.stereotype.Repository;
 
@@ -15,8 +17,14 @@ public class ChallengeRepositoryCustomImpl extends QuerydslRepositorySupport
   }
 
   @Override
-  public List<ChallengeEntity> findAll(ChallengeFilter filter) {
-    List<ChallengeEntity> challenges = new ArrayList<>();
-    return challenges;
+  public List<ChallengeEntity> findAll(Pageable pageable, ChallengeFilter filter) {
+    QChallengeEntity challenge = QChallengeEntity.challengeEntity;
+
+    JPQLQuery<ChallengeEntity> query = from(challenge);
+
+    query = super.getQuerydsl().applyPagination(pageable, query);
+
+    // List<ChallengeEntity> challenges = new ArrayList<>();
+    return query.fetch();
   }
 }

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepositoryCustomImpl.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepositoryCustomImpl.java
@@ -22,6 +22,14 @@ public class ChallengeRepositoryCustomImpl extends QuerydslRepositorySupport
 
     JPQLQuery<ChallengeEntity> query = from(challenge);
 
+    if (filter.getStatus() != null && filter.getStatus().size() > 0) {
+      query = query.where(challenge.status.in(filter.getStatus()));
+    }
+
+    if (filter.getDifficulty() != null && filter.getDifficulty().size() > 0) {
+      query = query.where(challenge.difficulty.in(filter.getDifficulty()));
+    }
+
     query = super.getQuerydsl().applyPagination(pageable, query);
 
     // List<ChallengeEntity> challenges = new ArrayList<>();

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepositoryCustomImpl.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepositoryCustomImpl.java
@@ -1,0 +1,22 @@
+package org.sagebionetworks.challenge.model.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.sagebionetworks.challenge.model.entity.ChallengeEntity;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ChallengeRepositoryCustomImpl extends QuerydslRepositorySupport
+    implements ChallengeRepositoryCustom {
+
+  public ChallengeRepositoryCustomImpl() {
+    super(ChallengeEntity.class);
+  }
+
+  @Override
+  public List<ChallengeEntity> findAll(ChallengeFilter filter) {
+    List<ChallengeEntity> challenges = new ArrayList<>();
+    return challenges;
+  }
+}

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepositoryCustomImpl.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/ChallengeRepositoryCustomImpl.java
@@ -1,9 +1,11 @@
 package org.sagebionetworks.challenge.model.repository;
 
+import com.querydsl.core.QueryResults;
 import com.querydsl.jpa.JPQLQuery;
-import java.util.List;
 import org.sagebionetworks.challenge.model.entity.ChallengeEntity;
 import org.sagebionetworks.challenge.model.entity.QChallengeEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.stereotype.Repository;
@@ -17,7 +19,7 @@ public class ChallengeRepositoryCustomImpl extends QuerydslRepositorySupport
   }
 
   @Override
-  public List<ChallengeEntity> findAll(Pageable pageable, ChallengeFilter filter) {
+  public Page<ChallengeEntity> findAll(Pageable pageable, ChallengeFilter filter) {
     QChallengeEntity challenge = QChallengeEntity.challengeEntity;
 
     JPQLQuery<ChallengeEntity> query = from(challenge);
@@ -32,7 +34,11 @@ public class ChallengeRepositoryCustomImpl extends QuerydslRepositorySupport
 
     query = super.getQuerydsl().applyPagination(pageable, query);
 
-    // List<ChallengeEntity> challenges = new ArrayList<>();
-    return query.fetch();
+    // SearchResults<Employees> entitys = query.listResults(QEmployees.employees);
+    // return new PageImpl<Employees>(entitys.getResults(), pageable, entitys.getTotal());
+    // SearchResults
+    QueryResults<ChallengeEntity> results = query.fetchResults();
+
+    return new PageImpl<ChallengeEntity>(results.getResults(), pageable, results.getTotal());
   }
 }

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/service/ChallengeService.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/service/ChallengeService.java
@@ -10,7 +10,9 @@ import org.sagebionetworks.challenge.model.dto.ChallengesPageDto;
 import org.sagebionetworks.challenge.model.entity.ChallengeEntity;
 import org.sagebionetworks.challenge.model.entity.QChallengeEntity;
 import org.sagebionetworks.challenge.model.mapper.ChallengeMapper;
+import org.sagebionetworks.challenge.model.repository.ChallengeFilter;
 import org.sagebionetworks.challenge.model.repository.ChallengeRepository;
+import org.sagebionetworks.challenge.model.repository.ChallengeRepositoryCustom;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -22,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChallengeService {
 
   @Autowired private ChallengeRepository challengeRepository;
+  @Autowired private ChallengeRepositoryCustom challengeRepositoryCustom;
 
   private ChallengeMapper challengeMapper = new ChallengeMapper();
 
@@ -34,6 +37,11 @@ public class ChallengeService {
 
     log.info("status {}", status);
     log.info("difficulty {}", difficulty);
+
+    ChallengeFilter filter =
+        ChallengeFilter.builder().difficulty("good_for_beginners").status("upcoming").build();
+    List<ChallengeEntity> ce = challengeRepositoryCustom.findAll(filter);
+    log.info("challengeRepositoryCustom {}", ce);
 
     QChallengeEntity qChallenge = QChallengeEntity.challengeEntity;
     BooleanExpression q = qChallenge.status.in(status.stream().map(s -> s.toString()).toList());

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/service/ChallengeService.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/service/ChallengeService.java
@@ -44,15 +44,16 @@ public class ChallengeService {
 
     Pageable pageable = PageRequest.of(pageNumber, pageSize);
 
-    Page<ChallengeEntity> challengeEntitiesPage = challengeRepository.findAll(q, pageable);
+    // Page<ChallengeEntity> challengeEntitiesPage = challengeRepository.findAll(q, pageable);
 
     ChallengeFilter filter =
         ChallengeFilter.builder()
             .difficulty(difficulty.stream().map(d -> d.toString()).toList())
             .status(status.stream().map(s -> s.toString()).toList())
             .build();
-    List<ChallengeEntity> ce = challengeRepositoryCustom.findAll(pageable, filter);
-    log.info("challengeRepositoryCustom {}", ce);
+    Page<ChallengeEntity> challengeEntitiesPage =
+        challengeRepositoryCustom.findAll(pageable, filter);
+    log.info("challengeRepositoryCustom {}", challengeEntitiesPage);
 
     List<ChallengeDto> challenges =
         challengeMapper.convertToDtoList(challengeEntitiesPage.getContent());

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/service/ChallengeService.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/service/ChallengeService.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.challenge.service;
 
-import com.querydsl.core.types.dsl.BooleanExpression;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.sagebionetworks.challenge.model.dto.ChallengeDifficultyDto;
@@ -8,7 +7,6 @@ import org.sagebionetworks.challenge.model.dto.ChallengeDto;
 import org.sagebionetworks.challenge.model.dto.ChallengeStatusDto;
 import org.sagebionetworks.challenge.model.dto.ChallengesPageDto;
 import org.sagebionetworks.challenge.model.entity.ChallengeEntity;
-import org.sagebionetworks.challenge.model.entity.QChallengeEntity;
 import org.sagebionetworks.challenge.model.mapper.ChallengeMapper;
 import org.sagebionetworks.challenge.model.repository.ChallengeFilter;
 import org.sagebionetworks.challenge.model.repository.ChallengeRepository;
@@ -39,18 +37,13 @@ public class ChallengeService {
     log.info("status {}", status);
     log.info("difficulty {}", difficulty);
 
-    QChallengeEntity qChallenge = QChallengeEntity.challengeEntity;
-    BooleanExpression q = qChallenge.status.in(status.stream().map(s -> s.toString()).toList());
-
     Pageable pageable = PageRequest.of(pageNumber, pageSize);
-
-    // Page<ChallengeEntity> challengeEntitiesPage = challengeRepository.findAll(q, pageable);
-
     ChallengeFilter filter =
         ChallengeFilter.builder()
             .difficulty(difficulty.stream().map(d -> d.toString()).toList())
             .status(status.stream().map(s -> s.toString()).toList())
             .build();
+
     Page<ChallengeEntity> challengeEntitiesPage =
         challengeRepositoryCustom.findAll(pageable, filter);
     log.info("challengeRepositoryCustom {}", challengeEntitiesPage);

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/service/ChallengeService.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/service/ChallengeService.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.challenge.service;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.sagebionetworks.challenge.model.dto.ChallengeDifficultyDto;
 import org.sagebionetworks.challenge.model.dto.ChallengeDto;
 import org.sagebionetworks.challenge.model.dto.ChallengeStatusDto;
 import org.sagebionetworks.challenge.model.dto.ChallengesPageDto;
@@ -26,9 +27,14 @@ public class ChallengeService {
 
   @Transactional(readOnly = true)
   public ChallengesPageDto listChallenges(
-      Integer pageNumber, Integer pageSize, List<ChallengeStatusDto> status) {
+      Integer pageNumber,
+      Integer pageSize,
+      List<ChallengeStatusDto> status,
+      List<ChallengeDifficultyDto> difficulty) {
 
     log.info("status {}", status);
+    log.info("difficulty {}", difficulty);
+
     QChallengeEntity qChallenge = QChallengeEntity.challengeEntity;
     BooleanExpression q = qChallenge.status.in(status.stream().map(s -> s.toString()).toList());
 

--- a/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/service/ChallengeService.java
+++ b/apps/challenge-service/src/main/java/org/sagebionetworks/challenge/service/ChallengeService.java
@@ -12,7 +12,7 @@ import org.sagebionetworks.challenge.model.entity.QChallengeEntity;
 import org.sagebionetworks.challenge.model.mapper.ChallengeMapper;
 import org.sagebionetworks.challenge.model.repository.ChallengeFilter;
 import org.sagebionetworks.challenge.model.repository.ChallengeRepository;
-import org.sagebionetworks.challenge.model.repository.ChallengeRepositoryCustomImpl;
+import org.sagebionetworks.challenge.model.repository.ChallengeRepositoryCustom;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -25,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChallengeService {
 
   @Autowired private ChallengeRepository challengeRepository;
-  @Autowired private ChallengeRepositoryCustomImpl challengeRepositoryCustom;
+  @Autowired private ChallengeRepositoryCustom challengeRepositoryCustom;
 
   private ChallengeMapper challengeMapper = new ChallengeMapper();
 
@@ -47,7 +47,10 @@ public class ChallengeService {
     Page<ChallengeEntity> challengeEntitiesPage = challengeRepository.findAll(q, pageable);
 
     ChallengeFilter filter =
-        ChallengeFilter.builder().difficulty("good_for_beginners").status("upcoming").build();
+        ChallengeFilter.builder()
+            .difficulty(difficulty.stream().map(d -> d.toString()).toList())
+            .status(status.stream().map(s -> s.toString()).toList())
+            .build();
     List<ChallengeEntity> ce = challengeRepositoryCustom.findAll(pageable, filter);
     log.info("challengeRepositoryCustom {}", ce);
 

--- a/apps/challenge-service/src/main/resources/db/migration/V1.0.0__create_challenge_table.sql
+++ b/apps/challenge-service/src/main/resources/db/migration/V1.0.0__create_challenge_table.sql
@@ -5,6 +5,7 @@ CREATE TABLE `challenge`
     `id`                    bigint(20) NOT NULL AUTO_INCREMENT,
     `name`                  varchar(255) DEFAULT NULL,
     `status`                ENUM('upcoming', 'active', 'completed'),
+    `difficulty`            ENUM('good_for_beginners', 'intermediate', 'advanced'),
     -- `email`                 varchar(255) DEFAULT NULL,
     -- `login`                 varchar(255) UNIQUE,
     -- `avatar_url`            varchar(255) DEFAULT NULL,

--- a/apps/challenge-service/src/main/resources/db/migration/V1.0.1__temp_data.sql
+++ b/apps/challenge-service/src/main/resources/db/migration/V1.0.1__temp_data.sql
@@ -1,12 +1,19 @@
-INSERT INTO challenge (id, name, status)
+INSERT INTO challenge (id, name, status, difficulty)
 VALUES (
     '1',
     'The Digital Mammography DREAM Challenge',
-    'upcoming'
+    'upcoming',
+    'good_for_beginners'
   ),
   (
     '2',
     'Patient Mortality EHR DREAM Challenge',
-    'active'
+    'active',
+    'intermediate'
   ),
-  ('3', 'COVID-19 EHR DREAM Challenge', 'completed');
+  (
+    '3',
+    'COVID-19 EHR DREAM Challenge',
+    'completed',
+    'advanced'
+  );

--- a/apps/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-service/src/main/resources/openapi.yaml
@@ -43,7 +43,7 @@ paths:
           minimum: 1
           type: integer
         style: form
-      - description: Array of challenge status used to filter the results.
+      - description: An array of challenge status used to filter the results.
         explode: true
         in: query
         name: status
@@ -53,7 +53,7 @@ paths:
             $ref: '#/components/schemas/ChallengeStatus'
           type: array
         style: form
-      - description: Array of challenge difficulty levels used to filter the results.
+      - description: An array of challenge difficulty levels used to filter the results.
         explode: true
         in: query
         name: difficulty
@@ -116,7 +116,7 @@ components:
         type: integer
       style: form
     status:
-      description: Array of challenge status used to filter the results.
+      description: An array of challenge status used to filter the results.
       explode: true
       in: query
       name: status
@@ -127,7 +127,7 @@ components:
         type: array
       style: form
     difficulty:
-      description: Array of challenge difficulty levels used to filter the results.
+      description: An array of challenge difficulty levels used to filter the results.
       explode: true
       in: query
       name: difficulty

--- a/apps/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/challenge-service/src/main/resources/openapi.yaml
@@ -53,6 +53,16 @@ paths:
             $ref: '#/components/schemas/ChallengeStatus'
           type: array
         style: form
+      - description: Array of challenge difficulty levels used to filter the results.
+        explode: true
+        in: query
+        name: difficulty
+        required: false
+        schema:
+          items:
+            $ref: '#/components/schemas/ChallengeDifficulty'
+          type: array
+        style: form
       responses:
         "200":
           content:
@@ -116,6 +126,17 @@ components:
           $ref: '#/components/schemas/ChallengeStatus'
         type: array
       style: form
+    difficulty:
+      description: Array of challenge difficulty levels used to filter the results.
+      explode: true
+      in: query
+      name: difficulty
+      required: false
+      schema:
+        items:
+          $ref: '#/components/schemas/ChallengeDifficulty'
+        type: array
+      style: form
   responses:
     BadRequest:
       content:
@@ -137,6 +158,14 @@ components:
       - active
       - completed
       example: active
+      type: string
+    ChallengeDifficulty:
+      description: The difficulty level of a challenge.
+      enum:
+      - good_for_beginners
+      - intermediate
+      - advanced
+      example: intermediate
       type: string
     PageMetadata:
       description: The metadata of a page.
@@ -187,6 +216,8 @@ components:
           type: string
         status:
           $ref: '#/components/schemas/ChallengeStatus'
+        difficulty:
+          $ref: '#/components/schemas/ChallengeDifficulty'
       required:
       - name
       - status

--- a/apps/challenge-service/templates/converter.mustache
+++ b/apps/challenge-service/templates/converter.mustache
@@ -1,0 +1,34 @@
+package {{configPackage}};
+
+{{#models}}
+    {{#model}}
+        {{#isEnum}}
+import {{modelPackage}}.{{classname}};
+        {{/isEnum}}
+    {{/model}}
+{{/models}}
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+
+@Configuration
+public class EnumConverterConfiguration {
+
+{{#models}}
+{{#model}}
+{{#isEnum}}
+    @Bean
+    Converter<{{{dataType}}}, {{classname}}> {{classVarName}}Converter() {
+        return new Converter<{{{dataType}}}, {{classname}}>() {
+            @Override
+            public {{classname}} convert({{{dataType}}} source) {
+                return {{classname}}.fromValue(source);
+            }
+        };
+    }
+{{/isEnum}}
+{{/model}}
+{{/models}}
+
+}

--- a/apps/challenge-service/templates/v6.2.1/converter.mustache
+++ b/apps/challenge-service/templates/v6.2.1/converter.mustache
@@ -1,0 +1,34 @@
+package {{configPackage}};
+
+{{#models}}
+    {{#model}}
+        {{#isEnum}}
+import {{modelPackage}}.{{name}};
+        {{/isEnum}}
+    {{/model}}
+{{/models}}
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+
+@Configuration
+public class EnumConverterConfiguration {
+
+{{#models}}
+{{#model}}
+{{#isEnum}}
+    @Bean
+    Converter<{{{dataType}}}, {{name}}> {{classVarName}}Converter() {
+        return new Converter<{{{dataType}}}, {{name}}>() {
+            @Override
+            public {{name}} convert({{{dataType}}} source) {
+                return {{name}}.fromValue(source);
+            }
+        };
+    }
+{{/isEnum}}
+{{/model}}
+{{/models}}
+
+}

--- a/apps/challenge-service/tools/pull-templates.sh
+++ b/apps/challenge-service/tools/pull-templates.sh
@@ -9,3 +9,5 @@ curl -O --output-dir "${destinationFolder}" \
   "https://raw.githubusercontent.com/OpenAPITools/openapi-generator/${openapiGeneratorVersion}/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/openapi2SpringBoot.mustache"
 curl -O --output-dir "${destinationFolder}" \
   "https://raw.githubusercontent.com/OpenAPITools/openapi-generator/${openapiGeneratorVersion}/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache"
+curl -O --output-dir "${destinationFolder}" \
+  "https://raw.githubusercontent.com/OpenAPITools/openapi-generator/${openapiGeneratorVersion}/modules/openapi-generator/src/main/resources/JavaSpring/converter.mustache"

--- a/libs/api-spec/build/challenge.openapi.yaml
+++ b/libs/api-spec/build/challenge.openapi.yaml
@@ -61,7 +61,7 @@ components:
         minimum: 1
     status:
       name: status
-      description: Array of challenge status used to filter the results.
+      description: An array of challenge status used to filter the results.
       in: query
       required: false
       schema:
@@ -70,7 +70,7 @@ components:
           $ref: '#/components/schemas/ChallengeStatus'
     difficulty:
       name: difficulty
-      description: Array of challenge difficulty levels used to filter the results.
+      description: An array of challenge difficulty levels used to filter the results.
       in: query
       required: false
       schema:

--- a/libs/api-spec/build/challenge.openapi.yaml
+++ b/libs/api-spec/build/challenge.openapi.yaml
@@ -27,6 +27,7 @@ paths:
         - $ref: '#/components/parameters/pageNumber'
         - $ref: '#/components/parameters/pageSize'
         - $ref: '#/components/parameters/status'
+        - $ref: '#/components/parameters/difficulty'
       responses:
         '200':
           content:
@@ -67,6 +68,15 @@ components:
         type: array
         items:
           $ref: '#/components/schemas/ChallengeStatus'
+    difficulty:
+      name: difficulty
+      description: Array of challenge difficulty levels used to filter the results.
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/ChallengeDifficulty'
   schemas:
     ChallengeStatus:
       description: The status of the challenge.
@@ -76,6 +86,14 @@ components:
         - active
         - completed
       example: active
+    ChallengeDifficulty:
+      description: The difficulty level of a challenge.
+      type: string
+      enum:
+        - good_for_beginners
+        - intermediate
+        - advanced
+      example: intermediate
     PageMetadata:
       type: object
       description: The metadata of a page.
@@ -126,6 +144,8 @@ components:
           example: Example challenge
         status:
           $ref: '#/components/schemas/ChallengeStatus'
+        difficulty:
+          $ref: '#/components/schemas/ChallengeDifficulty'
       required:
         - name
         - status

--- a/libs/api-spec/build/challenge.openapi.yaml
+++ b/libs/api-spec/build/challenge.openapi.yaml
@@ -28,7 +28,6 @@ paths:
         - $ref: '#/components/parameters/pageSize'
         - $ref: '#/components/parameters/status'
         - $ref: '#/components/parameters/difficulty'
-        - $ref: '#/components/parameters/incentiveTypes'
       responses:
         '200':
           content:
@@ -78,15 +77,6 @@ components:
         type: array
         items:
           $ref: '#/components/schemas/ChallengeDifficulty'
-    incentiveTypes:
-      name: incentiveTypes
-      description: Array of challenge incentive types used to filter the results.
-      in: query
-      required: false
-      schema:
-        type: array
-        items:
-          $ref: '#/components/schemas/ChallengeIncentiveType'
   schemas:
     ChallengeStatus:
       description: The status of the challenge.
@@ -104,15 +94,6 @@ components:
         - intermediate
         - advanced
       example: intermediate
-    ChallengeIncentiveType:
-      description: The incentive type of the challenge.
-      type: string
-      enum:
-        - monetary
-        - publication
-        - speaking_engagement
-        - other
-      example: publication
     PageMetadata:
       type: object
       description: The metadata of a page.
@@ -152,6 +133,15 @@ components:
         - totalPages
         - hasNext
         - hasPrevious
+    ChallengeIncentiveType:
+      description: The incentive type of the challenge.
+      type: string
+      enum:
+        - monetary
+        - publication
+        - speaking_engagement
+        - other
+      example: publication
     ChallengeCreateRequest:
       type: object
       description: The information used to create a challenge

--- a/libs/api-spec/build/challenge.openapi.yaml
+++ b/libs/api-spec/build/challenge.openapi.yaml
@@ -133,15 +133,6 @@ components:
         - totalPages
         - hasNext
         - hasPrevious
-    ChallengeIncentiveType:
-      description: The incentive type of the challenge.
-      type: string
-      enum:
-        - monetary
-        - publication
-        - speaking_engagement
-        - other
-      example: publication
     ChallengeCreateRequest:
       type: object
       description: The information used to create a challenge
@@ -153,10 +144,6 @@ components:
           example: Example challenge
         status:
           $ref: '#/components/schemas/ChallengeStatus'
-        incentiveTypes:
-          type: array
-          items:
-            $ref: '#/components/schemas/ChallengeIncentiveType'
         difficulty:
           $ref: '#/components/schemas/ChallengeDifficulty'
       required:

--- a/libs/api-spec/build/challenge.openapi.yaml
+++ b/libs/api-spec/build/challenge.openapi.yaml
@@ -28,6 +28,7 @@ paths:
         - $ref: '#/components/parameters/pageSize'
         - $ref: '#/components/parameters/status'
         - $ref: '#/components/parameters/difficulty'
+        - $ref: '#/components/parameters/incentiveTypes'
       responses:
         '200':
           content:
@@ -77,6 +78,15 @@ components:
         type: array
         items:
           $ref: '#/components/schemas/ChallengeDifficulty'
+    incentiveTypes:
+      name: incentiveTypes
+      description: Array of challenge incentive types used to filter the results.
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/ChallengeIncentiveType'
   schemas:
     ChallengeStatus:
       description: The status of the challenge.
@@ -94,6 +104,15 @@ components:
         - intermediate
         - advanced
       example: intermediate
+    ChallengeIncentiveType:
+      description: The incentive type of the challenge.
+      type: string
+      enum:
+        - monetary
+        - publication
+        - speaking_engagement
+        - other
+      example: publication
     PageMetadata:
       type: object
       description: The metadata of a page.
@@ -144,6 +163,10 @@ components:
           example: Example challenge
         status:
           $ref: '#/components/schemas/ChallengeStatus'
+        incentiveTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChallengeIncentiveType'
         difficulty:
           $ref: '#/components/schemas/ChallengeDifficulty'
       required:

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -32,7 +32,6 @@ paths:
         - $ref: '#/components/parameters/pageSize'
         - $ref: '#/components/parameters/status'
         - $ref: '#/components/parameters/difficulty'
-        - $ref: '#/components/parameters/incentiveTypes'
       responses:
         '200':
           content:
@@ -187,15 +186,6 @@ components:
         - intermediate
         - advanced
       example: intermediate
-    ChallengeIncentiveType:
-      description: The incentive type of the challenge.
-      type: string
-      enum:
-        - monetary
-        - publication
-        - speaking_engagement
-        - other
-      example: publication
     PageMetadata:
       type: object
       description: The metadata of a page.
@@ -235,6 +225,15 @@ components:
         - totalPages
         - hasNext
         - hasPrevious
+    ChallengeIncentiveType:
+      description: The incentive type of the challenge.
+      type: string
+      enum:
+        - monetary
+        - publication
+        - speaking_engagement
+        - other
+      example: publication
     ChallengeCreateRequest:
       type: object
       description: The information used to create a challenge
@@ -587,15 +586,6 @@ components:
         type: array
         items:
           $ref: '#/components/schemas/ChallengeDifficulty'
-    incentiveTypes:
-      name: incentiveTypes
-      description: Array of challenge incentive types used to filter the results.
-      in: query
-      required: false
-      schema:
-        type: array
-        items:
-          $ref: '#/components/schemas/ChallengeIncentiveType'
     organizationLogin:
       name: organizationLogin
       in: path

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -31,6 +31,7 @@ paths:
         - $ref: '#/components/parameters/pageNumber'
         - $ref: '#/components/parameters/pageSize'
         - $ref: '#/components/parameters/status'
+        - $ref: '#/components/parameters/difficulty'
       responses:
         '200':
           content:
@@ -177,6 +178,14 @@ components:
         - active
         - completed
       example: active
+    ChallengeDifficulty:
+      description: The difficulty level of a challenge.
+      type: string
+      enum:
+        - good_for_beginners
+        - intermediate
+        - advanced
+      example: intermediate
     PageMetadata:
       type: object
       description: The metadata of a page.
@@ -227,6 +236,8 @@ components:
           example: Example challenge
         status:
           $ref: '#/components/schemas/ChallengeStatus'
+        difficulty:
+          $ref: '#/components/schemas/ChallengeDifficulty'
       required:
         - name
         - status
@@ -553,6 +564,15 @@ components:
         type: array
         items:
           $ref: '#/components/schemas/ChallengeStatus'
+    difficulty:
+      name: difficulty
+      description: Array of challenge difficulty levels used to filter the results.
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/ChallengeDifficulty'
     organizationLogin:
       name: organizationLogin
       in: path

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -557,7 +557,7 @@ components:
         minimum: 1
     status:
       name: status
-      description: Array of challenge status used to filter the results.
+      description: An array of challenge status used to filter the results.
       in: query
       required: false
       schema:
@@ -566,7 +566,7 @@ components:
           $ref: '#/components/schemas/ChallengeStatus'
     difficulty:
       name: difficulty
-      description: Array of challenge difficulty levels used to filter the results.
+      description: An array of challenge difficulty levels used to filter the results.
       in: query
       required: false
       schema:

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -225,15 +225,6 @@ components:
         - totalPages
         - hasNext
         - hasPrevious
-    ChallengeIncentiveType:
-      description: The incentive type of the challenge.
-      type: string
-      enum:
-        - monetary
-        - publication
-        - speaking_engagement
-        - other
-      example: publication
     ChallengeCreateRequest:
       type: object
       description: The information used to create a challenge
@@ -245,10 +236,6 @@ components:
           example: Example challenge
         status:
           $ref: '#/components/schemas/ChallengeStatus'
-        incentiveTypes:
-          type: array
-          items:
-            $ref: '#/components/schemas/ChallengeIncentiveType'
         difficulty:
           $ref: '#/components/schemas/ChallengeDifficulty'
       required:

--- a/libs/api-spec/build/openapi.yaml
+++ b/libs/api-spec/build/openapi.yaml
@@ -32,6 +32,7 @@ paths:
         - $ref: '#/components/parameters/pageSize'
         - $ref: '#/components/parameters/status'
         - $ref: '#/components/parameters/difficulty'
+        - $ref: '#/components/parameters/incentiveTypes'
       responses:
         '200':
           content:
@@ -186,6 +187,15 @@ components:
         - intermediate
         - advanced
       example: intermediate
+    ChallengeIncentiveType:
+      description: The incentive type of the challenge.
+      type: string
+      enum:
+        - monetary
+        - publication
+        - speaking_engagement
+        - other
+      example: publication
     PageMetadata:
       type: object
       description: The metadata of a page.
@@ -236,6 +246,10 @@ components:
           example: Example challenge
         status:
           $ref: '#/components/schemas/ChallengeStatus'
+        incentiveTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChallengeIncentiveType'
         difficulty:
           $ref: '#/components/schemas/ChallengeDifficulty'
       required:
@@ -573,6 +587,15 @@ components:
         type: array
         items:
           $ref: '#/components/schemas/ChallengeDifficulty'
+    incentiveTypes:
+      name: incentiveTypes
+      description: Array of challenge incentive types used to filter the results.
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/ChallengeIncentiveType'
     organizationLogin:
       name: organizationLogin
       in: path

--- a/libs/api-spec/src/components/parameters/query/challenge/difficulty.yaml
+++ b/libs/api-spec/src/components/parameters/query/challenge/difficulty.yaml
@@ -1,5 +1,5 @@
 name: difficulty
-description: Array of challenge difficulty levels used to filter the results.
+description: An array of challenge difficulty levels used to filter the results.
 in: query
 required: false
 schema:

--- a/libs/api-spec/src/components/parameters/query/challenge/difficulty.yaml
+++ b/libs/api-spec/src/components/parameters/query/challenge/difficulty.yaml
@@ -1,0 +1,8 @@
+name: difficulty
+description: Array of challenge difficulty levels used to filter the results.
+in: query
+required: false
+schema:
+  type: array
+  items:
+    $ref: ../../../schemas/ChallengeDifficulty.yaml

--- a/libs/api-spec/src/components/parameters/query/challenge/incentiveTypes.yaml
+++ b/libs/api-spec/src/components/parameters/query/challenge/incentiveTypes.yaml
@@ -1,0 +1,8 @@
+name: incentiveTypes
+description: Array of challenge incentive types used to filter the results.
+in: query
+required: false
+schema:
+  type: array
+  items:
+    $ref: ../../../schemas/ChallengeIncentiveType.yaml

--- a/libs/api-spec/src/components/parameters/query/challenge/platformIds.yaml
+++ b/libs/api-spec/src/components/parameters/query/challenge/platformIds.yaml
@@ -1,0 +1,8 @@
+name: platformIds
+description: Array of challenge platform ids used to filter the results.
+in: query
+required: false
+schema:
+  type: array
+  items:
+    $ref: ../../../schemas/ChallengePlatformId.yaml

--- a/libs/api-spec/src/components/parameters/query/challenge/status.yaml
+++ b/libs/api-spec/src/components/parameters/query/challenge/status.yaml
@@ -1,5 +1,5 @@
 name: status
-description: Array of challenge status used to filter the results.
+description: An array of challenge status used to filter the results.
 in: query
 required: false
 schema:

--- a/libs/api-spec/src/components/schemas/ChallengeCreateRequest.yaml
+++ b/libs/api-spec/src/components/schemas/ChallengeCreateRequest.yaml
@@ -20,24 +20,24 @@ properties:
   #     format: url
   status:
     $ref: ChallengeStatus.yaml
-#   startDate:
-#     type: string
-#     format: date
-#     nullable: true
-#   endDate:
-#     type: string
-#     format: date
-#     nullable: true
-#   incentiveTypes:
-#     type: array
-#     items:
-#       $ref: ChallengeIncentiveType.yaml
-#     nullable: true
-#   platformId:
-#     $ref: ChallengePlatformId.yaml
-#     nullable: true
-#   difficulty:
-#     $ref: ChallengeDifficulty.yaml
+  #   startDate:
+  #     type: string
+  #     format: date
+  #     nullable: true
+  #   endDate:
+  #     type: string
+  #     format: date
+  #     nullable: true
+  #   incentiveTypes:
+  #     type: array
+  #     items:
+  #       $ref: ChallengeIncentiveType.yaml
+  #     nullable: true
+  #   platformId:
+  #     $ref: ChallengePlatformId.yaml
+  #     nullable: true
+  difficulty:
+    $ref: ChallengeDifficulty.yaml
 #   submissionTypes:
 #     type: array
 #     items:

--- a/libs/api-spec/src/components/schemas/ChallengeCreateRequest.yaml
+++ b/libs/api-spec/src/components/schemas/ChallengeCreateRequest.yaml
@@ -20,18 +20,18 @@ properties:
   #     format: url
   status:
     $ref: ChallengeStatus.yaml
-  #   startDate:
-  #     type: string
-  #     format: date
-  #     nullable: true
-  #   endDate:
-  #     type: string
-  #     format: date
-  #     nullable: true
-  #   incentiveTypes:
-  #     type: array
-  #     items:
-  #       $ref: ChallengeIncentiveType.yaml
+    #   startDate:
+    #     type: string
+    #     format: date
+    #     nullable: true
+    #   endDate:
+    #     type: string
+    #     format: date
+    #     nullable: true
+  incentiveTypes:
+    type: array
+    items:
+      $ref: ChallengeIncentiveType.yaml
   #     nullable: true
   #   platformId:
   #     $ref: ChallengePlatformId.yaml

--- a/libs/api-spec/src/components/schemas/ChallengeCreateRequest.yaml
+++ b/libs/api-spec/src/components/schemas/ChallengeCreateRequest.yaml
@@ -28,10 +28,10 @@ properties:
     #     type: string
     #     format: date
     #     nullable: true
-  incentiveTypes:
-    type: array
-    items:
-      $ref: ChallengeIncentiveType.yaml
+  # incentiveTypes:
+  #   type: array
+  #   items:
+  #     $ref: ChallengeIncentiveType.yaml
   #     nullable: true
   #   platformId:
   #     $ref: ChallengePlatformId.yaml

--- a/libs/api-spec/src/components/schemas/ChallengeDifficulty.yaml
+++ b/libs/api-spec/src/components/schemas/ChallengeDifficulty.yaml
@@ -1,7 +1,7 @@
-description: The difficulty level of a challenge
+description: The difficulty level of a challenge.
 type: string
 enum:
-  - GoodForBeginners
-  - Intermediate
-  - Advanced
-example: Intermediate
+  - good_for_beginners
+  - intermediate
+  - advanced
+example: intermediate

--- a/libs/api-spec/src/components/schemas/ChallengeIncentiveType.yaml
+++ b/libs/api-spec/src/components/schemas/ChallengeIncentiveType.yaml
@@ -1,8 +1,8 @@
-description: The incentive type of the challenge
+description: The incentive type of the challenge.
 type: string
 enum:
-  - Monetary
-  - Publication
-  - SpeakingEngagement
-  - Other
-example: Monetary
+  - monetary
+  - publication
+  - speaking_engagement
+  - other
+example: publication

--- a/libs/api-spec/src/paths/challenges.yaml
+++ b/libs/api-spec/src/paths/challenges.yaml
@@ -48,7 +48,7 @@ get:
     # - $ref: parameters/challenge/platformIds.yaml
     - $ref: ../components/parameters/query/challenge/difficulty.yaml
     # - $ref: parameters/challenge/submissionTypes.yaml
-    # - $ref: parameters/challenge/incentiveTypes.yaml
+    - $ref: ../components/parameters/query/challenge/incentiveTypes.yaml
     # - $ref: parameters/challenge/startDateRange.yaml
     # - $ref: parameters/challenge/orgIds.yaml
     # - $ref: parameters/challenge/organizerIds.yaml

--- a/libs/api-spec/src/paths/challenges.yaml
+++ b/libs/api-spec/src/paths/challenges.yaml
@@ -37,18 +37,18 @@ get:
   parameters:
     - $ref: ../components/parameters/query/pageNumber.yaml
     - $ref: ../components/parameters/query/pageSize.yaml
-    # - $ref: parameters/limit.yaml
-    # - $ref: parameters/offset.yaml
     # - $ref: parameters/sort.yaml
     # - $ref: parameters/direction.yaml
     # - $ref: parameters/searchTerms.yaml
     # - $ref: parameters/topics.yaml
     # - $ref: parameters/inputDataTypes.yaml
     - $ref: ../components/parameters/query/challenge/status.yaml
-    # - $ref: parameters/challenge/platformIds.yaml
+    # - $ref: ../components/parameters/query/challenge/platformIds.yaml
     - $ref: ../components/parameters/query/challenge/difficulty.yaml
     # - $ref: parameters/challenge/submissionTypes.yaml
-    - $ref: ../components/parameters/query/challenge/incentiveTypes.yaml
+
+    # - $ref: ../components/parameters/query/challenge/incentiveTypes.yaml
+
     # - $ref: parameters/challenge/startDateRange.yaml
     # - $ref: parameters/challenge/orgIds.yaml
     # - $ref: parameters/challenge/organizerIds.yaml

--- a/libs/api-spec/src/paths/challenges.yaml
+++ b/libs/api-spec/src/paths/challenges.yaml
@@ -46,7 +46,7 @@ get:
     # - $ref: parameters/inputDataTypes.yaml
     - $ref: ../components/parameters/query/challenge/status.yaml
     # - $ref: parameters/challenge/platformIds.yaml
-    # - $ref: parameters/challenge/difficulty.yaml
+    - $ref: ../components/parameters/query/challenge/difficulty.yaml
     # - $ref: parameters/challenge/submissionTypes.yaml
     # - $ref: parameters/challenge/incentiveTypes.yaml
     # - $ref: parameters/challenge/startDateRange.yaml

--- a/libs/api-spec/src/paths/parameters/challenge/difficulty.yaml
+++ b/libs/api-spec/src/paths/parameters/challenge/difficulty.yaml
@@ -1,8 +1,0 @@
-name: difficulty
-description: Array of challenge difficulty levels used to filter the results
-in: query
-required: false
-schema:
-  type: array
-  items:
-    $ref: ../../../components/schemas/ChallengeDifficulty.yaml

--- a/libs/api-spec/src/paths/parameters/challenge/incentiveTypes.yaml
+++ b/libs/api-spec/src/paths/parameters/challenge/incentiveTypes.yaml
@@ -1,8 +1,0 @@
-name: incentiveTypes
-description: Array of challenge incentive types used to filter the results
-in: query
-required: false
-schema:
-  type: array
-  items:
-    $ref: ../../../components/schemas/ChallengeIncentiveType.yaml

--- a/libs/api-spec/src/paths/parameters/challenge/platformIds.yaml
+++ b/libs/api-spec/src/paths/parameters/challenge/platformIds.yaml
@@ -1,8 +1,0 @@
-name: platformIds
-description: Array of challenge platform ids used to filter the results
-in: query
-required: false
-schema:
-  type: array
-  items:
-    $ref: ../../../components/schemas/ChallengePlatformId.yaml

--- a/libs/api-spec/src/paths/parameters/challenge/status.yaml
+++ b/libs/api-spec/src/paths/parameters/challenge/status.yaml
@@ -1,8 +1,0 @@
-name: status
-description: Array of challenge status used to filter the results
-in: query
-required: false
-schema:
-  type: array
-  items:
-    $ref: ../../../components/schemas/ChallengeStatus.yaml

--- a/libs/api-spec/src/paths/parameters/limit.yaml
+++ b/libs/api-spec/src/paths/parameters/limit.yaml
@@ -1,9 +1,0 @@
-name: limit
-description: Maximum number of results returned
-in: query
-required: false
-schema:
-  type: integer
-  default: 10
-  minimum: 10
-  maximum: 100

--- a/libs/api-spec/src/paths/parameters/offset.yaml
+++ b/libs/api-spec/src/paths/parameters/offset.yaml
@@ -1,8 +1,0 @@
-name: offset
-description: Index of the first result that must be returned
-in: query
-required: false
-schema:
-  type: integer
-  default: 0
-  minimum: 0


### PR DESCRIPTION
Fixes #1029 

## Changelog

- Update Challenge OA description
  - Add property `Challenge.difficulty` and corresponding query filter
- Submitted [this issue](https://github.com/OpenAPITools/openapi-generator/issues/14302) to the OA generator project
- Implement a custom repository for Challenges that enables to write advanced queries with `querydsl`.