### PR TITLE
fix(model-ad): fix no results styling condition for CTs (MG-497)

### DIFF
--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.html
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.html
@@ -15,7 +15,7 @@
     [currentPageReportTemplate]="pagination?.currentPageReportTemplate ?? ''"
     [showPageLinks]="pagination?.showPageLinks ?? null"
   >
-    <ng-template pTemplate="emptymessage" let-rowData>
+    <ng-template pTemplate="emptymessage">
       @if (shouldShowNoDataMessage()) {
         <div class="no-results">No results found...</div>
       }

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.scss
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.scss
@@ -4,7 +4,11 @@
   .no-results {
     color: #a6a6a6;
     text-align: center;
-    padding: 15px 20px 20px;
+    min-height: 300px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-top: 1px solid var(--color-gray-300);
   }
 
   .p-datatable-tbody {

--- a/libs/explorers/comparison-tool/src/lib/help-links/help-links.component.html
+++ b/libs/explorers/comparison-tool/src/lib/help-links/help-links.component.html
@@ -1,4 +1,4 @@
-<div class="help-links">
+<div class="help-links" [class.has-data]="hasData()">
   <div class="help-links-inner">
     @if (viewConfig().legendEnabled) {
       <div>

--- a/libs/explorers/comparison-tool/src/lib/help-links/help-links.component.scss
+++ b/libs/explorers/comparison-tool/src/lib/help-links/help-links.component.scss
@@ -3,11 +3,15 @@
   align-items: center;
   padding: 10px 80px 10px 275px;
   height: 75px;
-  position: relative;
-  margin-top: -68px;
-  margin-bottom: 24px;
   z-index: 100;
   pointer-events: none;
+  border-top: 1px solid var(--color-gray-300);
+
+  &.has-data {
+    position: relative;
+    margin-top: -63px;
+    margin-bottom: 24px;
+  }
 
   .help-links-inner {
     display: flex;

--- a/libs/explorers/comparison-tool/src/lib/help-links/help-links.component.ts
+++ b/libs/explorers/comparison-tool/src/lib/help-links/help-links.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { ComparisonToolService } from '@sagebionetworks/explorers/services';
 
 @Component({
@@ -10,4 +10,9 @@ export class HelpLinksComponent {
   comparisonToolService = inject(ComparisonToolService);
 
   viewConfig = this.comparisonToolService.viewConfig;
+
+  hasData = computed(() => {
+    const unpinnedData = this.comparisonToolService.unpinnedData();
+    return unpinnedData.length > 0;
+  });
 }


### PR DESCRIPTION
## Description

When there are no results for a CT, the styling is broken.  This PR fixes the styling for this condition.

## Related Issue

[MG-497](https://sagebionetworks.jira.com/browse/MG-497)

## Changelog
- Add component logic to determine if div should display and apply the corresponding styles

## Preview
Before:
<img width="3024" height="1086" alt="image" src="https://github.com/user-attachments/assets/db82580a-8c30-45dc-bf98-f2c303dd3d88" />

After:
<img width="1512" height="731" alt="image" src="https://github.com/user-attachments/assets/00256d77-7ef9-46e4-bd40-257ef2580585" />


[MG-497]: https://sagebionetworks.jira.com/browse/MG-497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ