### PR TITLE
feat: Add python3-dev to dev container

### DIFF
--- a/tools/devcontainers/challenge/.devcontainer/Dockerfile
+++ b/tools/devcontainers/challenge/.devcontainer/Dockerfile
@@ -25,7 +25,7 @@ RUN groupadd docker \
   && apt-get update -qq -y && export DEBIAN_FRONTEND=noninteractive \
   && apt-get install --no-install-recommends -qq -y \
     ca-certificates curl git bash-completion gnupg2 lsb-release ssh sudo \
-    python3-pip python-is-python3 openjdk-17-jdk \
+    python3-pip python3-dev python-is-python3 openjdk-17-jdk \
     htop unzip vim wget lsof iproute2 build-essential \
   # Add Node.js repository
   && curl -sL https://deb.nodesource.com/setup_18.x | bash - \


### PR DESCRIPTION
## Changelog

- Add `python3-dev` to the dev container, required to install uWSGI in Python projects.