### PR TITLE
chore(sage-monorepo): add BixArena and Model-AD to the GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - 'agora/v*'
       - 'amp-als/v*'
       - 'bixarena/v*'
+      - 'model-ad/v*'
       - 'openchallenges/v*'
       - 'sage/v*'
 


### PR DESCRIPTION
## Description

Add BixArena and Model-AD to the GitHub release workflow.
