### PR TITLE
feat(model-ad): update search tile wording (MG-366)

### DIFF
--- a/apps/model-ad/app/e2e/search.spec.ts
+++ b/apps/model-ad/app/e2e/search.spec.ts
@@ -93,7 +93,11 @@ test.describe('search', () => {
   test('can search using home card input', async ({ page }) => {
     const model = 'APOE4';
     await page.goto('/');
-    const searchListItems = await searchAndGetSearchListItems(model, page, 'Find model by name...');
+    const searchListItems = await searchAndGetSearchListItems(
+      model,
+      page,
+      'Find model by name or ID...',
+    );
     await expect(searchListItems.first()).toHaveText(model);
   });
 

--- a/libs/model-ad/home/src/lib/home.component.html
+++ b/libs/model-ad/home/src/lib/home.component.html
@@ -23,11 +23,11 @@
         <explorers-home-card
           [title]="'Model Search'"
           [description]="
-            'Find a model organism by name to get detailed information and additional experimental results, including pathology results and biomarker evidence.'
+            'Find a model by name, JAX ID, or RRID to view detailed information and experimental results.'
           "
         >
           <model-ad-search-input
-            [searchPlaceholder]="'Find model by name...'"
+            [searchPlaceholder]="'Find model by name or ID...'"
             [searchImagePath]="'/model-ad-assets/images/mouse.svg'"
             [searchImageAltText]="'mouse icon'"
             [hasThickBorder]="true"

--- a/libs/model-ad/ui/src/lib/components/search-input/search-input.component.spec.ts
+++ b/libs/model-ad/ui/src/lib/components/search-input/search-input.component.spec.ts
@@ -39,7 +39,7 @@ describe('SearchInputComponent', () => {
 
   it('should render with default placeholder', async () => {
     await setup();
-    const searchInput = screen.getByPlaceholderText('Find model by name...');
+    const searchInput = screen.getByPlaceholderText('Find model by name or ID...');
     expect(searchInput).toBeInTheDocument();
   });
 

--- a/libs/model-ad/ui/src/lib/components/search-input/search-input.component.ts
+++ b/libs/model-ad/ui/src/lib/components/search-input/search-input.component.ts
@@ -16,7 +16,7 @@ export class SearchInputComponent {
   router = inject(Router);
   modelService = inject(ModelService);
 
-  searchPlaceholder = input<string>('Find model by name...');
+  searchPlaceholder = input<string>('Find model by name or ID...');
   searchImagePath = input<string | undefined>();
   searchImageAltText = input<string>('');
   hasThickBorder = input<boolean>(false);


### PR DESCRIPTION
## Description

Update search tile wording on the Model-AD home page.

## Related Issue

[MG-366](https://sagebionetworks.jira.com/browse/MG-366)

## Changelog

- Update search tile wording on Model-AD home page

## Preview

dev (current) | this PR (updated)
:---: | :---:
<img width="591" height="326" alt="image" src="https://github.com/user-attachments/assets/4544fe23-80a2-4a2c-b098-1d5e28325109" /> | <img width="577" height="320" alt="image" src="https://github.com/user-attachments/assets/8e2dbf4c-c8c2-40ae-86ea-995eeac1891b" />


[MG-366]: https://sagebionetworks.jira.com/browse/MG-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ