### PR TITLE
feat(explorers): extend explorers search-input to make "no results found" error message configurable (AG-1879)

### DIFF
--- a/libs/explorers/testing/src/lib/mocks/search-result-mocks.ts
+++ b/libs/explorers/testing/src/lib/mocks/search-result-mocks.ts
@@ -21,10 +21,17 @@ export function mockNavigateToResult(id: string): void {
 }
 
 export function mockGetSearchResults(query: string): Observable<SearchResult[]> {
-  if (query === 'notfound') {
+  if (query === 'notfound' || query === 'ensg00000000000') {
     return of(dummyEmptySearchResults).pipe(delay(2000));
   }
   return of(dummySearchResults).pipe(delay(1000));
+}
+
+export function mockGetNoSearchResultsMessage(query: string): string {
+  if (isEnsemblId(query) && query.length === 15) {
+    return 'Unable to find a matching gene. Try searching by gene symbol.';
+  }
+  return 'No results found. Try searching by the Ensembl Gene ID.';
 }
 
 function isEnsemblId(query: string): boolean {

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.spec.ts
@@ -5,6 +5,7 @@ import { SvgIconService } from '@sagebionetworks/explorers/services';
 import {
   mockCheckQueryForErrors,
   mockFormatResultSubtextForDisplay,
+  mockGetNoSearchResultsMessage,
   mockGetSearchResults,
   SvgIconServiceStub,
 } from '@sagebionetworks/explorers/testing';
@@ -35,8 +36,19 @@ async function waitForSpinner() {
   );
 }
 
-async function setup(formatResultSubtextForDisplay?: (result: SearchResult) => string | undefined) {
-  const optionalInputs = formatResultSubtextForDisplay ? { formatResultSubtextForDisplay } : {};
+async function setup(
+  formatResultSubtextForDisplay?: (result: SearchResult) => string | undefined,
+  getNoSearchResultsMessage?: (query: string) => string,
+) {
+  const optionalInputs: Record<string, any> = {};
+
+  if (formatResultSubtextForDisplay) {
+    optionalInputs['formatResultSubtextForDisplay'] = formatResultSubtextForDisplay;
+  }
+
+  if (getNoSearchResultsMessage) {
+    optionalInputs['getNoSearchResultsMessage'] = getNoSearchResultsMessage;
+  }
 
   const user = userEvent.setup();
   const component = await render(SearchInputComponent, {
@@ -332,6 +344,30 @@ describe('SearchInputComponent', () => {
 
     await waitForSpinner();
     expect(input).toHaveValue(specialCharQuery);
+  });
+
+  it('should display default no results message when no custom function provided', async () => {
+    const { user } = await setup();
+
+    const input = getInput();
+    await user.type(input, 'ensg00000000000');
+    expect(input).toHaveValue('ensg00000000000');
+
+    await waitForSpinner();
+
+    screen.getByText('No results match your search term.');
+  });
+
+  it('should display custom no results message when provided', async () => {
+    const { user } = await setup(mockFormatResultSubtextForDisplay, mockGetNoSearchResultsMessage);
+
+    const input = getInput();
+    await user.type(input, 'ensg00000000000');
+    expect(input).toHaveValue('ensg00000000000');
+
+    await waitForSpinner();
+
+    screen.getByText('Unable to find a matching gene. Try searching by gene symbol.');
   });
 
   it('should construct expected not valid search message for different minimumSearchLength values', async () => {

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.stories.ts
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.stories.ts
@@ -3,6 +3,7 @@ import { provideRouter } from '@angular/router';
 import {
   mockCheckQueryForErrors,
   mockFormatResultSubtextForDisplay,
+  mockGetNoSearchResultsMessage,
   mockGetSearchResults,
   mockNavigateToResult,
 } from '@sagebionetworks/explorers/testing';
@@ -21,6 +22,7 @@ const meta: Meta<SearchInputComponent> = {
   argTypes: {
     navigateToResult: { control: false },
     getSearchResults: { control: false },
+    getNoSearchResultsMessage: { control: false },
     checkQueryForErrors: { control: false },
     formatResultSubtextForDisplay: { control: false },
   },
@@ -46,6 +48,7 @@ export const HomeSearchInput: Story = {
     formatResultSubtextForDisplay: mockFormatResultSubtextForDisplay,
     navigateToResult: mockNavigateToResult,
     getSearchResults: mockGetSearchResults,
+    getNoSearchResultsMessage: mockGetNoSearchResultsMessage,
     checkQueryForErrors: mockCheckQueryForErrors,
     minimumSearchLength: 2,
   },

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.ts
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.ts
@@ -63,6 +63,9 @@ export class SearchInputComponent implements AfterViewInit {
 
   navigateToResult = input.required<(id: string) => void>();
   getSearchResults = input.required<(query: string) => Observable<SearchResult[]>>();
+  getNoSearchResultsMessage = input<(query: string) => string>(
+    (query: string) => 'No results match your search term.',
+  );
   checkQueryForErrors = input.required<(query: string) => string>(); // empty string if no error
   formatResultForDisplay = input<(result: SearchResult) => string>(
     (result: SearchResult) => result.id,
@@ -82,11 +85,6 @@ export class SearchInputComponent implements AfterViewInit {
   selectedResultIndex = -1; // -1 means no result is selected
 
   showResults = false;
-  errorMessages: { [key: string]: string } = {
-    notFound: 'No results match your search term.',
-    notValidSearch: 'Please enter at least three characters.',
-    unknown: 'An unknown error occurred, please try again.',
-  };
 
   root = viewChild.required<ElementRef>('root');
   input = viewChild.required<ElementRef<HTMLInputElement>>('input');
@@ -110,7 +108,7 @@ export class SearchInputComponent implements AfterViewInit {
           const target = event.target as HTMLInputElement;
           return this.search(target.value).pipe(
             catchError(() => {
-              this.error = this.errorMessages['unknown'];
+              this.error = 'An unknown error occurred, please try again.';
               this.isLoading = false;
               this.showResults = true;
               return of([]);
@@ -164,7 +162,7 @@ export class SearchInputComponent implements AfterViewInit {
 
   setResults(results: SearchResult[]) {
     if (results.length < 1 && !this.error) {
-      this.error = this.errorMessages['notFound'];
+      this.error = this.getNoSearchResultsMessage()(this.query);
     }
     this.results = results;
     this.selectedResultIndex = -1;


### PR DESCRIPTION
## Description

The “not found” message is currently hard coded in the explorers `search-input`, but should be made configurable since Agora has a different “not found” message from Model-AD. The Agora “not found” message also depends on the search query. 

> [!NOTE]
> ~~This PR will be kept as a draft until #3499 and #3497 are merged, because those PRs update the same component and will cause merge conflicts that need to be resolved here afterwards.~~ 
>
> Both PRs have been merged, so this has been marked as ready for review.

## Related Issue

- [AG-1879](https://sagebionetworks.jira.com/browse/AG-1879)
- [AG-443](https://sagebionetworks.jira.com/browse/AG-443)

## Changelog

- Adds input to explorers `search-input` to configure no results found message

## Preview

`nx storybook explorers-storybook`

Here, we demonstrate that the explorers `search-input` can return both of the "not found" messages used by Agora and described in [AG-443](https://sagebionetworks.jira.com/browse/AG-443).

https://github.com/user-attachments/assets/43f0df93-c1b2-411b-a2ca-3455825bfe7e

[AG-1879]: https://sagebionetworks.jira.com/browse/AG-1879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-443]: https://sagebionetworks.jira.com/browse/AG-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-443]: https://sagebionetworks.jira.com/browse/AG-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ