### PR TITLE
fix(bixarena): enable to display example prompts by switching cards on battle page (SMR-557)

### DIFF
--- a/apps/bixarena/api/src/main/java/org/sagebionetworks/bixarena/api/model/repository/ExamplePromptRepository.java
+++ b/apps/bixarena/api/src/main/java/org/sagebionetworks/bixarena/api/model/repository/ExamplePromptRepository.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Repository;
 public interface ExamplePromptRepository
   extends JpaRepository<ExamplePromptEntity, UUID>, JpaSpecificationExecutor<ExamplePromptEntity> {
   @Query(
-    value = "SELECT * FROM example_prompt ep " +
+    value = "SELECT * FROM api.example_prompt ep " +
     "WHERE ep.active = TRUE " +
     "ORDER BY random() LIMIT :page_size",
     nativeQuery = true


### PR DESCRIPTION
## Description

Fix the fetching issue to enable to show example prompts by switching cards on battle page

## Related Issue

Fixes [SMR-557](https://sagebionetworks.jira.com/browse/SMR-557)

## Changelog

- Add schema qualifier to ExamplePromptRepository random query

## Preview

### Restart the Full Stack

```
bixarena-build-images
nx serve-detach bixarena-apex
```
![example-prompt](https://github.com/user-attachments/assets/705f2ffb-6180-481a-a8e2-ec0ea0ebe283)



[SMR-557]: https://sagebionetworks.jira.com/browse/SMR-557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ