### PR TITLE
chore(openchallenges): update openchallenges-app base Docker image to Node.js 22 (SMR-200)

### DIFF
--- a/apps/openchallenges/app/Dockerfile
+++ b/apps/openchallenges/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.7.0-alpine
+FROM node:22.17.0-alpine3.21
 
 ENV APP_DIR=/opt/app
 


### PR DESCRIPTION
## Description

Align the major version number of Node.js used as the base Docker image of the OC web app to the version installed inside the dev environment. The update also fixes a [critical CVE.](https://hub.docker.com/layers/library/node/20.7.0-alpine/images/sha256-ad38de8de343e0fed46efcb5b8df47f4996da2a3fb359eef3f53243b1670b50e)

## Related Issue

- [SMR-200](https://sagebionetworks.jira.com/browse/SMR-200)

## Changelog

- Update openchallenges-app base Docker image to Node.js 22.

## Preview

```
$ node --version
v22.15.0
```


[SMR-200]: https://sagebionetworks.jira.com/browse/SMR-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ