### PR TITLE
chore(bixarena): make the Battle button primary when shown and the Logout button secondary

### DIFF
--- a/apps/bixarena/app/bixarena_app/page/bixarena_header.py
+++ b/apps/bixarena/app/bixarena_app/page/bixarena_header.py
@@ -20,9 +20,9 @@ def build_header():
                 """
             )
         with gr.Column(scale=1):
-            battle_btn = gr.Button("Battle", variant="secondary", visible=False)
+            battle_btn = gr.Button("⚔️ Battle", variant="primary", visible=False)
         with gr.Column(scale=1):
-            leaderboard_btn = gr.Button("Leaderboard", variant="secondary")
+            leaderboard_btn = gr.Button("🏆 Leaderboard", variant="secondary")
         with gr.Column(scale=1):
             # Start as Login; value updated by load / callback events
             login_btn = gr.Button("Login", variant="primary", elem_id="login-btn")
@@ -46,7 +46,7 @@ def update_login_button():
     """Return gr.update for login button based on Python-side auth state."""
     state = get_user_state()
     if state.is_authenticated():
-        return gr.update(value="Logout", variant="primary")
+        return gr.update(value="Logout", variant="secondary")
     return gr.update(value="Login", variant="primary")
 
 


### PR DESCRIPTION
## Description

Make the Battle button primary when shown and the Logout button secondary. The motivation is to guide the user. When the user is logged out, the Login button is colored in orange (primary color). Once logged in, the Battle button is displayed and colored in orange while the Logout button is no longer colored.

## Changelog

- Make the Battle button primary when shown and the Logout button secondary.
- Add emoji to the "⚔️ Battle" and "🏆 Leaderboard" buttons in the header.

## Preview

### When the user is logged out

<img width="1689" height="1286" alt="image" src="https://github.com/user-attachments/assets/a7cb4f6d-a56c-41e8-a664-bbb9082756a9" />

### When the user is logged in

<img width="1689" height="1288" alt="image" src="https://github.com/user-attachments/assets/6f37a2b6-b65d-4c04-bdb1-00c64cdd9619" />

