### PR TITLE
refactor(bixarena): remove `temperature` and `top_p` generation parameters (SMR-604)

### DIFF
--- a/apps/bixarena/app/bixarena_app/config/constants.py
+++ b/apps/bixarena/app/bixarena_app/config/constants.py
@@ -9,5 +9,4 @@ PROMPT_LEN_LIMIT = int(os.getenv("PROMPT_LEN_LIMIT", 5000))
 BATTLE_ROUND_LIMIT = int(os.getenv("BATTLE_ROUND_LIMIT", 20))
 
 # Generation parameters
-DEFAULT_TOP_P = 1.0
 MAX_RESPONSE_TOKENS = int(os.getenv("MAX_RESPONSE_TOKENS", 1024))

--- a/apps/bixarena/app/bixarena_app/model/api_provider.py
+++ b/apps/bixarena/app/bixarena_app/model/api_provider.py
@@ -62,7 +62,6 @@ def report_model_error(
 def get_api_provider_stream_iter(
     conv,
     model_api_dict,
-    top_p,
     max_new_tokens,
     battle_session=None,
     cookies: dict[str, str] | None = None,
@@ -72,7 +71,6 @@ def get_api_provider_stream_iter(
         stream_iter = openai_api_stream_iter(
             model_api_dict["model_name"],
             prompt,
-            top_p,
             max_new_tokens,
             api_base=model_api_dict.get("api_base"),
             api_key=model_api_dict.get("api_key"),
@@ -89,7 +87,6 @@ def get_api_provider_stream_iter(
 def openai_api_stream_iter(
     model_name,
     messages,
-    top_p,
     max_new_tokens,
     api_base=None,
     api_key=None,
@@ -114,7 +111,6 @@ def openai_api_stream_iter(
     gen_params = {
         "model": model_name,
         "prompt": messages,
-        "top_p": top_p,
         "max_new_tokens": max_new_tokens,
     }
 

--- a/apps/bixarena/app/bixarena_app/model/model_response.py
+++ b/apps/bixarena/app/bixarena_app/model/model_response.py
@@ -12,10 +12,7 @@ from bixarena_api_client import (
 
 from bixarena_app.api.api_client_helper import create_authenticated_api_client
 from bixarena_app.auth.request_auth import get_session_cookie
-from bixarena_app.config.constants import (
-    DEFAULT_TOP_P,
-    MAX_RESPONSE_TOKENS,
-)
+from bixarena_app.config.constants import MAX_RESPONSE_TOKENS
 from bixarena_app.config.conversation import Conversation
 from bixarena_app.model.api_provider import get_api_provider_stream_iter
 from bixarena_app.model.error_handler import handle_error_message
@@ -112,12 +109,10 @@ def _update_battle_round_with_responses(
 
 def bot_response(
     state,
-    top_p,
     max_new_tokens,
     battle_session: BattleSession | None = None,
     cookies: dict[str, str] | None = None,
 ):
-    top_p = float(top_p)
     max_new_tokens = int(max_new_tokens)
 
     if state.skip_next:
@@ -140,7 +135,6 @@ def bot_response(
     stream_iter = get_api_provider_stream_iter(
         conv,
         model_api_dict,
-        top_p,
         max_new_tokens,
         battle_session=battle_session,
         cookies=cookies,
@@ -182,7 +176,6 @@ def bot_response_multi(
     state0,
     state1,
     battle_session: BattleSession,
-    top_p=DEFAULT_TOP_P,
     max_new_tokens=MAX_RESPONSE_TOKENS,
     request: gr.Request | None = None,
 ):
@@ -209,7 +202,6 @@ def bot_response_multi(
         gen.append(
             bot_response(
                 states[i],
-                top_p,
                 max_new_tokens,
                 battle_session=battle_session,
                 cookies=cookies,


### PR DESCRIPTION
## Description

Remove `temperature` and `top_p` generation parameters from LLM API calls to rely on OpenRouter's [default settings](https://openrouter.ai/docs/api-reference/parameters). 

## Related Issue

[SMR-604](https://sagebionetworks.jira.com/browse/)

## Changelog

- Remove `temperature` and `top_p` parameters from LLM API calls, relying on OpenRouter defaults instead


[SMR-604]: https://sagebionetworks.jira.com/browse/SMR-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ