### PR TITLE
fix: address uv warning: Failed to hardlink files (SMR-534)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
     "NX_CLOUD_ENCRYPTION_KEY": "${localEnv:NX_CLOUD_ENCRYPTION_KEY}",
     "NX_HEAD": "${localEnv:NX_HEAD}",
     "SONAR_PULL_REQUEST_NUMBER": "${localEnv:SONAR_PULL_REQUEST_NUMBER}",
-    "SONAR_TOKEN": "${localEnv:SONAR_TOKEN}"
+    "SONAR_TOKEN": "${localEnv:SONAR_TOKEN}",
+    "UV_CACHE_DIR": "${containerWorkspaceFolder}/.cache/uv"
   },
   "features": {},
   "forwardPorts": [

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -258,11 +258,6 @@ function workspace-initialize-env {
   # Prevent Corepack showing the URL when it needs to download software
   # https://github.com/nodejs/corepack/blob/main/README.md#environment-variables
   export COREPACK_ENABLE_DOWNLOAD_PROMPT="0"
-
-  # Store uv's package cache inside the workspace to keep it on the same filesystem
-  # as the virtual environment. This allows uv to use hardlinks instead of copies,
-  # improving installation speed and reducing disk usage.
-  export UV_CACHE_DIR=$WORKSPACE_DIR/.cache/uv
 }
 
 function workspace-nuke {


### PR DESCRIPTION
## Description

Address the uv warning displayed below when updating dependencies and running `uv sync`, which is also run by git hooks. The issue stems from the uv cache folder (in the user's home) being on a different filesystem from where Python packages are installed in `.venv` folders in the workspace directory mounted inside the dev container.

```console
Failed to hardlink files; falling back to full copy. This may lead to degraded performance.
         If the cache and target directories are on different filesystems, hardlinking may not be supported.
         If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning.
```

Installing Python dependencies should be a bit faster now in addition to addressing the above warning.

> [!NOTE]
> This change will be effective after rebuilding the dev container.

## Design

The initial solution defined `UV_CACHE_DIR` in `dev-env.sh`. As I'm considering the future of this file, `UV_CACHE_DIR` is now defined in the active `devcontainer.json`. Both solutions also worked when the dev container is used by GitHub workflows, though the adopted solution does not require to source `dev-env.sh`.

## Related Issue

- [SMR-534](https://sagebionetworks.jira.com/browse/SMR-534)

## Changelog

- Move the uv cache folder from the user's home to the workspace directory.

[SMR-534]: https://sagebionetworks.jira.com/browse/SMR-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ