### PR TITLE
chore(sage-monorepo): use chat.tools.terminal.autoApprove instead (SMR-388)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -123,7 +123,7 @@
   "rewrap.wrappingColumn": 100,
   "jest.runMode": "on-demand",
   "nxConsole.generateAiAgentRules": true,
-  "github.copilot.chat.agent.terminal.allowList": {
+  "chat.tools.terminal.autoApprove": {
     "/^(?:\\.\\/)?gradlew(?:\\s+.+)?$/": true,
     "cat": true,
     "cd": true,
@@ -135,16 +135,14 @@
     "git status": true,
     "grep": true,
     "ls": true,
-    "pwd": true
-  },
-  "github.copilot.chat.agent.terminal.denyList": {
-    "rm": true,
-    "rmdir": true,
-    "kill": true,
-    "curl": true,
-    "wget": true,
-    "eval": true,
-    "chmod": true,
-    "chown": true
+    "pwd": true,
+    "rm": false,
+    "rmdir": false,
+    "kill": false,
+    "curl": false,
+    "wget": false,
+    "eval": false,
+    "chmod": false,
+    "chown": false
   }
 }


### PR DESCRIPTION
## Description

Use `chat.tools.terminal.autoApprove` instead of `github.copilot.chat.agent.terminal.allowList` to [auto-approve terminal commands](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_autoapprove-terminal-commands). 

## Related Issue

[SMR-388](https://sagebionetworks.jira.com/browse/SMR-388)

## Changelog

- Use `chat.tools.terminal.autoApprove` instead of `github.copilot.chat.agent.terminal.allowList`

[SMR-388]: https://sagebionetworks.jira.com/browse/SMR-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ