### PR TITLE
fix(bixarena): fix 'Start Evaluating Models' button click handler

### DIFF
--- a/apps/bixarena/app/bixarena_app/main.py
+++ b/apps/bixarena/app/bixarena_app/main.py
@@ -320,7 +320,7 @@ def build_app():
         # Authenticated CTA button - navigates to battle page
         cta_btn_authenticated.click(
             lambda: navigator.show_page(1),
-            outputs=pages + prompt_outputs,
+            outputs=pages,
         )
 
         # Login CTA button - redirects to login page
@@ -411,7 +411,6 @@ def build_app():
         # Load CTA button visibility based on authentication
         demo.load(
             fn=update_cta_buttons_on_page_load,
-            inputs=None,
             outputs=[cta_btn_authenticated, cta_btn_login],
         )
 


### PR DESCRIPTION
## Description

This PR fixes two issues when clicking the "Start Evaluating Models" button:

- Clicking the button will raise the error due to mismatched output count
- Clicking the button for anonymous users will skip the login process because `inputs=None` was explicitly set.

The issues were probably caused from the updates after we implemented the CTA button.
 
## Changelog

- Fix "Start Evaluating Models" button throwing ValueError when clicked
- Fix "Start Evaluating Models" button not reflecting user authentication state

## Preview

![chrome-capture-2025-11-5](https://github.com/user-attachments/assets/60e45554-b86a-4ff8-9cb8-5b2b92f0037f)
