### PR TITLE
chore: update trigger for Lint PR workflow and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
   pull_request:
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
   merge_group:
 
 env:

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,11 +1,11 @@
 name: 'Lint PR'
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
+  # pull_request_target:
+  #   types:
+  #     - opened
+  #     - edited
+  #     - synchronize
   pull_request:
     types:
       - edited


### PR DESCRIPTION
## Description

This PR updates the trigger for the Lint PR workflow. Initially, we had only `pull_request_target` trigger but then recently added `pull_request`. I believe that the latter is not needed if we have `pull_request_target`. Having both also triggers the workflow twice, and because of the recent concurrency config, this leads to workflows being canceled.

This PR also updates the trigger of the main CI workflow to include the trigger type `ready_for_review` so that the CI workflow is triggered when marking a PR created with `peter-evans/create-pull-request` as Ready for Review.

## Related Issue

- [SMR-507](https://sagebionetworks.jira.com/browse/SMR-507)


[SMR-507]: https://sagebionetworks.jira.com/browse/SMR-507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ