### PR TITLE
feat(openchallenges): add a resource for mcp server (SMR-167)

### DIFF
--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/EdamConceptResourceService.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/EdamConceptResourceService.java
@@ -1,0 +1,70 @@
+package org.sagebionetworks.openchallenges.mcp.server;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.List;
+import org.sagebionetworks.openchallenges.api.client.api.EdamConceptApi;
+import org.sagebionetworks.openchallenges.api.client.model.EdamConceptSearchQuery;
+import org.sagebionetworks.openchallenges.api.client.model.EdamConceptsPage;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Service;
+
+@Service
+@Configuration
+public class EdamConceptResourceService {
+
+  private final EdamConceptApi edamConceptApi;
+  private final ObjectMapper objectMapper;
+
+  public EdamConceptResourceService(EdamConceptApi edamConceptApi, ObjectMapper objectMapper) {
+    this.edamConceptApi = edamConceptApi;
+    this.objectMapper = objectMapper;
+  }
+
+  @Bean
+  public List<McpServerFeatures.SyncResourceSpecification> edamConceptResources() {
+    var edamConceptResource = new McpSchema.Resource(
+      "list_edam_concepts",
+      "List EDAM Concepts",
+      "List EDAM ontology for bioinformatics data types, formats, operations, and topics",
+      "application/json",
+      null
+    );
+
+    var resourceSpecification = new McpServerFeatures.SyncResourceSpecification(
+      edamConceptResource,
+      (exchange, request) -> {
+        try {
+          EdamConceptSearchQuery query = new EdamConceptSearchQuery();
+          EdamConceptsPage result = edamConceptApi.listEdamConcepts(query);
+          String jsonContent = objectMapper.writeValueAsString(result);
+
+          return new McpSchema.ReadResourceResult(
+            List.of(
+              new McpSchema.TextResourceContents(request.uri(), "application/json", jsonContent)
+            )
+          );
+        } catch (Exception e) {
+          throw new RuntimeException("Failed to retrieve EDAM concepts: " + e.getMessage(), e);
+        }
+      }
+    );
+
+    return List.of(resourceSpecification);
+  }
+  // @Bean
+  // public List<McpSchema.ResourceTemplate> edamConceptResourceTemplates() {
+  //   return List.of(
+  //     new McpSchema.ResourceTemplate(
+  //       "list_edam_concepts?searchTerms={searchTerms}&sections={sections}&pageSize={pageSize}&ids={ids}",
+  //       "List EDAM Concepts with Parameters",
+  //       "List EDAM ontology concepts. Parameters: searchTerms (text search), sections (data/format/operation/topic), pageSize (limit results), ids (specific concept IDs)",
+  //       "application/json",
+  //       null
+  //     )
+  //   );
+  // }
+}


### PR DESCRIPTION
## Description

This pr explored treating API responses using EDAM concept search as a [resources](https://modelcontextprotocol.io/docs/concepts/resources) instead of [tools](https://modelcontextprotocol.io/docs/concepts/tools). 

## Related Issue

Closes https://sagebionetworks.jira.com/browse/SMR-167

## Changelog

<!-- Itemize the changes made in this PR. -->

- Add a resource to get static response from the `/edamConcepts` endpoint

## Preview

Although I can successfully to implement a resource to retrieve the edam concepts data using API endpoint, following the [spring AI code snippet example](https://spec.modelcontextprotocol.io/specification/2024-11-05/server/resources/) how to manage a resource, I was not able to register the [Resource Template](https://modelcontextprotocol.io/docs/concepts/resources#resource-templates) (for dynamic API response), aka not able to make it discoverable or usable in MCP clients.

This PR only adds a [direct resource](https://modelcontextprotocol.io/docs/concepts/resources#direct-resources) for static data. Based on testing, in order to use a resource in practice, users need to manually add the resource from the MCP server, as shown below on Claude Desktop or [MCP support for resources](https://code.visualstudio.com/updates/v1_101#_mcp-support-for-resources) on VScode.

<img width="830" alt="Screen Shot 2025-06-11 at 2 31 42 PM" src="https://github.com/user-attachments/assets/6b81c859-e491-43b6-bfe8-abefa9e46ac7" />

This call will fetch the resource and attach the response (as plain text) to the chat context, making it available for downstream use by LLMs.

#### Some Observations

- It seems tools has higher priority over attached resources.
- The MCP ecosystem currently lacks clear tutorials or examples to make resource template (dynamic API response) exposed to MCP clients for LLM to decide which dynamic parameters to use.

I think currently using tools for challenge discovery for our case is more straightforward when LLM can automatically detect available tools without manually adding to each conversation like resource. it'd better to continue to add functionality as tools, until more support and documentation are provided for resource for API response using spring AI. 




