### PR TITLE
chore: remove empty `implicitDependencies` in `project.json` files (SMR-362)

### DIFF
--- a/apps/agora/apex/project.json
+++ b/apps/agora/apex/project.json
@@ -24,6 +24,5 @@
       }
     }
   },
-  "tags": ["type:service", "scope:backend"],
-  "implicitDependencies": []
+  "tags": ["type:service", "scope:backend"]
 }

--- a/apps/agora/data/project.json
+++ b/apps/agora/data/project.json
@@ -39,6 +39,5 @@
       }
     }
   },
-  "tags": ["type:app", "scope:backend", "language:python", "package-manager:uv"],
-  "implicitDependencies": []
+  "tags": ["type:app", "scope:backend", "language:python", "package-manager:uv"]
 }

--- a/apps/agora/mongo/project.json
+++ b/apps/agora/mongo/project.json
@@ -25,6 +25,5 @@
         "color": true
       }
     }
-  },
-  "implicitDependencies": []
+  }
 }

--- a/apps/bixarena/app/project.json
+++ b/apps/bixarena/app/project.json
@@ -65,6 +65,5 @@
       }
     }
   },
-  "tags": ["type:app", "scope:backend", "language:python", "package-manager:uv"],
-  "implicitDependencies": []
+  "tags": ["type:app", "scope:backend", "language:python", "package-manager:uv"]
 }

--- a/apps/model-ad/apex/project.json
+++ b/apps/model-ad/apex/project.json
@@ -24,6 +24,5 @@
       }
     }
   },
-  "tags": ["type:service", "scope:backend"],
-  "implicitDependencies": []
+  "tags": ["type:service", "scope:backend"]
 }

--- a/apps/model-ad/data/project.json
+++ b/apps/model-ad/data/project.json
@@ -39,6 +39,5 @@
       }
     }
   },
-  "tags": ["type:app", "scope:backend", "language:python", "package-manager:uv"],
-  "implicitDependencies": []
+  "tags": ["type:app", "scope:backend", "language:python", "package-manager:uv"]
 }

--- a/apps/model-ad/mongo/project.json
+++ b/apps/model-ad/mongo/project.json
@@ -25,6 +25,5 @@
         "color": true
       }
     }
-  },
-  "implicitDependencies": []
+  }
 }

--- a/apps/openchallenges/infra/project.json
+++ b/apps/openchallenges/infra/project.json
@@ -4,7 +4,6 @@
   "sourceRoot": "apps/openchallenges/infra/src",
   "projectType": "application",
   "tags": ["type:app", "scope:admin"],
-  "implicitDependencies": [],
   "targets": {
     "build": {
       "executor": "@nx/js:tsc",

--- a/apps/openchallenges/thumbor/project.json
+++ b/apps/openchallenges/thumbor/project.json
@@ -25,6 +25,5 @@
       }
     }
   },
-  "tags": ["type:service", "scope:backend"],
-  "implicitDependencies": []
+  "tags": ["type:service", "scope:backend"]
 }

--- a/libs/agora/about/project.json
+++ b/libs/agora/about/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/agora/about/src",
   "prefix": "agora",
   "tags": ["type:feature", "scope:agora", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/agora/charts/project.json
+++ b/libs/agora/charts/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/agora/charts/src",
   "prefix": "agora",
   "tags": ["type:feature", "scope:agora", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/agora/config/project.json
+++ b/libs/agora/config/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/agora/config/src",
   "prefix": "agora",
   "tags": ["type:feature", "scope:agora", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/agora/gene-comparison-tool/project.json
+++ b/libs/agora/gene-comparison-tool/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/agora/gene-comparison-tool/src",
   "prefix": "agora",
   "tags": ["type:feature", "scope:agora", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/agora/genes/project.json
+++ b/libs/agora/genes/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/agora/genes/src",
   "prefix": "agora",
   "tags": ["type:feature", "scope:agora", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/agora/home/project.json
+++ b/libs/agora/home/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/agora/home/src",
   "prefix": "agora",
   "tags": ["type:feature", "scope:agora", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/agora/news/project.json
+++ b/libs/agora/news/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/agora/news/src",
   "prefix": "agora",
   "tags": ["type:feature", "scope:agora", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/agora/nominated-targets/project.json
+++ b/libs/agora/nominated-targets/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/agora/nominated-targets/src",
   "prefix": "agora",
   "tags": ["type:feature", "scope:agora", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/agora/not-found/project.json
+++ b/libs/agora/not-found/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/agora/not-found/src",
   "prefix": "agora",
   "tags": ["type:feature", "scope:agora", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/agora/services/project.json
+++ b/libs/agora/services/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/agora/services/src",
   "prefix": "agora",
   "tags": ["type:services", "scope:agora", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/agora/shared/project.json
+++ b/libs/agora/shared/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/agora/shared/src",
   "prefix": "agora",
   "tags": ["type:feature", "scope:agora", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/agora/teams/project.json
+++ b/libs/agora/teams/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/agora/teams/src",
   "prefix": "agora",
   "tags": ["type:feature", "scope:agora", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/agora/testing/project.json
+++ b/libs/agora/testing/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/agora/testing/src",
   "prefix": "agora",
   "tags": ["type:feature", "scope:agora", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/agora/themes/project.json
+++ b/libs/agora/themes/project.json
@@ -5,6 +5,5 @@
   "projectType": "library",
   "generators": {},
   "targets": {},
-  "tags": ["type:themes", "scope:agora", "language:typescript"],
-  "implicitDependencies": []
+  "tags": ["type:themes", "scope:agora", "language:typescript"]
 }

--- a/libs/agora/ui/project.json
+++ b/libs/agora/ui/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/agora/ui/src",
   "prefix": "agora",
   "tags": ["type:feature", "scope:agora", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/agora/util/project.json
+++ b/libs/agora/util/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/agora/util/src",
   "prefix": "agora",
   "tags": ["type:util", "scope:agora", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/explorers/comparison-tools/project.json
+++ b/libs/explorers/comparison-tools/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/explorers/comparison-tools/src",
   "prefix": "explorers",
   "tags": ["type:feature", "scope:explorers", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/explorers/constants/project.json
+++ b/libs/explorers/constants/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/explorers/constants/src",
   "prefix": "explorers",
   "tags": ["type:feature", "scope:explorers", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/explorers/models/project.json
+++ b/libs/explorers/models/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/explorers/models/src",
   "prefix": "explorers",
   "tags": ["type:feature", "scope:explorers", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/explorers/services/project.json
+++ b/libs/explorers/services/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/explorers/services/src",
   "prefix": "explorers",
   "tags": ["type:services", "scope:explorers", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/explorers/shared/project.json
+++ b/libs/explorers/shared/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/explorers/shared/src",
   "prefix": "explorers",
   "tags": ["type:feature", "scope:explorers", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/explorers/testing/project.json
+++ b/libs/explorers/testing/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/explorers/testing/src",
   "prefix": "explorers",
   "tags": ["type:feature", "scope:explorers", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/explorers/themes/project.json
+++ b/libs/explorers/themes/project.json
@@ -5,6 +5,5 @@
   "projectType": "library",
   "generators": {},
   "targets": {},
-  "tags": ["type:themes", "scope:explorers", "language:typescript"],
-  "implicitDependencies": []
+  "tags": ["type:themes", "scope:explorers", "language:typescript"]
 }

--- a/libs/explorers/ui/project.json
+++ b/libs/explorers/ui/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/explorers/ui/src",
   "prefix": "explorers",
   "tags": ["type:feature", "scope:explorers", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/explorers/util/project.json
+++ b/libs/explorers/util/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/explorers/util/src",
   "prefix": "explorers",
   "tags": ["type:feature", "scope:explorers", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/model-ad/config/project.json
+++ b/libs/model-ad/config/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/model-ad/config/src",
   "prefix": "model-ad",
   "tags": ["type:feature", "scope:model-ad", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/model-ad/disease-correlation-comparison-tool/project.json
+++ b/libs/model-ad/disease-correlation-comparison-tool/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/model-ad/disease-correlation-comparison-tool/src",
   "prefix": "model-ad",
   "tags": ["type:feature", "scope:model-ad", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/model-ad/gene-expression-comparison-tool/project.json
+++ b/libs/model-ad/gene-expression-comparison-tool/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/model-ad/gene-expression-comparison-tool/src",
   "prefix": "model-ad",
   "tags": ["type:feature", "scope:model-ad", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/model-ad/home/project.json
+++ b/libs/model-ad/home/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/model-ad/home/src",
   "prefix": "model-ad",
   "tags": ["type:feature", "scope:model-ad", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/model-ad/model-details/project.json
+++ b/libs/model-ad/model-details/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/model-ad/model-details/src",
   "prefix": "model-ad",
   "tags": ["type:feature", "scope:model-ad", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/model-ad/model-overview-comparison-tool/project.json
+++ b/libs/model-ad/model-overview-comparison-tool/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/model-ad/model-overview-comparison-tool/src",
   "prefix": "model-ad",
   "tags": ["type:feature", "scope:model-ad", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/model-ad/services/project.json
+++ b/libs/model-ad/services/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/model-ad/services/src",
   "prefix": "model-ad",
   "tags": ["type:services", "scope:model-ad", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/model-ad/testing/project.json
+++ b/libs/model-ad/testing/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/model-ad/testing/src",
   "prefix": "model-ad",
   "tags": ["type:feature", "scope:model-ad", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/model-ad/themes/project.json
+++ b/libs/model-ad/themes/project.json
@@ -5,6 +5,5 @@
   "projectType": "library",
   "generators": {},
   "targets": {},
-  "tags": ["type:themes", "scope:model-ad", "language:typescript"],
-  "implicitDependencies": []
+  "tags": ["type:themes", "scope:model-ad", "language:typescript"]
 }

--- a/libs/model-ad/ui/project.json
+++ b/libs/model-ad/ui/project.json
@@ -22,6 +22,5 @@
       }
     }
   },
-  "tags": ["type:feature", "scope:model-ad", "language:typescript"],
-  "implicitDependencies": []
+  "tags": ["type:feature", "scope:model-ad", "language:typescript"]
 }

--- a/libs/model-ad/util/project.json
+++ b/libs/model-ad/util/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/model-ad/util/src",
   "prefix": "model-ad",
   "tags": ["type:util", "scope:model-ad", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/openchallenges/about/project.json
+++ b/libs/openchallenges/about/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/openchallenges/about/src",
   "prefix": "openchallenges",
   "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/openchallenges/assets/project.json
+++ b/libs/openchallenges/assets/project.json
@@ -5,6 +5,5 @@
   "projectType": "library",
   "generators": {},
   "targets": {},
-  "tags": ["type:assets", "scope:openchallenges", "language:typescript"],
-  "implicitDependencies": []
+  "tags": ["type:assets", "scope:openchallenges", "language:typescript"]
 }

--- a/libs/openchallenges/challenge-search/project.json
+++ b/libs/openchallenges/challenge-search/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/openchallenges/challenge-search/src",
   "prefix": "openchallenges",
   "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/openchallenges/challenge/project.json
+++ b/libs/openchallenges/challenge/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/openchallenges/challenge/src",
   "prefix": "openchallenges",
   "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/openchallenges/config/project.json
+++ b/libs/openchallenges/config/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/openchallenges/config/src",
   "prefix": "openchallenges",
   "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/openchallenges/home/project.json
+++ b/libs/openchallenges/home/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/openchallenges/home/src",
   "prefix": "openchallenges",
   "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/openchallenges/not-found/project.json
+++ b/libs/openchallenges/not-found/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/openchallenges/not-found/src",
   "prefix": "openchallenges",
   "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/openchallenges/org-profile/project.json
+++ b/libs/openchallenges/org-profile/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/openchallenges/org-profile/src",
   "prefix": "openchallenges",
   "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/openchallenges/org-search/project.json
+++ b/libs/openchallenges/org-search/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/openchallenges/org-search/src",
   "prefix": "openchallenges",
   "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/openchallenges/styles/project.json
+++ b/libs/openchallenges/styles/project.json
@@ -5,6 +5,5 @@
   "projectType": "library",
   "generators": {},
   "targets": {},
-  "tags": ["type:styles", "scope:openchallenges", "language:typescript"],
-  "implicitDependencies": []
+  "tags": ["type:styles", "scope:openchallenges", "language:typescript"]
 }

--- a/libs/openchallenges/team/project.json
+++ b/libs/openchallenges/team/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/openchallenges/team/src",
   "prefix": "openchallenges",
   "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/openchallenges/themes/project.json
+++ b/libs/openchallenges/themes/project.json
@@ -5,6 +5,5 @@
   "projectType": "library",
   "generators": {},
   "targets": {},
-  "tags": ["type:themes", "scope:openchallenges", "language:typescript"],
-  "implicitDependencies": []
+  "tags": ["type:themes", "scope:openchallenges", "language:typescript"]
 }

--- a/libs/openchallenges/ui/project.json
+++ b/libs/openchallenges/ui/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/openchallenges/ui/src",
   "prefix": "openchallenges",
   "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/openchallenges/util/project.json
+++ b/libs/openchallenges/util/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/openchallenges/util/src",
   "prefix": "openchallenges",
   "tags": ["type:util", "scope:openchallenges", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/results-visualization-framework/ui/project.json
+++ b/libs/results-visualization-framework/ui/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/results-visualization-framework/ui/src",
   "prefix": "results-visualization-framework",
   "tags": ["type:feature", "scope:results-visualization-framework", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/shared/typescript/charts-angular/project.json
+++ b/libs/shared/typescript/charts-angular/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/shared/typescript/charts-angular/src",
   "prefix": "sage",
   "tags": ["type:util", "scope:shared", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/shared/typescript/charts/project.json
+++ b/libs/shared/typescript/charts/project.json
@@ -5,7 +5,6 @@
   "projectType": "library",
   "prefix": "sage",
   "tags": ["type:util", "scope:shared", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "build": {
       "executor": "@nx/js:tsc",

--- a/libs/shared/typescript/google-tag-manager/project.json
+++ b/libs/shared/typescript/google-tag-manager/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/shared/typescript/google-tag-manager/src",
   "prefix": "sage",
   "tags": ["type:util", "scope:shared", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/shared/typescript/themes/project.json
+++ b/libs/shared/typescript/themes/project.json
@@ -5,6 +5,5 @@
   "sourceRoot": "libs/shared/typescript/themes/src",
   "prefix": "shared",
   "targets": {},
-  "tags": ["type:themes", "scope:shared", "language:typescript"],
-  "implicitDependencies": []
+  "tags": ["type:themes", "scope:shared", "language:typescript"]
 }

--- a/libs/shared/typescript/util/project.json
+++ b/libs/shared/typescript/util/project.json
@@ -5,7 +5,6 @@
   "sourceRoot": "libs/shared/typescript/util/src",
   "prefix": "sage",
   "tags": ["type:util", "scope:shared", "language:typescript"],
-  "implicitDependencies": [],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/synapse/api-description/project.json
+++ b/libs/synapse/api-description/project.json
@@ -28,6 +28,5 @@
       "dependsOn": ["build"]
     }
   },
-  "tags": ["language:openapi"],
-  "implicitDependencies": []
+  "tags": ["language:openapi"]
 }


### PR DESCRIPTION
## Description

Remove empty `implicitDependencies` in `project.json` files.

## Related Issue

- [SMR-362](https://sagebionetworks.jira.com/browse/SMR-362)

## Changelog

- Remove empty `implicitDependencies` in `project.json` files.


[SMR-362]: https://sagebionetworks.jira.com/browse/SMR-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ