### PR TITLE
fix(bixarena): make the actuator health endpoint accessible without auth (SMR-591)

### DIFF
--- a/apps/bixarena/api-gateway/src/main/java/org/sagebionetworks/bixarena/api/gateway/configuration/RouteConfigConfiguration.java
+++ b/apps/bixarena/api-gateway/src/main/java/org/sagebionetworks/bixarena/api/gateway/configuration/RouteConfigConfiguration.java
@@ -18,6 +18,7 @@ public class RouteConfigConfiguration {
   RouteConfigRegistry routeConfigRegistry(RouteConfigProperties props) {
     Map<RouteKey, RouteConfig> typed = new LinkedHashMap<>();
 
+    // Load routes from OpenAPI-generated YAML
     for (RouteSpec r : props.routes()) {
       RouteKey key = RouteKey.of(r.method(), r.path());
       RouteConfig cfg = new RouteConfig(
@@ -34,6 +35,31 @@ public class RouteConfigConfiguration {
       }
     }
 
+    // Register infrastructure endpoints programmatically (not in OpenAPI spec)
+    // These endpoints allow anonymous access and don't require JWT minting
+    registerInfrastructureRoute(typed, "GET", "/actuator/health", 100);
+    registerInfrastructureRoute(typed, "GET", "/actuator/metrics", 100);
+    registerInfrastructureRoute(typed, "GET", "/favicon.ico", 100);
+
     return new RouteConfigRegistry(typed);
+  }
+
+  /**
+   * Helper to register infrastructure routes that aren't part of the OpenAPI spec.
+   * These routes allow anonymous access and don't need an audience (no JWT minting).
+   */
+  private void registerInfrastructureRoute(
+      Map<RouteKey, RouteConfig> routes,
+      String method,
+      String path,
+      int rateLimitRequestsPerMinute) {
+    RouteKey key = RouteKey.of(method, path);
+    RouteConfig cfg = new RouteConfig(
+        java.util.Set.of(),    // No scopes
+        null,                   // No audience (no JWT minting needed)
+        true,                   // Anonymous access allowed
+        rateLimitRequestsPerMinute
+    );
+    routes.put(key, cfg);
   }
 }

--- a/apps/bixarena/api-gateway/src/main/java/org/sagebionetworks/bixarena/api/gateway/configuration/SecurityConfiguration.java
+++ b/apps/bixarena/api-gateway/src/main/java/org/sagebionetworks/bixarena/api/gateway/configuration/SecurityConfiguration.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.bixarena.api.gateway.configuration;
 
 import lombok.RequiredArgsConstructor;
 import org.sagebionetworks.bixarena.api.gateway.filter.SessionToJwtFilter;
+import org.sagebionetworks.bixarena.api.gateway.routing.RouteConfigRegistry;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
@@ -24,16 +25,20 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 public class SecurityConfiguration {
 
   private final SessionToJwtFilter sessionToJwtFilter;
+  private final RouteConfigRegistry routeConfigRegistry;
 
   @Bean
   SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+    // Get all anonymous paths from registry (includes both OpenAPI routes and infrastructure endpoints)
+    String[] anonymousPaths = routeConfigRegistry.getAnonymousPaths();
+
     return http
       .csrf(ServerHttpSecurity.CsrfSpec::disable)
       // Add filter BEFORE authorization check
       .addFilterBefore(sessionToJwtFilter, SecurityWebFiltersOrder.AUTHORIZATION)
       .authorizeExchange(exchanges -> exchanges
-        // Infrastructure endpoints (not in OpenAPI spec, bypassed by SessionToJwtFilter)
-        .pathMatchers("/actuator/health", "/actuator/metrics", "/favicon.ico").permitAll()
+        // Allow anonymous access to routes marked as anonymousAccess=true in registry
+        .pathMatchers(anonymousPaths).permitAll()
         // Everything else requires authentication (set by filter)
         .anyExchange().authenticated()
       )

--- a/apps/bixarena/api-gateway/src/main/java/org/sagebionetworks/bixarena/api/gateway/filter/SessionToJwtFilter.java
+++ b/apps/bixarena/api-gateway/src/main/java/org/sagebionetworks/bixarena/api/gateway/filter/SessionToJwtFilter.java
@@ -51,13 +51,6 @@ public class SessionToJwtFilter implements WebFilter {
 
     log.debug("Processing request: {} {}", method, path);
 
-    // Step 0: Bypass filter for infrastructure/static endpoints (not in OpenAPI spec)
-    // These are handled by Spring Security permitAll or will 404 if not found
-    if (path.startsWith("/actuator/") || path.equals("/favicon.ico")) {
-      log.debug("Infrastructure endpoint, bypassing filter: {} {}", method, path);
-      return chain.filter(exchange);
-    }
-
     // Step 1: Check if route allows anonymous access
     if (routeConfigRegistry.isAnonymousAccessAllowed(method, path)) {
       log.debug("Anonymous access allowed for: {} {}", method, path);


### PR DESCRIPTION
## Description

The BixArena API Gateway's actuator health endpoint was incorrectly returning 401 Unauthorized errors instead of being publicly accessible. This occurred because infrastructure endpoints like `/actuator/health`, `/actuator/metrics`, and `/favicon.ico` were not registered in the route configuration registry, causing the SessionToJwtFilter to block unauthenticated requests before Spring Security could evaluate its `permitAll()` rules. This fix establishes a single source of truth for route configuration by programmatically registering infrastructure endpoints in the RouteConfigRegistry, eliminating hardcoded path definitions and ensuring these endpoints are properly recognized as public.

## Related Issue

Fixes [SMR-591](https://sagebionetworks.jira.com/browse/SMR-591)

## Changelog

- Add programmatic registration of infrastructure endpoints (/actuator/health, /actuator/metrics, /favicon.ico) to RouteConfigRegistry
- Update SecurityConfiguration to dynamically retrieve anonymous paths from registry instead of hardcoding them
- Add helper method registerInfrastructureRoute() for registering non-OpenAPI infrastructure endpoints
- Eliminate duplication between RouteConfigConfiguration and SecurityConfiguration for anonymous route definitions

## Preview

### Health check

```console
$ curl -i bixarena-api-gateway:8113/actuator/health
HTTP/1.1 200 OK
Content-Type: application/vnd.spring-boot.actuator.v3+json
Content-Length: 49
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-XSS-Protection: 0
Referrer-Policy: no-referrer

{"status":"UP","groups":["liveness","readiness"]}
```

> [!NOTE]
> This health check is used during the API Gateway deployment with CDK to determine whether the ECS task is healthy.

### Feature

The BixArena API Gateway now has:
- Publicly accessible actuator health and metrics endpoints without authentication requirements
- A single source of truth for route configuration, with infrastructure endpoints defined only in RouteConfigConfiguration
- Elimination of hardcoded path definitions in security configuration
- Proper handling of browser requests to /favicon.ico without throwing authentication errors
- Improved maintainability with infrastructure routes separate from OpenAPI-generated routes


[SMR-591]: https://sagebionetworks.jira.com/browse/SMR-591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ