### PR TITLE
feat(bixarena): add a disclaimer on battle page (SMR-427)

### DIFF
--- a/apps/bixarena/app/bixarena_app/main.py
+++ b/apps/bixarena/app/bixarena_app/main.py
@@ -163,6 +163,9 @@ def build_app(moderate=False):
             max-width: 1200px;
             margin: 0 auto;
         }
+        footer {
+            visibility: hidden;
+        }
         """,
     ) as demo:
         _, battle_btn, leaderboard_btn, login_btn = build_header()

--- a/apps/bixarena/app/bixarena_app/page/battle_page_css.py
+++ b/apps/bixarena/app/bixarena_app/page/battle_page_css.py
@@ -111,3 +111,32 @@ INPUT_PROMPT_CSS = """
     box-shadow: none;
 }
 """
+
+# CSS for disclaimer
+DISCLAIMER_CSS = """
+#disclaimer-footer {
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 16px 24px;
+    margin-top: 32px;
+}
+
+#disclaimer-content {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+}
+
+#disclaimer-text {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.pulse-dot {
+    width: 6px;
+    height: 6px;
+    background-color: rgba(245, 158, 11, 1);
+    border-radius: 50%;
+}
+"""

--- a/apps/bixarena/app/bixarena_app/page/bixarena_battle.py
+++ b/apps/bixarena/app/bixarena_app/page/bixarena_battle.py
@@ -30,6 +30,7 @@ from bixarena_app.model.model_response import (
 )
 from bixarena_app.model.model_selection import get_battle_pair, moderation_filter
 from bixarena_app.page.battle_page_css import (
+    DISCLAIMER_CSS,
     EXAMPLE_PROMPTS_CSS,
     INPUT_PROMPT_CSS,
 )
@@ -256,6 +257,7 @@ def build_side_by_side_ui_anony():
     <style>
     {EXAMPLE_PROMPTS_CSS}
     {INPUT_PROMPT_CSS}
+    {DISCLAIMER_CSS}
     </style>
     """
 
@@ -326,6 +328,23 @@ def build_side_by_side_ui_anony():
                 clear_btn = gr.Button(value="🧪 Next Battle", interactive=False)
             with gr.Column(scale=2):
                 gr.HTML("")
+
+        # Disclaimer
+        gr.HTML(
+            """
+            <div id="disclaimer-footer">
+                <div id="disclaimer-content">
+                    <div id="disclaimer-text">
+                        <div class="pulse-dot"></div>
+                        <span>
+                            AI may make mistakes. Please don't include private or
+                            sensitive information in your prompts.
+                        </span>
+                    </div>
+                </div>
+            </div>
+            """
+        )
 
     # Register listeners
     btn_list = [


### PR DESCRIPTION
## Description

This PR adds a disclaimer to the BixArena battle page.

## Related Issue

[SMR-427](https://sagebionetworks.jira.com/browse/SMR-427)

## Changelog

- Remove the Gradio default footer
- Add disclaimer on the battle page

## Preview

<img width="1080" height="488" alt="Screen Shot 2025-10-20 at 11 25 16 AM" src="https://github.com/user-attachments/assets/070e923f-0191-4213-934e-b99d0cfdb20a" />


[SMR-427]: https://sagebionetworks.jira.com/browse/SMR-427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ