### PR TITLE
chore(deps): adopt pnpm minimumReleaseAge (SMR-492)

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "vitest": "3.1.2",
     "yaml": "2.8.1"
   },
-  "packageManager": "pnpm@10.13.1",
+  "packageManager": "pnpm@10.17.1",
   "pnpm": {
     "onlyBuiltDependencies": [
       "canvas"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
   # prevent the creation of libs/**/api-client-angular/node_modules when running `workspace-install`
   # that break the apps and tests
   - '!libs/**/api-client-angular'
+minimumReleaseAge: 4320 # 3 days


### PR DESCRIPTION
## Description

Adopt pnpm `minimumReleaseAge` to reduce the risk of installing a compromised package version, by delaying the installation of newly released dependencies. 

## Related Issue

[SMR-492](https://sagebionetworks.jira.com/browse/SMR-492)

## Changelog

- Adds pnpm `minimumReleaseAge` to ensures that only packages released at least three days ago can be installed
- Updates pnpm to v10.17.1 to utilize feature and recent associated fixes

## Preview

1. Update `minimumReleaseAge` to a very large number 
2. Change package version in `package.json` to a version that was released recently
3. Run `pnpm install` -> should see an error and `pnpm-lock.yaml` should not be updated with the new version

<img width="1164" height="754" alt="SMR-492" src="https://github.com/user-attachments/assets/8a2ab0f5-a5ad-4dff-8d78-06b04adf1749" />

[SMR-492]: https://sagebionetworks.jira.com/browse/SMR-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ