### PR TITLE
fix: fix typo when creating two `.env.prod`

### DIFF
--- a/apps/bixarena/infra/cdk/project.json
+++ b/apps/bixarena/infra/cdk/project.json
@@ -11,7 +11,7 @@
           "cp --update=none .env.example .env",
           "cp --update=none .env.dev.example .env.dev",
           "cp --update=none .env.stage.example .env.stage",
-          "cp --update=none .env.prod.example .envprod"
+          "cp --update=none .env.prod.example .env.prod"
         ],
         "cwd": "{projectRoot}"
       }

--- a/apps/openchallenges/infra/cdk/project.json
+++ b/apps/openchallenges/infra/cdk/project.json
@@ -11,7 +11,7 @@
           "cp --update=none .env.example .env",
           "cp --update=none .env.dev.example .env.dev",
           "cp --update=none .env.stage.example .env.stage",
-          "cp --update=none .env.prod.example .envprod"
+          "cp --update=none .env.prod.example .env.prod"
         ],
         "cwd": "{projectRoot}"
       }


### PR DESCRIPTION
## Description

Fix typo when creating two `.env.prod`.