### PR TITLE
ci: update the Lint PR GitHub action and specify the PR types + infra

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,11 +1,6 @@
 name: 'Lint PR'
 
 on:
-  # pull_request_target:
-  #   types:
-  #     - opened
-  #     - edited
-  #     - synchronize
   pull_request:
     types:
       - edited
@@ -30,10 +25,25 @@ jobs:
     if: ${{ github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          # Configure which types are allowed (newline-delimited).
+          # These are regex patterns auto-wrapped in `^ $`.
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            infra
+            perf
+            refactor
+            revert
+            style
+            test
           # Configure which scopes are allowed (newline-delimited).
           # These are regex patterns auto-wrapped in `^ $`.
           scopes: |


### PR DESCRIPTION
## Description

Update the Lint PR GitHub action and specify the PR types + infra (for infrastructure code).

## Changelog

- Update the Lint PR GitHub action.
- Set the default types from conventional commit and add `infra`.

## Preview

Example of PR title that will then be accepted:

```
infra(bixarena): bootstrap the deployment of BixArena using Terraform (SMR-517)
```