### PR TITLE
chore(synapse): mark update-synapse-api PRs as 'Ready for Review' (SMR-596)

### DIFF
--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           branch: synapse/update-synapse-api
           delete-branch: true
-          draft: always-true
+          draft: false
           title: 'chore(synapse): update Synapse API description and generated artifacts'
           commit-message: 'chore(synapse): update Synapse API description and generated artifacts'
           body: |
@@ -120,6 +120,7 @@ jobs:
 
             ## Review checklist
 
+            - [ ] Transition PR from "Ready for Review" -> "Draft" -> "Ready for Review" to trigger CI jobs
             - [ ] Verify that the API changes are expected
             - [ ] Check that generated artifacts build/compile successfully
             - [ ] Run tests to ensure compatibility


### PR DESCRIPTION
## Description

We would like to mark PRs opened by the `update-synapse-api` workflow to be marked as “Ready for Review” rather than as “Draft” so the reviewing team is notified that there is a PR awaiting their review. 

## Related Issue

[SMR-596](https://sagebionetworks.jira.com/browse/SMR-596)

## Changelog

- Mark PRs opened by the `update-synapse-api` workflow to be marked as “Ready for Review”

[SMR-596]: https://sagebionetworks.jira.com/browse/SMR-596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ