### PR TITLE
fix(model-ad): fix filter panel styling for larger resolutions (MG-469)

### DIFF
--- a/libs/explorers/comparison-tools/src/lib/base-comparison-tool/base-comparison-tool.component.scss
+++ b/libs/explorers/comparison-tools/src/lib/base-comparison-tool/base-comparison-tool.component.scss
@@ -12,17 +12,23 @@ main {
     align-items: center;
     justify-content: center;
   }
-}
 
-.comparison-tool-body {
-  flex: 1;
+  .comparison-tool-body {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
 
-  .comparison-tool-body-inner {
-    position: relative;
-    overflow: hidden;
+    .comparison-tool-body-inner {
+      position: relative;
+      flex: 1 1 auto;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
 
-    .comparison-tool-tables {
-      min-height: 600px;
+      .comparison-tool-tables {
+        flex: 1 1 auto;
+        overflow: auto;
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
Filter Panel does not scale well when opened.

## Related Issue

[MG-469](https://sagebionetworks.jira.com/browse/MG-469)

## Changelog

- Update CSS to handle larger resolutions

## Preview
Figma Design:
https://www.figma.com/design/GtUYqZBxoOnPtjV1hLcTgw/Model-AD-Explorer-Designs?node-id=409-27319&m=dev

Before (panel does not extend to the footer):
<img width="4318" height="3544" alt="image" src="https://github.com/user-attachments/assets/e57729f5-a1aa-48db-9aa2-765a769f26de" />

After:
<img width="1081" height="887" alt="image" src="https://github.com/user-attachments/assets/6c1d7ffc-51ea-4c6c-bf69-54376e5c3443" />



[MG-469]: https://sagebionetworks.jira.com/browse/MG-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ