### PR TITLE
feat(model-ad): update model-ad search typeahead character limit to 1 (MG-526)

### DIFF
--- a/apps/model-ad/api/src/components/model-search.ts
+++ b/apps/model-ad/api/src/components/model-search.ts
@@ -4,6 +4,8 @@ import { NextFunction, Request, Response } from 'express';
 import { buildCacheKey, cache, sendProblemJson, setHeaders } from '../helpers';
 import { ModelCollection } from '../models';
 
+const MIN_QUERY_LENGTH = 1;
+
 export async function searchModels(query: string) {
   // Validate input is a primitive string and not an object
   if (typeof query !== 'string') {
@@ -93,12 +95,12 @@ export async function modelsSearchRoute(req: Request, res: Response, next: NextF
 
   const query = req.query.q;
 
-  if (query.length < 3 || query.length > 100) {
+  if (query.length < MIN_QUERY_LENGTH || query.length > 100) {
     sendProblemJson(
       res,
       400,
       'Bad Request',
-      'Query parameter q must be between 3 and 100 characters',
+      `Query parameter q must be between ${MIN_QUERY_LENGTH} and 100 characters`,
       req.path,
     );
     return;

--- a/apps/model-ad/app/e2e/search.spec.ts
+++ b/apps/model-ad/app/e2e/search.spec.ts
@@ -102,16 +102,6 @@ test.describe('search', () => {
     await expect(page.getByRole('heading', { level: 1 })).toHaveText(modelName);
   });
 
-  test('shows error when query is too short', async ({ page }) => {
-    await page.goto('/');
-
-    const input = page.getByPlaceholder(headerSearchPlaceholder);
-    await input.pressSequentially('ab');
-    await expect(
-      page.getByRole('listitem').filter({ hasText: /please enter at least three characters/i }),
-    ).toBeVisible();
-  });
-
   test('shows error when no results are returned', async ({ page }) => {
     await page.goto('/');
     const input = page.getByPlaceholder(headerSearchPlaceholder);

--- a/libs/model-ad/ui/src/lib/components/search-input/search-input.component.html
+++ b/libs/model-ad/ui/src/lib/components/search-input/search-input.component.html
@@ -7,4 +7,5 @@
   [getSearchResults]="getSearchResults"
   [checkQueryForErrors]="checkQueryForErrors"
   [formatResultForDisplay]="formatResultForDisplay"
+  [minimumSearchLength]="1"
 />


### PR DESCRIPTION
## Description

Update Model-AD search typeahead character limit to 1.

## Related Issue

[MG-526](https://sagebionetworks.jira.com/browse/MG-526)

## Changelog

- Update Model-AD search typeahead character limit to 1

## Preview

`model-ad-build-images && model-ad-docker-start`

https://github.com/user-attachments/assets/d689d5ba-3698-409d-b60a-3089c665b209


[MG-526]: https://sagebionetworks.jira.com/browse/MG-526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ