### PR TITLE
fix(bixarena): remove moderate arg left after FastChat code cleanup

### DIFF
--- a/apps/bixarena/app/bixarena_app/__main__.py
+++ b/apps/bixarena/app/bixarena_app/__main__.py
@@ -11,7 +11,7 @@ from bixarena_app.main import build_app, parse_args  # type: ignore
 def main() -> None:  # noqa: D401
     """Entry point used by the `bixarena-app` console script."""
     args = parse_args()
-    app = build_app(args.moderate)
+    app = build_app()
     app.queue(default_concurrency_limit=args.concurrency_count).launch(
         server_name=args.host,
         server_port=args.port,


### PR DESCRIPTION
## Description

Remove moderate arg left after FastChat code cleanup. This issue prevented to start `bixarena-app` with its container.