### PR TITLE
fix(agora): attempt to stabilize flaky search e2e test (AG-1888)

### DIFF
--- a/apps/agora/app/e2e/gene-details.spec.ts
+++ b/apps/agora/app/e2e/gene-details.spec.ts
@@ -37,11 +37,13 @@ test.describe('gene details', () => {
     await page.goto(`/genes/${gene1.id}`);
     await waitForSpinnerNotVisible(page);
 
+    await page.waitForURL(`/genes/${gene1.id}`);
     await expect(page.getByRole('heading', { name: gene1.name, exact: true })).toBeVisible();
 
     const responsePromise = page.waitForResponse(`**/genes/search/enhanced?q=${gene2.id}`);
     const searchInput = page.getByRole('textbox', { name: 'Search genes' });
     await searchInput.pressSequentially(gene2.id);
+    await expect(searchInput).toHaveValue(gene2.id);
     await responsePromise;
 
     const searchList = page.getByRole('list').filter({ hasText: gene2.name });


### PR DESCRIPTION
## Description

Attempt to stabilize flaky Agora e2e search test by allowing more time for component to initialize before attempting search.

## Related Issue

[AG-1888](https://sagebionetworks.jira.com/browse/AG-1888)

## Changelog

- Attempt to stabilize flaky Agora e2e search test

## Preview

`agora-build-images && agora-docker-start`

Run the flaky test repeatedly: 

```bash
$ nx e2e agora-app --trace=on --grep="via search bar" --repeat-each=10 --workers=1

 NX   Ensuring Playwright is installed.

use --skipInstall to skip installation.


Running 10 tests using 1 worker
  10 passed (29.4s)
```

[AG-1888]: https://sagebionetworks.jira.com/browse/AG-1888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ