### PR TITLE
fix(sage-monorepo): remove edited action type from CI workflow (SMR-515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
       - main
   pull_request:
     types:
-      - edited
       - opened
       - ready_for_review
       - synchronize


### PR DESCRIPTION
## Description

From this [stackoverflow answer](https://stackoverflow.com/a/79144219), “the edited action of the pull_request event means that: the title or body of a pull request was edited, or the base branch of a pull request was changed.” We would like to remove this type so the CI job is not triggered when the PR description or title are changed.

## Related Issue

[SMR-515](https://sagebionetworks.jira.com/browse/SMR-515)

## Changelog

- Removes `edited` action from CI workflow to prevent running on edits to PR title or description

[SMR-515]: https://sagebionetworks.jira.com/browse/SMR-515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ