### PR TITLE
feat(model-ad): update ensembl URLs in model hero (MG-512)

### DIFF
--- a/libs/model-ad/model-details/src/lib/components/model-details-hero/model-details-hero.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-hero/model-details-hero.component.spec.ts
@@ -61,6 +61,20 @@ describe('ModelDetailsHeroComponent', () => {
       expect(ensemblLink.getAttribute('href')).toContain('Homo_sapiens');
     });
 
+    it('should use https', async () => {
+      await setup();
+      const gene = modelMock.genetic_info[0];
+      const ensemblLink = screen.getByRole('link', { name: gene.ensembl_gene_id });
+      expect(ensemblLink.getAttribute('href')).toMatch(/^https:/);
+    });
+
+    it('should use latest ensembl release version', async () => {
+      await setup();
+      const gene = modelMock.genetic_info[0];
+      const ensemblLink = screen.getByRole('link', { name: gene.ensembl_gene_id });
+      expect(ensemblLink.getAttribute('href')).toContain('sep2025');
+    });
+
     it('should display allele type', async () => {
       await setup();
       const gene = modelMock.genetic_info[2];

--- a/libs/model-ad/model-details/src/lib/components/model-details-hero/model-details-hero.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-hero/model-details-hero.component.ts
@@ -25,6 +25,6 @@ export class ModelDetailsHeroComponent {
 
   getGeneUrl(gene: string) {
     const species = gene.startsWith('ENSMUSG') ? 'Mus_musculus' : 'Homo_sapiens';
-    return `http://May2025.archive.ensembl.org/${species}/Gene/Summary?db=core;g=${gene}`;
+    return `https://sep2025.archive.ensembl.org/${species}/Gene/Summary?db=core;g=${gene}`;
   }
 }


### PR DESCRIPTION
## Description

Update ensembl URLs in model hero to use latest release and https.

## Related Issue

[MG-512](https://sagebionetworks.jira.com/browse/MG-512)

## Changelog

- Update ensembl URLs to use latest release and https

## Preview

`model-ad-build-images && model-ad-docker-start`

https://github.com/user-attachments/assets/44c54c5d-89ba-43b2-adf1-00c66df9c24e

[MG-512]: https://sagebionetworks.jira.com/browse/MG-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ