### PR TITLE
feat(openchallenges): add setup instructions to MCP Server README

### DIFF
--- a/apps/openchallenges/mcp-server/README.md
+++ b/apps/openchallenges/mcp-server/README.md
@@ -64,7 +64,7 @@ Use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) local proxy to 
      "mcpServers": {
        "mcp-server": {
          "command": "npx",
-         "args": ["mcp-remote", "http://localhost:8887/mcp"]
+         "args": ["mcp-remote", "http://localhost:8887/mcp-server/sse"]
        }
      }
    }
@@ -83,8 +83,8 @@ Use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) local proxy to 
   {
     "servers": {
       "openchallenges-mcp-server": {
-        "type": "http",
-        "url": "http://localhost:8887/mcp"
+        "type": "sse",
+        "url": "http://localhost:8887/mcp-server/sse"
       }
     }
   }
@@ -94,7 +94,7 @@ Use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) local proxy to 
 
 #### Other MCP Clients
 
-For additional [MCP clients](https://modelcontextprotocol.io/clients) that support connecting to a remote MCP server via streamable HTTP, consult their setup guides. Compatibility beyond Claude Desktop and Copilot is currently experimental.
+For other [MCP clients](https://modelcontextprotocol.io/clients) that support connecting to a remote MCP server via Server-Sent Events (SSE), configure a custom SSE endpoint: `http://localhost:8887/mcp-server/sse`. Compatibility beyond Claude Desktop and GitHub Copilot is still experimental.
 
 ## Example Prompts
 

--- a/docker/openchallenges/services/mcp-server-standalone.yml
+++ b/docker/openchallenges/services/mcp-server-standalone.yml
@@ -12,7 +12,7 @@
 
 services:
   openchallenges-mcp-server:
-    image: ghcr.io/sage-bionetworks/openchallenges-mcp-server:sha-24282b5
+    image: ghcr.io/sage-bionetworks/openchallenges-mcp-server:1.3.8
     container_name: openchallenges-mcp-server
     restart: always
     ports:


### PR DESCRIPTION
## Description

This PR updates the README to include setup steps and client configuration guidance for running and connecting to the MCP Server.

## Changelog

- Add setup instructions to the MCP Server README 