### PR TITLE
feat(model-ad): enable multi-column sort (MG-502)

### DIFF
--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.html
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.html
@@ -5,6 +5,8 @@
     [value]="data()"
     [customSort]="true"
     (sortFunction)="sortCallback($event)"
+    sortMode="multiple"
+    [defaultSortOrder]="-1"
     breakpoint="0"
     stripedRows
     showGridlines

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.ts
@@ -49,6 +49,6 @@ export class BaseTableComponent {
   };
 
   sortCallback(event: SortEvent) {
-    this.comparisonToolService.setSort(event.field, event.order);
+    this.comparisonToolService.setSort(event);
   }
 }

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-columns/comparison-tool-columns.component.html
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-columns/comparison-tool-columns.component.html
@@ -5,6 +5,7 @@
   showGridlines
   [customSort]="true"
   (sortFunction)="sortCallback($event)"
+  sortMode="multiple"
   [defaultSortOrder]="-1"
 >
   <ng-template pTemplate="header">

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-columns/comparison-tool-columns.component.spec.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-columns/comparison-tool-columns.component.spec.ts
@@ -68,25 +68,43 @@ describe('ComparisonToolColumnsComponent', () => {
 
   it('should update sort state when column sorts are clicked', async () => {
     const { user, service } = await setup();
-    expect(service.sortField()).toBe(undefined);
-    expect(service.sortOrder()).toBe(-1);
+    expect(service.multiSortMeta()).toStrictEqual([]);
 
     const firstColumnToSort = mockComparisonToolColumns[0];
     const firstColumnHeader = screen.getByRole('columnheader', { name: firstColumnToSort.name });
 
     await user.click(firstColumnHeader);
-    expect(service.sortField()).toBe(firstColumnToSort.data_key);
-    expect(service.sortOrder()).toBe(-1);
+    expect(service.multiSortMeta()).toEqual([{ field: firstColumnToSort.data_key, order: -1 }]);
 
     await user.click(firstColumnHeader);
-    expect(service.sortField()).toBe(firstColumnToSort.data_key);
-    expect(service.sortOrder()).toBe(1);
+    expect(service.multiSortMeta()).toEqual([{ field: firstColumnToSort.data_key, order: 1 }]);
 
     const secondColumnToSort = mockComparisonToolColumns[1];
     const secondColumnHeader = screen.getByRole('columnheader', { name: secondColumnToSort.name });
 
     await user.click(secondColumnHeader);
-    expect(service.sortField()).toBe(secondColumnToSort.data_key);
-    expect(service.sortOrder()).toBe(-1);
+    expect(service.multiSortMeta()).toEqual([{ field: secondColumnToSort.data_key, order: -1 }]);
+  });
+
+  it('should allow sorting by multiple columns when metaKey is held', async () => {
+    const { user, service } = await setup();
+    expect(service.multiSortMeta()).toStrictEqual([]);
+
+    const firstColumnToSort = mockComparisonToolColumns[0];
+    const firstColumnHeader = screen.getByRole('columnheader', { name: firstColumnToSort.name });
+
+    await user.click(firstColumnHeader);
+    expect(service.multiSortMeta()).toEqual([{ field: firstColumnToSort.data_key, order: -1 }]);
+
+    const secondColumnToSort = mockComparisonToolColumns[1];
+    const secondColumnHeader = screen.getByRole('columnheader', { name: secondColumnToSort.name });
+
+    await user.keyboard('{Meta>}');
+    await user.click(secondColumnHeader);
+    await user.keyboard('{/Meta}');
+    expect(service.multiSortMeta()).toEqual([
+      { field: firstColumnToSort.data_key, order: -1 },
+      { field: secondColumnToSort.data_key, order: -1 },
+    ]);
   });
 });

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-columns/comparison-tool-columns.component.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-columns/comparison-tool-columns.component.ts
@@ -21,6 +21,6 @@ export class ComparisonToolColumnsComponent {
   resultsCount = this.comparisonToolService.totalResultsCount;
 
   sortCallback(event: SortEvent) {
-    this.comparisonToolService.setSort(event.field, event.order);
+    this.comparisonToolService.setSort(event);
   }
 }

--- a/libs/explorers/services/src/lib/comparison-tool.service.ts
+++ b/libs/explorers/services/src/lib/comparison-tool.service.ts
@@ -3,10 +3,10 @@ import {
   ComparisonToolColumn,
   ComparisonToolConfig,
   ComparisonToolConfigColumn,
-  ComparisonToolConfigColumnTypeEnum,
   ComparisonToolViewConfig,
 } from '@sagebionetworks/explorers/models';
 import { isEqual } from 'lodash';
+import { SortEvent, SortMeta } from 'primeng/api';
 import { NotificationService } from './notification.service';
 
 /**
@@ -23,7 +23,7 @@ export class ComparisonToolService<T> {
   // If future tools have more dropdowns and different column selection caching requirements,
   // this cutoff may need to be included in the ui_config instead, so the cutoff can be set per tool.
   private readonly DEFAULT_DROPDOWNS_COLUMN_SELECTION_CACHE_CUTOFF_LEVEL = 2;
-  private readonly DEFAULT_SORT_ORDER = -1;
+  private readonly DEFAULT_MULTI_SORT_META: SortMeta[] = [];
   private readonly DEFAULT_VIEW_CONFIG: ComparisonToolViewConfig = {
     selectorsWikiParams: {},
     headerTitle: 'Comparison Tool',
@@ -51,8 +51,7 @@ export class ComparisonToolService<T> {
   private readonly isVisualizationOverviewVisibleSignal = signal(false);
   private readonly maxPinnedItemsSignal = signal<number>(50);
   private readonly pinnedItemsSignal = signal<Set<string>>(new Set());
-  private readonly sortFieldSignal = signal<string | undefined>(undefined);
-  private readonly sortOrderSignal = signal<number>(this.DEFAULT_SORT_ORDER);
+  private readonly multiSortMetaSignal = signal<SortMeta[]>(this.DEFAULT_MULTI_SORT_META);
   private readonly columnsForDropdownsSignal = signal<Map<string, ComparisonToolColumn[]>>(
     new Map(),
   );
@@ -66,8 +65,7 @@ export class ComparisonToolService<T> {
   readonly isVisualizationOverviewVisible = this.isVisualizationOverviewVisibleSignal.asReadonly();
   readonly maxPinnedItems = this.maxPinnedItemsSignal.asReadonly();
   readonly pinnedItems = this.pinnedItemsSignal.asReadonly();
-  readonly sortField = this.sortFieldSignal.asReadonly();
-  readonly sortOrder = this.sortOrderSignal.asReadonly();
+  readonly multiSortMeta = this.multiSortMetaSignal.asReadonly();
   readonly unpinnedData = this.unpinnedDataSignal.asReadonly();
   readonly pinnedData = this.pinnedDataSignal.asReadonly();
 
@@ -136,7 +134,7 @@ export class ComparisonToolService<T> {
     this.configsSignal.set(configs ?? []);
     this.totalResultsCount.set(0);
     this.resetPinnedItems();
-    this.setSort(undefined, this.DEFAULT_SORT_ORDER);
+    this.multiSortMetaSignal.set(this.DEFAULT_MULTI_SORT_META);
     this.setUnpinnedData([]);
     this.setPinnedData([]);
 
@@ -383,8 +381,7 @@ export class ComparisonToolService<T> {
     );
   }
 
-  setSort(sortField: string | undefined, sortOrder: number | undefined) {
-    this.sortFieldSignal.set(sortField);
-    this.sortOrderSignal.set(sortOrder || this.DEFAULT_SORT_ORDER);
+  setSort(event: SortEvent) {
+    this.multiSortMetaSignal.set(event.multiSortMeta || this.DEFAULT_MULTI_SORT_META);
   }
 }


### PR DESCRIPTION
## Description

Enable multi-column sort for the comparison tool.

## Related Issue

[MG-502](https://sagebionetworks.jira.com/browse/MG-502)

## Changelog

- Enable multi-column sort for the comparison tool

## Preview

`model-ad-build-images && model-ad-docker-start`

> [!NOTE]
> Sorting has not been implemented, so the table does not update when the sort is changed. Here, we're just demonstrating that the table column headers allow sort state to be set on multiple columns. 

Clicking with the metaKey (e.g. `⌘`) allows sort to be set on multiple columns. Clicking without the metaKey resets the sort.

https://github.com/user-attachments/assets/9dfe48b4-cdbb-4dd9-b19f-3e10a55f56ca

[MG-502]: https://sagebionetworks.jira.com/browse/MG-502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ