### PR TITLE
fix(bixarena): move the model_error table after battle and round tables (SMR-592)

### DIFF
--- a/apps/bixarena/api/src/main/resources/db/migration/V1.0.0__create_tables.sql
+++ b/apps/bixarena/api/src/main/resources/db/migration/V1.0.0__create_tables.sql
@@ -29,21 +29,6 @@ CREATE TABLE api.model (
 CREATE INDEX idx_api_model_license ON api.model(license);
 CREATE INDEX idx_api_model_active ON api.model(active);
 
--- Model errors table
-CREATE TABLE api.model_error (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  model_id UUID NOT NULL REFERENCES api.model(id) ON DELETE CASCADE,
-  code INTEGER,
-  message VARCHAR(1000) NOT NULL,
-  battle_id UUID NOT NULL REFERENCES api.battle(id) ON DELETE CASCADE,
-  round_id UUID NOT NULL REFERENCES api.battle_round(id) ON DELETE CASCADE,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-
--- Indexes for model_error
-CREATE INDEX idx_api_model_error_model_id ON api.model_error(model_id);
-CREATE INDEX idx_api_model_error_created_at ON api.model_error(created_at DESC);
-
 -- Leaderboard snapshots table
 CREATE TABLE api.leaderboard_snapshot (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -151,3 +136,19 @@ CREATE TABLE api.battle_evaluation (
 -- Indexes for battle evaluation
 CREATE INDEX idx_api_battle_evaluation_outcome ON api.battle_evaluation(outcome);
 CREATE INDEX idx_api_battle_evaluation_created_at ON api.battle_evaluation(created_at DESC);
+
+
+-- Model errors table
+CREATE TABLE api.model_error (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  model_id UUID NOT NULL REFERENCES api.model(id) ON DELETE CASCADE,
+  code INTEGER,
+  message VARCHAR(1000) NOT NULL,
+  battle_id UUID NOT NULL REFERENCES api.battle(id) ON DELETE CASCADE,
+  round_id UUID NOT NULL REFERENCES api.battle_round(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Indexes for model_error
+CREATE INDEX idx_api_model_error_model_id ON api.model_error(model_id);
+CREATE INDEX idx_api_model_error_created_at ON api.model_error(created_at DESC);


### PR DESCRIPTION
## Description

Reordered table creation in the SQL migration file to ensure `model_error` table is created after the tables it references (`battle` and `battle_round`).

## Related Issue

```console
Caused by: org.postgresql.util.PSQLException: ERROR: relation "api.battle" does not exist
```


## Changelog

- Reorder table creation in migration to ensure `model_error` table is created after `battle` and `round`
