### PR TITLE
fix(sage-monorepo): add `nx.instructions.md` to `.prettierignore`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -20,6 +20,7 @@ pnpm-lock.yaml
 great_expectations
 
 # Nx
+/.github/instructions/nx.instructions.md
 /.nx/cache
 /.nx/workspace-data
 


### PR DESCRIPTION
## Description

Add `nx.instructions.md` to `.prettierignore` to prevent infinite formatting loop.

## Details

The file `nx.instructions.md` is generated by the Nx VS Code extension. The file was initially added to `.gitignore` by Nx. I decided to track this file with git to detect changes to it and ensure we all use the same one. Because of our pre-commit hook that run prettier on md files, the file was stuck in an infinite loop that kept it "changed": Nx generates the file, the file is formatted before commit, Nx regenerate the file (most of the time just with a different format), the file is staged and formatted by the pre-commit hook, etc.

If the Nx VS Code extension modifies `nx.instructions.md` too often, which would require a PR to update, it may then be preferable to add it back to `.gitignore`. We will cross this bridge when we are there.