### PR TITLE
fix(bixarena): fix horizontal alignment of next battle button (SMR-617)

### DIFF
--- a/apps/bixarena/app/bixarena_app/page/battle_page_css.py
+++ b/apps/bixarena/app/bixarena_app/page/battle_page_css.py
@@ -235,3 +235,14 @@ DISCLAIMER_CSS = """
     font-weight: 700;
 }
 """
+
+# CSS for Next Battle button
+NEXT_BATTLE_BUTTON_CSS = """
+#next-battle-row {
+    justify-content: center;
+}
+
+#next-battle-btn {
+    max-width: 240px;
+}
+"""

--- a/apps/bixarena/app/bixarena_app/page/bixarena_battle.py
+++ b/apps/bixarena/app/bixarena_app/page/bixarena_battle.py
@@ -39,6 +39,7 @@ from bixarena_app.page.battle_page_css import (
     DISCLAIMER_CSS,
     EXAMPLE_PROMPTS_CSS,
     INPUT_PROMPT_CSS,
+    NEXT_BATTLE_BUTTON_CSS,
 )
 from bixarena_app.page.example_prompt_ui import (
     PROMPT_CARD_CLICK_JS,
@@ -460,6 +461,7 @@ def build_side_by_side_ui_anony():
     {EXAMPLE_PROMPTS_CSS}
     {INPUT_PROMPT_CSS}
     {DISCLAIMER_CSS}
+    {NEXT_BATTLE_BUTTON_CSS}
     </style>
     """
 
@@ -525,13 +527,12 @@ def build_side_by_side_ui_anony():
             )
 
         # Next Round button
-        with gr.Row(visible=False) as next_battle_row:
-            with gr.Column(scale=2):
-                gr.HTML("")
-            with gr.Column(scale=1):
-                clear_btn = gr.Button(value="Next Battle", variant="primary")
-            with gr.Column(scale=2):
-                gr.HTML("")
+        with gr.Row(visible=False, elem_id="next-battle-row") as next_battle_row:
+            clear_btn = gr.Button(
+                value="Next Battle",
+                variant="primary",
+                elem_id="next-battle-btn",
+            )
 
         # Disclaimer
         disclaimer = gr.HTML(


### PR DESCRIPTION
## Description

Fix horizontal alignment to ensure the "Next Battle" button always aligned at center

## Related Issue

[SMR-617](https://sagebionetworks.jira.com/browse/SMR-617)

## Changelog

- Fix horizontal alignment to ensure the next battle button always aligned at center

## Preview

| Before | After |
|--------|--------|
| <img width="866" height="673" alt="Screen Shot 2025-11-14 at 12 34 23 PM" src="https://github.com/user-attachments/assets/abf64913-b77b-4c9c-92f1-d0aa366a04ca" /> | <img width="998" height="719" alt="Screen Shot 2025-11-14 at 3 34 51 PM" src="https://github.com/user-attachments/assets/3cf3465c-eca1-47a3-a94b-708ae986b6ca" /> | 

[SMR-617]: https://sagebionetworks.jira.com/browse/SMR-617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ