### PR TITLE
feat: Add OpenSearch and OpenSearch Dashboards to the Challenge Registry

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,8 +40,6 @@
     3306,
     4200,
     4211,
-    5000,
-    5044,
     5432,
     5601,
     7010,
@@ -61,7 +59,6 @@
     8091,
     8092,
     9200,
-    9300,
     9600,
     27017
   ],
@@ -79,20 +76,12 @@
       "label": "nx graph",
       "onAutoForward": "silent"
     },
-    "5000": {
-      "label": "challenge-logstash (TCP input)",
-      "onAutoForward": "silent"
-    },
-    "5044": {
-      "label": "challenge-logstash (Beats input)",
-      "onAutoForward": "silent"
-    },
     "5432": {
       "label": "challenge-registry-postgres",
       "onAutoForward": "silent"
     },
     "5601": {
-      "label": "challenge-kibana",
+      "label": "challenge-registry-opensearch-dashboards",
       "onAutoForward": "silent"
     },
     "7010": {
@@ -160,15 +149,11 @@
       "onAutoForward": "silent"
     },
     "9200": {
-      "label": "challenge-elasticsearch (HTTP)",
-      "onAutoForward": "silent"
-    },
-    "9300": {
-      "label": "challenge-elasticsearch (TCP transport)",
+      "label": "challenge-registry-opensearch",
       "onAutoForward": "silent"
     },
     "9600": {
-      "label": "challenge-logstash (monitoring API)",
+      "label": "challenge-registry-opensearch (Performance Analyzer)",
       "onAutoForward": "silent"
     },
     "27017": {

--- a/apps/challenge-registry/opensearch-dashboards/.env.example
+++ b/apps/challenge-registry/opensearch-dashboards/.env.example
@@ -1,0 +1,1 @@
+OPENSEARCH_HOSTS='["https://challenge-registry-opensearch:9200"]'

--- a/apps/challenge-registry/opensearch-dashboards/Dockerfile
+++ b/apps/challenge-registry/opensearch-dashboards/Dockerfile
@@ -1,0 +1,1 @@
+FROM opensearchproject/opensearch-dashboards:1.3.7

--- a/apps/challenge-registry/opensearch-dashboards/docker-compose.yml
+++ b/apps/challenge-registry/opensearch-dashboards/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.8"
+
+services:
+  challenge-registry-opensearch-dashboards:
+    image: sagebionetworks/challenge-registry-opensearch-dashboards:latest
+    container_name: challenge-registry-opensearch-dashboards
+    restart: always
+    env_file:
+      - .env
+    # volumes:
+    #   - challenge-registry-opensearch-dashboards:/data/db
+    #   - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+    networks:
+      - challenge-registry
+    ports:
+     - "5601:5601"
+
+# volumes:
+#   challenge-registry-opensearch-dashboards:
+#     name: challenge-registry-opensearch-dashboards
+
+networks:
+  challenge-registry:
+    name: challenge-registry

--- a/apps/challenge-registry/opensearch-dashboards/project.json
+++ b/apps/challenge-registry/opensearch-dashboards/project.json
@@ -1,0 +1,40 @@
+{
+  "name": "challenge-registry-opensearch-dashboards",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/challenge-registry-opensearch-dashboards/src",
+  "projectType": "application",
+  "targets": {
+    "prepare": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "shx cp -n .env.example .env",
+        "cwd": "apps/challenge-registry/opensearch-dashboards"
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker compose up",
+        "cwd": "apps/challenge-registry/opensearch-dashboards"
+      },
+      "dependsOn": ["prepare", "build-image"]
+    },
+    "serve-detach": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker compose up -d",
+        "cwd": "apps/challenge-registry/opensearch-dashboards"
+      },
+      "dependsOn": ["prepare", "build-image"]
+    },
+    "build-image": {
+      "executor": "@nx-tools/nx-docker:build",
+      "options": {
+        "context": "apps/challenge-registry/opensearch-dashboards",
+        "push": false,
+        "tags": ["sagebionetworks/challenge-registry-opensearch-dashboards:latest"]
+      }
+    }
+  },
+  "tags": ["type:db", "scope:backend"]
+}

--- a/apps/challenge-registry/opensearch/.env.example
+++ b/apps/challenge-registry/opensearch/.env.example
@@ -1,0 +1,1 @@
+discovery.type=single-node

--- a/apps/challenge-registry/opensearch/Dockerfile
+++ b/apps/challenge-registry/opensearch/Dockerfile
@@ -1,0 +1,1 @@
+FROM opensearchproject/opensearch:1.3.7

--- a/apps/challenge-registry/opensearch/docker-compose.yml
+++ b/apps/challenge-registry/opensearch/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.8"
+
+services:
+  challenge-registry-opensearch:
+    image: sagebionetworks/challenge-registry-opensearch:latest
+    container_name: challenge-registry-opensearch
+    restart: always
+    env_file:
+      - .env
+    # volumes:
+    #   - challenge-registry-opensearch:/data/db
+    #   - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+    networks:
+      - challenge-registry
+    ports:
+      - "9200:9200"
+      - "9600:9600"
+
+# volumes:
+#   challenge-registry-opensearch:
+#     name: challenge-registry-opensearch
+
+networks:
+  challenge-registry:
+    name: challenge-registry

--- a/apps/challenge-registry/opensearch/docker-compose.yml
+++ b/apps/challenge-registry/opensearch/docker-compose.yml
@@ -13,8 +13,8 @@ services:
     networks:
       - challenge-registry
     ports:
-      - "9200:9200"
-      - "9600:9600"
+      - "9200:9200"  # REST API
+      - "9600:9600"  # Performance Analyzer
 
 # volumes:
 #   challenge-registry-opensearch:

--- a/apps/challenge-registry/opensearch/project.json
+++ b/apps/challenge-registry/opensearch/project.json
@@ -1,0 +1,40 @@
+{
+  "name": "challenge-registry-opensearch",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/challenge-registry-opensearch/src",
+  "projectType": "application",
+  "targets": {
+    "prepare": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "shx cp -n .env.example .env",
+        "cwd": "apps/challenge-registry/opensearch"
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker compose up",
+        "cwd": "apps/challenge-registry/opensearch"
+      },
+      "dependsOn": ["prepare", "build-image"]
+    },
+    "serve-detach": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker compose up -d",
+        "cwd": "apps/challenge-registry/opensearch"
+      },
+      "dependsOn": ["prepare", "build-image"]
+    },
+    "build-image": {
+      "executor": "@nx-tools/nx-docker:build",
+      "options": {
+        "context": "apps/challenge-registry/opensearch",
+        "push": false,
+        "tags": ["sagebionetworks/challenge-registry-opensearch:latest"]
+      }
+    }
+  },
+  "tags": ["type:db", "scope:backend"]
+}

--- a/tools/configure-hostnames.sh
+++ b/tools/configure-hostnames.sh
@@ -12,6 +12,7 @@ declare -a hostnames=(
   "127.0.0.1 challenge-registry-keycloak"
   "127.0.0.1 challenge-registry-mariadb"
   "127.0.0.1 challenge-registry-mongo"
+  "127.0.0.1 challenge-registry-opensearch"
   "127.0.0.1 challenge-registry-organization-service"
   "127.0.0.1 challenge-registry-postgres"
   "127.0.0.1 challenge-registry-rabbitmq"


### PR DESCRIPTION
Fixes #1105 

## Changelog

- Add the project `challenge-registry-opensearch`
  - Use version 1.x of OpenSearch because version 2.x is not documented as being [supported by Hibernate Search](https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/#elasticsearch-integration)
- Add the project `challenge-registry-opensearch-dashboards`
- Reserve ports for OpenSearch and OpenSearch Dashboards
  - They are a subset of the ports previously defined for ELK

## Preview

### OpenSearch

Start OpenSearch:

```console
nx serve challenge-registry-opensearch
```

Run the test requests provided on Docker Hub:

```console
$ curl -XGET https://localhost:9200 -u admin:admin --insecure
{
  "name" : "5d8f395238cd",
  "cluster_name" : "docker-cluster",
  "cluster_uuid" : "6KDbY2zaRsShlxZmvk-0Dw",
  "version" : {
    "distribution" : "opensearch",
    "number" : "1.3.7",
    "build_type" : "tar",
    "build_hash" : "db18a0d5a08b669fb900c00d81462e221f4438ee",
    "build_date" : "2022-12-07T22:59:20.186520Z",
    "build_snapshot" : false,
    "lucene_version" : "8.10.1",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}

$ curl -XGET https://localhost:9200/_cat/nodes?v -u admin:admin --insecure
ip         heap.percent ram.percent cpu load_1m load_5m load_15m node.role master name
172.19.0.7           31          98  71    2.06    1.43     1.44 dimr      *      5d8f395238cd

$ curl -XGET https://localhost:9200/_cat/plugins?v -u admin:admin --insecure
name         component                            version
5d8f395238cd opensearch-alerting                  1.3.7.0
5d8f395238cd opensearch-anomaly-detection         1.3.7.0
5d8f395238cd opensearch-asynchronous-search       1.3.7.0
5d8f395238cd opensearch-cross-cluster-replication 1.3.7.0
5d8f395238cd opensearch-index-management          1.3.7.0
5d8f395238cd opensearch-job-scheduler             1.3.7.0
5d8f395238cd opensearch-knn                       1.3.7.0
5d8f395238cd opensearch-ml                        1.3.7.0
5d8f395238cd opensearch-observability             1.3.7.0
5d8f395238cd opensearch-performance-analyzer      1.3.7.0
5d8f395238cd opensearch-reports-scheduler         1.3.7.0
5d8f395238cd opensearch-security                  1.3.7.0
5d8f395238cd opensearch-sql                       1.3.7.0
```

### OpenSearch Dashboards

Start OpenSearch Dashboards:

```console
nx serve challenge-registry-opensearch-dashboards
```

Access the Dashboards on http://localhost:5601

Default credentials defined by OpenSearch: `admin/admin`

![image](https://user-images.githubusercontent.com/3056480/210196129-3cdafefe-e74f-4f9a-9ad0-0ef0f1a07990.png)
