### PR TITLE
chore(model-ad): bump model-ad-data to mv85 and align e2e tests with available data (MG-398)

### DIFF
--- a/apps/model-ad/app/e2e/model-details.spec.ts
+++ b/apps/model-ad/app/e2e/model-details.spec.ts
@@ -53,7 +53,7 @@ test.describe('model details', () => {
 
   test('correct tab is loaded when navigating to new model via search', async ({ page }) => {
     const initialModelPath = '/models/3xTg-AD';
-    const nextModel = 'LOAD2';
+    const nextModel = 'LOAD1';
 
     await page.goto('/models/3xTg-AD');
     await expect(page.getByRole('heading', { level: 2, name: 'Available Data' })).toBeVisible();

--- a/apps/model-ad/app/e2e/search.spec.ts
+++ b/apps/model-ad/app/e2e/search.spec.ts
@@ -39,7 +39,7 @@ test.describe('search', () => {
   });
 
   test('can search for jax id', async ({ page }) => {
-    const expectedResultsCount = 3;
+    const expectedResultsCount = 2;
     const modelQuery = '306';
 
     await page.goto('/');
@@ -68,11 +68,10 @@ test.describe('search', () => {
     await page.goto('/');
     const { searchListItems } = await searchAndGetSearchListItems(modelQuery, page);
 
-    await expect(searchListItems.first()).toHaveText(/trem2 ko/i);
-    await expect(searchListItems.nth(1)).toHaveText(/trem2-r47h_nss/i);
-    await expect(searchListItems.nth(2)).toHaveText(/trem2r47h/i);
-    await expect(searchListItems.nth(3)).toHaveText(/load1 \(alias apoe4\/trem2\*r47h\)/i);
-    await expect(searchListItems.last()).toHaveText(/load2 \(alias habeta\/apoe4\/trem2\*r47h\)/i);
+    await expect(searchListItems.first()).toHaveText(/trem2-r47h_nss/i);
+    await expect(searchListItems.nth(1)).toHaveText(/trem2r47h/i);
+    await expect(searchListItems.nth(2)).toHaveText(/load1 \(alias apoe4\/trem2\*r47h\)/i);
+    await expect(searchListItems.last()).toHaveText(/load1.snx1d465n/i);
   });
 
   test('can search using home card input', async ({ page }) => {
@@ -143,8 +142,8 @@ test.describe('search', () => {
   });
 
   test('can navigate search results with arrow keys and select with enter', async ({ page }) => {
-    const modelQuery = 'trem2';
-    const expectedFirstResult = 'Trem2 KO';
+    const modelQuery = 'load1';
+    const expectedFirstResult = 'LOAD1';
 
     await page.goto('/');
 
@@ -155,7 +154,7 @@ test.describe('search', () => {
     await input.press('ArrowUp');
     await input.press('Enter');
 
-    await page.waitForURL(/trem2/i);
+    await page.waitForURL(/load1/i);
     await expect(page.getByRole('heading', { level: 1 })).toHaveText(expectedFirstResult);
   });
 

--- a/apps/model-ad/data/.env.example
+++ b/apps/model-ad/data/.env.example
@@ -7,5 +7,5 @@ DB_HOST="model-ad-mongo" # must match mongo service name
 
 # specifies data release manifest
 DATA_FILE="syn63540270"
-DATA_VERSION="84"
+DATA_VERSION="85"
 SYNAPSE_AUTH_TOKEN="model-ad-service-user-pat-here"


### PR DESCRIPTION
## Description

Bump model-ad-data to mv85 and align e2e tests with available data.

## Related Issue

[MG-398](https://sagebionetworks.jira.com/browse/MG-398)

## Changelog

- Bumps model-ad-data to mv85
- Updates e2e tests to reference models available in the data release

[MG-398]: https://sagebionetworks.jira.com/browse/MG-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ