### PR TITLE
fix: exclude `./.pdm-build/*` when searching for `project.json` files

### DIFF
--- a/tools/nx-util.js
+++ b/tools/nx-util.js
@@ -10,7 +10,9 @@ const getNxProjectNames = async () => {
 };
 
 const getNxProjects = async () => {
-  let projectFiles = await exec('find . -name project.json -not -path "./node_modules/*"');
+  let projectFiles = await exec(
+    'find . -name project.json -not -path "./node_modules/*" -not -path "./dist/*" -not -path "./.pdm-build/*"',
+  );
   projectFiles = projectFiles.stdout.trim().split(/\n/);
   // const prefix = './';
   // projectFiles = projectFiles.map((projectFile) => {


### PR DESCRIPTION
## Description

Fix the issue triggered by git hooks when `./.pdm-build` does not exists.

```console
$ git switch main
...
node:internal/errors:983
  const err = new Error(message);
              ^

Error: Command failed: find . -name project.json -not -path "./node_modules/*"
find: ‘./.pdm-build’: No such file or directory

    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at ChildProcess.exithandler (node:child_process:417:12)
    at ChildProcess.emit (node:events:519:28)
    at maybeClose (node:internal/child_process:1101:16)
    at ChildProcess._handle.onexit (node:internal/child_process:304:5) {
  code: 1,
  killed: false,
  signal: null,
  cmd: 'find . -name project.json -not -path "./node_modules/*"',
  stdout: './apps/agora/apex/project.json\n' +
    './apps/agora/api-docs/project.json\n' +
    './apps/agora/api/project.json\n' +
    './apps/agora/app/project.json\n' +
    './apps/agora/data/project.json\n' +
    './apps/agora/locust/project.json\n' +
    './apps/agora/mongo/project.json\n' +
    './apps/agora/api-next/project.json\n' +
    './apps/amp-als/apex/project.json\n' +
    './apps/amp-als/api-docs/project.json\n' +
    './apps/amp-als/dataset-service/project.json\n' +
    './apps/amp-als/keycloak/project.json\n' +
    './apps/amp-als/opensearch/project.json\n' +
    './apps/amp-als/postgres/project.json\n' +
    './apps/amp-als/user-service/project.json\n' +
    './apps/bixarena/apex/project.json\n' +
    './apps/bixarena/api/project.json\n' +
    './apps/bixarena/app/project.json\n' +
    './apps/bixarena/postgres/project.json\n' +
    './apps/bixarena/tools/project.json\n' +
    './apps/bixarena/api-gateway/project.json\n' +
    './apps/bixarena/ai-service/project.json\n' +
    './apps/bixarena/infra/cdk/project.json\n' +
    './apps/iatlas/api/project.json\n' +
    './apps/iatlas/data/project.json\n' +
    './apps/iatlas/postgres/project.json\n' +
    './apps/model-ad/apex/project.json\n' +
    './apps/model-ad/api-docs/project.json\n' +
    './apps/model-ad/api/project.json\n' +
    './apps/model-ad/app/project.json\n' +
    './apps/model-ad/data/project.json\n' +
    './apps/model-ad/mongo/project.json\n' +
    './apps/monorepo/tools/project.json\n' +
    './apps/monorepo/docs-maintainer-agent/project.json\n' +
    './apps/observability/apex/project.json\n' +
    './apps/observability/grafana/project.json\n' +
    './apps/observability/loki/project.json\n' +
    './apps/observability/otel-collector/project.json\n' +
    './apps/observability/prometheus/project.json\n' +
    './apps/observability/pyroscope/project.json\n' +
    './apps/observability/tempo/project.json\n' +
    './apps/openchallenges/apex/project.json\n' +
    './apps/openchallenges/api-docs/project.json\n' +
    './apps/openchallenges/api-gateway/project.json\n' +
    './apps/openchallenges/app/project.json\n' +
    './apps/openchallenges/auth-service/project.json\n' +
    './apps/openchallenges/challenge-service/project.json\n' +
    './apps/openchallenges/image-service/project.json\n' +
    './apps/openchallenges/mcp-server/project.json\n' +
    './apps/openchallenges/opensearch-dashboards/project.json\n' +
    './apps/openchallenges/opensearch/project.json\n' +
    './apps/openchallenges/organization-service/project.json\n' +
    './apps/openchallenges/postgres/project.json\n' +
    './apps/openchallenges/thumbor/project.json\n' +
    './apps/openchallenges/tools/project.json\n' +
    './apps/openchallenges/infra/cdk/project.json\n' +
    './apps/sage/otel-collector/project.json\n' +
    './apps/sandbox/lambda-nodejs/project.json\n' +
    './apps/sandbox/observability-python/project.json\n' +
    './libs/agora/about/project.json\n' +
    './libs/agora/api-client-angular/project.json\n' +
    './libs/agora/api-description/project.json\n' +
    './libs/agora/charts/project.json\n' +
    './libs/agora/config/project.json\n' +
    './libs/agora/gene-comparison-tool/project.json\n' +
    './libs/agora/genes/project.json\n' +
    './libs/agora/home/project.json\n' +
    './libs/agora/news/project.json\n' +
    './libs/agora/nominated-targets/project.json\n' +
    './libs/agora/not-found/project.json\n' +
    './libs/agora/services/project.json\n' +
    './libs/agora/shared/project.json\n' +
    './libs/agora/storybook/project.json\n' +
    './libs/agora/styles/project.json\n' +
    './libs/agora/teams/project.json\n' +
    './libs/agora/testing/project.json\n' +
    './libs/agora/themes/project.json\n' +
    './libs/agora/ui/project.json\n' +
    './libs/agora/util/project.json\n' +
    './libs/amp-als/api-client-angular/project.json\n' +
    './libs/amp-als/api-description/project.json\n' +
    './libs/amp-als/app-config-data/project.json\n' +
    './libs/bixarena/api-client-python/project.json\n' +
    './libs/bixarena/api-description/project.json\n' +
    './libs/explorers/comparison-tools/project.json\n' +
    './libs/explorers/constants/project.json\n' +
    './libs/explorers/models/project.json\n' +
    './libs/explorers/services/project.json\n' +
    './libs/explorers/shared/project.json\n' +
    './libs/explorers/storybook/project.json\n' +
    './libs/explorers/styles/project.json\n' +
    './libs/explorers/testing/project.json\n' +
    './libs/explorers/themes/project.json\n' +
    './libs/explorers/ui/project.json\n' +
    './libs/explorers/util/project.json\n' +
    './libs/explorers/charts-angular/project.json\n' +
    './libs/explorers/charts/project.json\n' +
    './libs/model-ad/api-client-angular/project.json\n' +
    './libs/model-ad/api-description/project.json\n' +
    './libs/model-ad/config/project.json\n' +
    './libs/model-ad/disease-correlation-comparison-tool/project.json\n' +
    './libs/model-ad/gene-expression-comparison-tool/project.json\n' +
    './libs/model-ad/home/project.json\n' +
    './libs/model-ad/model-details/project.json\n' +
    './libs/model-ad/model-overview-comparison-tool/project.json\n' +
    './libs/model-ad/services/project.json\n' +
    './libs/model-ad/styles/project.json\n' +
    './libs/model-ad/testing/project.json\n' +
    './libs/model-ad/themes/project.json\n' +
    './libs/model-ad/util/project.json\n' +
    './libs/model-ad/ui/project.json\n' +
    './libs/openchallenges/about/project.json\n' +
    './libs/openchallenges/api-client-angular/project.json\n' +
    './libs/openchallenges/api-client-java/project.json\n' +
    './libs/openchallenges/api-client-python/project.json\n' +
    './libs/openchallenges/api-description/project.json\n' +
    './libs/openchallenges/assets/project.json\n' +
    './libs/openchallenges/challenge-search/project.json\n' +
    './libs/openchallenges/challenge/project.json\n' +
    './libs/openchallenges/config/project.json\n' +
    './libs/openchallenges/home/project.json\n' +
    './libs/openchallenges/not-found/project.json\n' +
    './libs/openchallenges/org-profile/project.json\n' +
    './libs/openchallenges/org-search/project.json\n' +
    './libs/openchallenges/styles/project.json\n' +
    './libs/openchallenges/team/project.json\n' +
    './libs/openchallenges/themes/project.json\n' +
    './libs/openchallenges/ui/project.json\n' +
    './libs/openchallenges/util/project.json\n' +
    './libs/openchallenges/client-python/project.json\n' +
    './libs/results-visualization-framework/ui/project.json\n' +
    './libs/sage-monorepo/nx-plugin/project.json\n' +
    './libs/shared/java/util/project.json\n' +
    './libs/shared/typescript/assets/project.json\n' +
    './libs/shared/typescript/google-tag-manager/project.json\n' +
    './libs/shared/typescript/styles/project.json\n' +
    './libs/shared/typescript/themes/project.json\n' +
    './libs/shared/typescript/util/project.json\n' +
    './libs/synapse/api-client-angular/project.json\n' +
    './libs/synapse/api-description/project.json\n' +
    './tmp/app-config-data/project.json\n',
  stderr: 'find: ‘./.pdm-build’: No such file or directory\n'
}

Node.js v22.20.0
husky - post-checkout script failed (code 1)
```

## Changelog

- Exclude `./.pdm-build/*` when searching for `project.json` files.
