### PR TITLE
refactor(bixarena): remove dev as default Spring active profile from `application.yml` (SMR-613)

### DIFF
--- a/apps/bixarena/api-gateway/.env.example
+++ b/apps/bixarena/api-gateway/.env.example
@@ -1,0 +1,2 @@
+# Environment name (dev, stage, prod)
+SPRING_PROFILES_ACTIVE=dev

--- a/apps/bixarena/api-gateway/src/main/resources/application.yml
+++ b/apps/bixarena/api-gateway/src/main/resources/application.yml
@@ -96,8 +96,6 @@ spring:
                       maxBackoff: 500ms
                       factor: 2
                       basedOnPreviousValue: false
-  profiles:
-    active: dev
   config:
     import: 'classpath:routes.yml'
 

--- a/apps/bixarena/api/.env.example
+++ b/apps/bixarena/api/.env.example
@@ -1,3 +1,6 @@
 # Auth Service Configuration
 # Base URL of the BixArena Auth Service for JWT validation
 AUTH_SERVICE_BASE_URL=http://bixarena-auth-service:8115
+
+# Environment name (dev, stage, prod)
+SPRING_PROFILES_ACTIVE=dev

--- a/apps/bixarena/api/src/main/resources/application.yml
+++ b/apps/bixarena/api/src/main/resources/application.yml
@@ -53,8 +53,6 @@ spring:
           time_zone: UTC
         default_schema: api
     open-in-view: false
-  profiles:
-    active: dev
 
 management:
   endpoints:

--- a/apps/bixarena/auth-service/.env.example
+++ b/apps/bixarena/auth-service/.env.example
@@ -1,2 +1,5 @@
 APP_AUTH_CLIENT_ID=
 APP_AUTH_CLIENT_SECRET=
+
+# Environment name (dev, stage, prod)
+SPRING_PROFILES_ACTIVE=dev

--- a/apps/bixarena/auth-service/src/main/resources/application.yml
+++ b/apps/bixarena/auth-service/src/main/resources/application.yml
@@ -53,8 +53,6 @@ spring:
           time_zone: UTC
         default_schema: auth
     open-in-view: false
-  profiles:
-    active: dev
 
 management:
   endpoints:


### PR DESCRIPTION
## Description

Remove default Spring active profile. The motivation is that with the "dev" profile, the API service wipe the database at startup. Hence, settings the active profile to "dev" is risky when deploying to staging and production environment, as forgetting to override the active profile with `SPRING_PROFILES_ACTIVE` would destroy the data and tables upon restarting the API service.

> [!NOTE]
> This PR requires to update the `.env` files of all the Spring projects: `bixarena-api-gateway`, `bixarena-api`, `bixarena-auth-service` (see their updated `.env.example` files).

## Related Issues

Resolves [SMR-613](https://sagebionetworks.jira.com/browse/SMR-613)

## Changelog

- Remove default Spring active profile from `application.yml`.
- Add `SPRING_PROFILES_ACTIVE` to the env files of the Spring projects.


[SMR-613]: https://sagebionetworks.jira.com/browse/SMR-613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ