### PR TITLE
refactor(sage-monorepo): centralize all Posgres images minus the image of `iatlas-postgres`

### DIFF
--- a/apps/bixarena/postgres/Dockerfile
+++ b/apps/bixarena/postgres/Dockerfile
@@ -1,5 +1,0 @@
-FROM mirror.gcr.io/postgres:16.9-bullseye
-
-COPY docker-healthcheck /usr/local/bin/
-
-HEALTHCHECK CMD ["docker-healthcheck"]

--- a/apps/bixarena/postgres/project.json
+++ b/apps/bixarena/postgres/project.json
@@ -17,5 +17,5 @@
       }
     }
   },
-  "tags": ["type:db", "scope:backend"]
+  "tags": ["type:db", "scope:backend", "container-image:postgres"]
 }


### PR DESCRIPTION
## Description

Centralize all Posgres images minus the image of `iatlas-postgres`.