### PR TITLE
fix(model-ad): track the column selection for the first two dropdown levels, use a map to track column selections (MG-468)

### DIFF
--- a/libs/explorers/models/src/lib/comparison-tool.ts
+++ b/libs/explorers/models/src/lib/comparison-tool.ts
@@ -69,11 +69,6 @@ export interface ComparisonToolColumn extends ComparisonToolConfigColumn {
   selected: boolean;
 }
 
-export interface ComparisonToolColumns {
-  dropdowns: string[];
-  columns: ComparisonToolColumn[];
-}
-
 export interface ComparisonToolConfig {
   page: ComparisonToolPage;
   dropdowns: string[];


### PR DESCRIPTION
## Description

Tracks the column selections for the first two dropdowns levels in the CT. 

## Related Issue

[MG-468](https://sagebionetworks.jira.com/browse/MG-468)

## Changelog

- Tracks the column selections for the first two dropdown levels in the CT
- Uses a map to track column selections

## Preview

`model-ad-build-images && model-ad-docker-start`

Disease correlation -- all column selections are tracked separately (2 dropdowns): 

https://github.com/user-attachments/assets/57552514-2afa-49a3-9417-2376809fbba0

Gene expression -- column selections are not tracked separately for Sex (3 dropdowns): 

https://github.com/user-attachments/assets/b5caae1c-fadc-489f-a7ce-1dbfd33e1ac5


[MG-468]: https://sagebionetworks.jira.com/browse/MG-468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ