### PR TITLE
fix(model-ad): move comparison tool search input alignment over table and align displayed results component (MG-480, MG-481)

### DIFF
--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-controls/comparison-tool-controls.component.scss
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-controls/comparison-tool-controls.component.scss
@@ -1,13 +1,22 @@
 .controls {
+  position: relative;
   display: flex;
   flex-direction: row;
-  padding: 20px 0;
-  gap: 22px;
 
   .controls-left {
     display: flex;
     flex-direction: column;
+    align-items: center;
     width: var(--comparison-tool-primary-column-width);
+    padding: 20px;
+
+    explorers-comparison-tool-search-input {
+      position: absolute;
+      top: 100%;
+      z-index: 10;
+      width: 100%;
+      max-width: 200px;
+    }
   }
 
   .controls-right {
@@ -16,6 +25,8 @@
     align-items: start;
     justify-content: flex-end;
     flex-grow: 1;
+    border: 1px solid var(--color-gray-300);
+    padding: 20px;
 
     .significance-and-column-selector {
       display: flex;

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-controls/displayed-results/displayed-results.component.scss
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-controls/displayed-results/displayed-results.component.scss
@@ -7,7 +7,6 @@
   align-items: center;
   height: 100px;
   width: var(--comparison-tool-primary-column-width);
-  border: 1px solid var(--color-gray-300);
 
   h5 {
     font-weight: 700;


### PR DESCRIPTION
## Description

The search input field needs to be aligned above the table to match the design.  Also, borders in the Displayed Results component and other components need to be removed to match the creative.

## Related Issue

[MG-480](https://sagebionetworks.jira.com/browse/MG-480)
[MG-481](https://sagebionetworks.jira.com/browse/MG-481)

Fixes #(issue)

## Changelog
- Update positioning of search input
- Update borders, gaps and alignment of components to match the original design

## Preview
Before (Model-Overview)
Alignment is above the column row and borders exist around the input.  Also the input width is set to 100% of width.
<img width="2992" height="620" alt="image" src="https://github.com/user-attachments/assets/59da3239-737c-4b20-bf42-955a973ea703" />

After (Model-Overview)
Alignment is now matching the design by positioning the input above the table's upper-left hand corner.  The input also does not take 100% of the width.
<img width="2992" height="566" alt="image" src="https://github.com/user-attachments/assets/972f96bc-011f-45ba-b00f-f8b5050e52ae" />


Before (Gene Expression)
Same issues as in Model Overview
<img width="2994" height="724" alt="image" src="https://github.com/user-attachments/assets/734ec52b-7179-4bfd-8505-86261eae4a20" />

After (Gene Expression)
Alignment is fixed in this and other CTs
<img width="1496" height="283" alt="image" src="https://github.com/user-attachments/assets/43584944-3637-4fcc-9c1b-cd7ca9992514" />



[MG-480]: https://sagebionetworks.jira.com/browse/MG-480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-481]: https://sagebionetworks.jira.com/browse/MG-481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ