### PR TITLE
feat(explorers): add input for minimum characters in search query (AG-1877)

### DIFF
--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.spec.ts
@@ -334,6 +334,28 @@ describe('SearchInputComponent', () => {
     expect(input).toHaveValue(specialCharQuery);
   });
 
+  it('should construct expected not valid search message for different minimumSearchLength values', async () => {
+    const { component } = await setup();
+    const { fixture } = component;
+    const instance = fixture.componentInstance;
+
+    const testCases = [
+      { minLength: 1, expectedMessage: 'Please enter at least one character.' },
+      { minLength: 2, expectedMessage: 'Please enter at least two characters.' },
+      { minLength: 3, expectedMessage: 'Please enter at least three characters.' },
+      { minLength: 4, expectedMessage: 'Please enter at least four characters.' },
+      { minLength: 5, expectedMessage: 'Please enter at least five characters.' },
+      { minLength: 6, expectedMessage: 'Please enter at least six characters.' },
+      { minLength: 7, expectedMessage: 'Please enter at least seven characters.' },
+      { minLength: 8, expectedMessage: 'Please enter at least eight characters.' },
+      { minLength: 9, expectedMessage: 'Please enter at least nine characters.' },
+    ];
+
+    for (const { minLength, expectedMessage } of testCases) {
+      expect(instance.getNotValidSearchMessage(minLength)).toBe(expectedMessage);
+    }
+  });
+
   it('should only display results text when subtext format function is not provided', async () => {
     const { user } = await setup();
     const input = getInput();

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.stories.ts
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.stories.ts
@@ -47,5 +47,6 @@ export const HomeSearchInput: Story = {
     navigateToResult: mockNavigateToResult,
     getSearchResults: mockGetSearchResults,
     checkQueryForErrors: mockCheckQueryForErrors,
+    minimumSearchLength: 2,
   },
 };


### PR DESCRIPTION
## Description

Adds input to configure minimum search length to the explorers search-input to accommodate different minimum search length in Agora (2 characters) than Model-AD (3 characters). 

## Related Issue

[AG-1877](https://sagebionetworks.jira.com/browse/AG-1877)

## Changelog

- Adds input to configure minimum search length to explorers search-input, which accepts values from 1:9

## Preview

`nx storybook explorers-storybook`

> [!NOTE]
> The story returns static mock search results, so the search results don't change based on the search query.

https://github.com/user-attachments/assets/aa6a8863-998d-4649-ae11-3af3f0082883

[AG-1877]: https://sagebionetworks.jira.com/browse/AG-1877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ