### PR TITLE
chore(synapse): update CODEOWNERS for synapse (SMR-530)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,3 +35,5 @@
 /libs/results-visualization-framework/ @Sage-Bionetworks/sage-monorepo-agora
 
 /libs/explorers/ @Sage-Bionetworks/sage-monorepo-agora
+
+/libs/synapse/ @Sage-Bionetworks/sage-monorepo-agora


### PR DESCRIPTION
## Description

Update `CODEOWNERS` for synapse so Sage Monorepo Agora team is automatically added as reviewer to auto-created PRs updating Synapse API.

## Related Issue

[SMR-530](https://sagebionetworks.jira.com/browse/SMR-530)

## Changelog

- Update CODEOWNERS for `/libs/synapse`

[SMR-530]: https://sagebionetworks.jira.com/browse/SMR-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ