### PR TITLE
feat(model-ad): drive y-axis scale by y_axis_max (MG-515)

### DIFF
--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
@@ -6,6 +6,7 @@
   [xAxisLabelFormatter]="xAxisLabelFormatter"
   [xAxisCategories]="genotypeOrder()"
   [yAxisTitle]="yAxisTitle()"
+  [yAxisMax]="modelData().y_axis_max"
   [pointTooltipFormatter]="pointTooltipFormatter"
   [pointCategoryColors]="pointCategoryColors"
   [pointCategoryShapes]="pointCategoryShapes"


### PR DESCRIPTION
## Description

Drive y-axis max in model details boxplots by the `y_axis_max` field.

## Related Issue

[MG-515](https://sagebionetworks.jira.com/browse/MG-515)

## Changelog

- Drive y-axis max in model details boxplots by the `y_axis_max` field 

## Preview

`model-ad-build-images && model-ad-docker-start`

dev (current) | pr (updated) 
:---: | :---: 
<img width="1624" height="1056" alt="MG-515_dev" src="https://github.com/user-attachments/assets/09aa02a1-ec72-49b9-9ed9-b3e5769a52e0" /> | <img width="1624" height="1056" alt="MG-515_pr" src="https://github.com/user-attachments/assets/19c7f737-6e1c-4184-8a19-2a554535017d" />


[MG-515]: https://sagebionetworks.jira.com/browse/MG-515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ