### PR TITLE
chore(model-ad): bump data version to mv90, align data model, don't display hidden columns in CT ui (MG-490)

### DIFF
--- a/apps/model-ad/api/src/models/comparison-tool-config.ts
+++ b/apps/model-ad/api/src/models/comparison-tool-config.ts
@@ -20,6 +20,8 @@ const ComparisonToolConfigColumnSchema = new Schema<ComparisonToolConfigColumn>(
   sort_tooltip: { type: String, required: false },
   link_text: { type: String, required: false },
   link_url: { type: String, required: false },
+  is_exported: { type: Boolean, required: true },
+  is_hidden: { type: Boolean, required: true },
 });
 
 const ComparisonToolConfigSchema = new Schema<ComparisonToolConfig>(

--- a/apps/model-ad/data/.env.example
+++ b/apps/model-ad/data/.env.example
@@ -7,5 +7,5 @@ DB_HOST="model-ad-mongo" # must match mongo service name
 
 # specifies data release manifest
 DATA_FILE="syn63540270"
-DATA_VERSION="89"
+DATA_VERSION="90"
 SYNAPSE_AUTH_TOKEN="model-ad-service-user-pat-here"

--- a/libs/explorers/models/src/lib/comparison-tool.ts
+++ b/libs/explorers/models/src/lib/comparison-tool.ts
@@ -63,6 +63,8 @@ export interface ComparisonToolConfigColumn {
   sort_tooltip?: string;
   link_text?: string;
   link_url?: string;
+  is_exported: boolean;
+  is_hidden: boolean;
 }
 
 export interface ComparisonToolColumn extends ComparisonToolConfigColumn {

--- a/libs/explorers/services/src/lib/comparison-tool.service.spec.ts
+++ b/libs/explorers/services/src/lib/comparison-tool.service.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+import { ComparisonToolColumn } from '@sagebionetworks/explorers/models';
+import { mockComparisonToolDataConfig } from '@sagebionetworks/explorers/testing';
+import { FilterService, MessageService } from 'primeng/api';
+import { ComparisonToolService } from './comparison-tool.service';
+import { provideComparisonToolService } from './comparison-tool.service.providers';
+
+describe('ComparisonToolService', () => {
+  let service: ComparisonToolService<Record<string, unknown>>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [FilterService, ...provideComparisonToolService(), MessageService],
+    });
+    service = TestBed.inject(ComparisonToolService);
+  });
+
+  it('excludes hidden columns from columns and cached dropdown columns', () => {
+    service.initialize(mockComparisonToolDataConfig);
+
+    const columns = service.columns();
+    expect(columns.every((column) => !column.is_hidden)).toBe(true);
+    expect(columns.find((column) => column.data_key === 'available_data')).toBeUndefined();
+
+    const columnsForDropdowns: Map<string, ComparisonToolColumn[]> = (
+      service as any
+    ).columnsForDropdownsSignal();
+    const cachedColumns = columnsForDropdowns.get(JSON.stringify([]));
+
+    expect(cachedColumns).toBeDefined();
+    expect(cachedColumns?.find((column) => column.data_key === 'available_data')).toBeUndefined();
+    expect(cachedColumns?.every((column) => column.selected)).toBe(true);
+  });
+});

--- a/libs/explorers/services/src/lib/comparison-tool.service.ts
+++ b/libs/explorers/services/src/lib/comparison-tool.service.ts
@@ -152,7 +152,7 @@ export class ComparisonToolService<T> {
     for (const config of configs) {
       columnsMap.set(
         this.dropdownKey(config.dropdowns),
-        config.columns.map((column) => ({ ...column, selected: true })),
+        this.applyColumnPreferences(config.columns),
       );
     }
 
@@ -358,13 +358,15 @@ export class ComparisonToolService<T> {
     configColumns: ComparisonToolConfigColumn[],
     savedColumns?: ComparisonToolColumn[],
   ): ComparisonToolColumn[] {
+    const visibleColumns = configColumns.filter((column) => !column.is_hidden);
+
     if (!savedColumns?.length) {
-      return configColumns.map((column) => ({ ...column, selected: true }));
+      return visibleColumns.map((column) => ({ ...column, selected: true }));
     }
 
     const selectionMap = new Map(savedColumns.map((col) => [col.data_key, col.selected]));
 
-    return configColumns.map((column) => ({
+    return visibleColumns.map((column) => ({
       ...column,
       selected: selectionMap.get(column.data_key) ?? true,
     }));

--- a/libs/explorers/testing/src/lib/mocks/comparison-tool-config-mocks.ts
+++ b/libs/explorers/testing/src/lib/mocks/comparison-tool-config-mocks.ts
@@ -100,6 +100,8 @@ export const mockComparisonToolColumns: ComparisonToolConfigColumn[] = [
     data_key: 'age',
     tooltip: '',
     sort_tooltip: 'Sort by Age value',
+    is_exported: true,
+    is_hidden: false,
   },
   {
     name: 'Sex',
@@ -107,6 +109,8 @@ export const mockComparisonToolColumns: ComparisonToolConfigColumn[] = [
     data_key: 'sex',
     tooltip: '',
     sort_tooltip: 'Sort by Sex value',
+    is_exported: true,
+    is_hidden: false,
   },
   {
     name: 'CBE',
@@ -114,6 +118,8 @@ export const mockComparisonToolColumns: ComparisonToolConfigColumn[] = [
     data_key: 'CBE',
     tooltip: 'Cerebellum',
     sort_tooltip: 'Sort by correlation value',
+    is_exported: true,
+    is_hidden: false,
   },
   {
     name: 'DLPFC',
@@ -121,6 +127,8 @@ export const mockComparisonToolColumns: ComparisonToolConfigColumn[] = [
     data_key: 'DLPFC',
     tooltip: 'Dorsolateral Prefrontal Cortex',
     sort_tooltip: 'Sort by correlation value',
+    is_exported: true,
+    is_hidden: false,
   },
   {
     name: 'PHG',
@@ -128,6 +136,8 @@ export const mockComparisonToolColumns: ComparisonToolConfigColumn[] = [
     data_key: 'PHG',
     tooltip: 'Parahippocampal Gyrus',
     sort_tooltip: 'Sort by correlation value',
+    is_exported: true,
+    is_hidden: false,
   },
 ];
 

--- a/libs/explorers/testing/src/lib/mocks/comparison-tool-mocks.ts
+++ b/libs/explorers/testing/src/lib/mocks/comparison-tool-mocks.ts
@@ -20,6 +20,8 @@ export const mockComparisonToolDataConfig: ComparisonToolConfig[] = [
       {
         type: 'primary',
         data_key: 'name',
+        is_exported: true,
+        is_hidden: false,
       },
       {
         name: 'Model Type',
@@ -27,6 +29,8 @@ export const mockComparisonToolDataConfig: ComparisonToolConfig[] = [
         data_key: 'model_type',
         tooltip: '',
         sort_tooltip: 'Sort by Model Type value',
+        is_exported: true,
+        is_hidden: false,
       },
       {
         name: 'Matched Control',
@@ -34,6 +38,8 @@ export const mockComparisonToolDataConfig: ComparisonToolConfig[] = [
         data_key: 'matched_controls',
         tooltip: '',
         sort_tooltip: 'Sort by Matched Control value',
+        is_exported: true,
+        is_hidden: false,
       },
       {
         name: 'Disease Correlation',
@@ -42,6 +48,8 @@ export const mockComparisonToolDataConfig: ComparisonToolConfig[] = [
         tooltip: '',
         sort_tooltip: 'Sort by Disease Correlation value',
         link_text: 'Results',
+        is_exported: true,
+        is_hidden: false,
       },
       {
         name: 'Center',
@@ -50,6 +58,8 @@ export const mockComparisonToolDataConfig: ComparisonToolConfig[] = [
         tooltip: '',
         sort_tooltip: 'Sort by Center value',
         link_url: 'https://www.model-ad.org/',
+        is_exported: true,
+        is_hidden: false,
       },
       {
         name: 'Age',
@@ -57,6 +67,8 @@ export const mockComparisonToolDataConfig: ComparisonToolConfig[] = [
         data_key: 'age',
         tooltip: '',
         sort_tooltip: 'Sort by Age value',
+        is_exported: true,
+        is_hidden: false,
       },
       {
         name: 'IFG',
@@ -64,6 +76,8 @@ export const mockComparisonToolDataConfig: ComparisonToolConfig[] = [
         data_key: 'IFG',
         tooltip: 'Inferior Frontal Gyrus',
         sort_tooltip: 'Sort by correlation value',
+        is_exported: true,
+        is_hidden: false,
       },
       {
         name: 'PHG',
@@ -71,6 +85,14 @@ export const mockComparisonToolDataConfig: ComparisonToolConfig[] = [
         data_key: 'PHG',
         tooltip: 'Parahippocampal Gyrus',
         sort_tooltip: 'Sort by correlation value',
+        is_exported: true,
+        is_hidden: false,
+      },
+      {
+        type: 'text',
+        data_key: 'available_data',
+        is_exported: false,
+        is_hidden: true,
       },
     ],
     filters: [
@@ -108,6 +130,7 @@ export const mockComparisonToolData: Record<string, any>[] = [
       correlation: 0.084295638183579,
       adj_p_val: 0.409231075552908,
     },
+    available_data: ['Gene Expression', 'Pathology', 'Biomarkers'],
   },
   {
     _id: '68fff1aaeb12b9674515fd59',
@@ -128,6 +151,7 @@ export const mockComparisonToolData: Record<string, any>[] = [
       correlation: 0.120000548192961,
       adj_p_val: 0.239210931286464,
     },
+    available_data: ['Gene Expression', 'Pathology', 'Biomarkers'],
   },
   {
     _id: '68fff1aaeb12b9674515fd5a',
@@ -150,6 +174,7 @@ export const mockComparisonToolData: Record<string, any>[] = [
       correlation: 0.0555691060937462,
       adj_p_val: 0.586807542376288,
     },
+    available_data: ['Gene Expression', 'Disease Correlation'],
   },
   {
     _id: '68fff1aaeb12b9674515fd5b',
@@ -170,6 +195,7 @@ export const mockComparisonToolData: Record<string, any>[] = [
       correlation: 0.0748918760876008,
       adj_p_val: 0.463613681499704,
     },
+    available_data: ['Gene Expression', 'Pathology', 'Biomarkers'],
   },
   {
     _id: '68fff1aaeb12b9674515fd5c',
@@ -192,5 +218,6 @@ export const mockComparisonToolData: Record<string, any>[] = [
       correlation: 0.0472918655548024,
       adj_p_val: 0.638623415843113,
     },
+    available_data: ['Gene Expression', 'Disease Correlation'],
   },
 ];

--- a/libs/model-ad/api-client-angular/src/lib/model/comparison-tool-config-column.ts
+++ b/libs/model-ad/api-client-angular/src/lib/model/comparison-tool-config-column.ts
@@ -37,6 +37,14 @@ export interface ComparisonToolConfigColumn {
    * The default URL for this column.
    */
   link_url?: string;
+  /**
+   * Indicates whether the column is included in data exports.
+   */
+  is_exported: boolean;
+  /**
+   * Indicates whether the column is shown in the comparison table UI.
+   */
+  is_hidden: boolean;
 }
 export namespace ComparisonToolConfigColumn {
   export type TypeEnum = 'text' | 'heat_map' | 'link_internal' | 'link_external' | 'primary';

--- a/libs/model-ad/api-description/openapi/api-public.openapi.yaml
+++ b/libs/model-ad/api-description/openapi/api-public.openapi.yaml
@@ -433,9 +433,17 @@ components:
         link_url:
           type: string
           description: The default URL for this column.
+        is_exported:
+          type: boolean
+          description: Indicates whether the column is included in data exports.
+        is_hidden:
+          type: boolean
+          description: Indicates whether the column is shown in the comparison table UI.
       required:
         - type
         - data_key
+        - is_exported
+        - is_hidden
     ComparisonToolConfigFilter:
       type: object
       description: Comparison Tool Config Filter

--- a/libs/model-ad/api-description/openapi/api-service.openapi.yaml
+++ b/libs/model-ad/api-description/openapi/api-service.openapi.yaml
@@ -433,9 +433,17 @@ components:
         link_url:
           type: string
           description: The default URL for this column.
+        is_exported:
+          type: boolean
+          description: Indicates whether the column is included in data exports.
+        is_hidden:
+          type: boolean
+          description: Indicates whether the column is shown in the comparison table UI.
       required:
         - type
         - data_key
+        - is_exported
+        - is_hidden
     ComparisonToolConfigFilter:
       type: object
       description: Comparison Tool Config Filter

--- a/libs/model-ad/api-description/openapi/openapi.yaml
+++ b/libs/model-ad/api-description/openapi/openapi.yaml
@@ -433,9 +433,17 @@ components:
         link_url:
           type: string
           description: The default URL for this column.
+        is_exported:
+          type: boolean
+          description: Indicates whether the column is included in data exports.
+        is_hidden:
+          type: boolean
+          description: Indicates whether the column is shown in the comparison table UI.
       required:
         - type
         - data_key
+        - is_exported
+        - is_hidden
     ComparisonToolConfigFilter:
       type: object
       description: Comparison Tool Config Filter

--- a/libs/model-ad/api-description/src/components/schemas/ComparisonToolConfigColumn.yaml
+++ b/libs/model-ad/api-description/src/components/schemas/ComparisonToolConfigColumn.yaml
@@ -29,6 +29,14 @@ properties:
   link_url:
     type: string
     description: The default URL for this column.
+  is_exported:
+    type: boolean
+    description: Indicates whether the column is included in data exports.
+  is_hidden:
+    type: boolean
+    description: Indicates whether the column is shown in the comparison table UI.
 required:
   - type
   - data_key
+  - is_exported
+  - is_hidden


### PR DESCRIPTION
## Description

Bumps model-ad-data to mv90, aligns data model, and ensures `is_hidden` columns are not shown in the comparison tool table.

## Related Issue

[MG-490](https://sagebionetworks.jira.com/browse/MG-490)

## Changelog

- Bumps model-ad-data to mv90
- Adds new fields (`is_hidden`, `is_exported`) to data model, which support downloading pinned data ([MG-451](https://sagebionetworks.jira.com/browse/MG-451))
- Ensures `is_hidden` columns are not show in CT table

## Preview

`model-ad-build-images && model-ad-docker-start`

New columns have been added to the [ui_config](https://www.synapse.org/Synapse:syn66531901) with `is_hidden` set to `true` (note: the "Center" column was in the config previously, so has `is_hidden` set to `false`): 

<img width="452" height="514" alt="MG-490_modeloverview_ui_config" src="https://github.com/user-attachments/assets/a29477af-696e-417f-8326-78a0fecfab98" />

However, there is no change in which columns are shown in the CT table or in the columns selector, so the hidden columns are being appropriately hidden from the CT UI: 

model overview | dev (current) | this PR (updated) 
:---: | :---: | :---: 
visible columns |  <img width="1624" height="1056" alt="MG-490_modeloverview_columns_dev" src="https://github.com/user-attachments/assets/963c342b-c4b8-428a-a6df-681a190228ed" /> | <img width="1624" height="1056" alt="MG-490_modeloverview_columns_pr" src="https://github.com/user-attachments/assets/aca93514-5f44-4040-9aaa-63aacb752172" />
columns selector | <img width="282" height="430" alt="MG-490_modeloverview_columnsSelector_dev" src="https://github.com/user-attachments/assets/9c32505e-8dcd-4903-a436-18acfe7ca59f" /> | <img width="290" height="441" alt="MG-490_modeloverview_columnsSelector_pr" src="https://github.com/user-attachments/assets/d5fb1f83-9107-4ea6-8435-ca63004533f8" />


[MG-490]: https://sagebionetworks.jira.com/browse/MG-490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-451]: https://sagebionetworks.jira.com/browse/MG-451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ