### PR TITLE
fix(model-ad): remove redirection to Java server until model-ad deployed stack supports api-next (MG-546)

### DIFF
--- a/apps/model-ad/apex/Caddyfile
+++ b/apps/model-ad/apex/Caddyfile
@@ -4,10 +4,10 @@
   }
 
   # Route /api/v1/comparison-tools to the next api, stripping /api
-  handle /api/v1/comparison-tools/* {
-    uri strip_prefix /api
-    reverse_proxy {env.API_NEXT_HOST}:{env.API_NEXT_PORT}
-  }
+  # handle /api/v1/comparison-tools/* {
+  #  uri strip_prefix /api
+  #  reverse_proxy {env.API_NEXT_HOST}:{env.API_NEXT_PORT}
+  # }
 
 	# Route all other /api/* requests to the default API service, stripping /api
   handle_path /api/* {


### PR DESCRIPTION
## Description

#3667 cut over to the new api-next Java Spring Boot server CT routes. However, the Model-AD infra has not yet been updated to deploy the Java Spring Boot server. We would like to wait on updating the infra until the api-next is more mature. For now, we will remove the redirect so that the app continues using the Express CT routes for now.

## Related Issue

[MG-546](https://sagebionetworks.jira.com/browse/MG-546)

## Changelog

- Remove redirection to Java server until model-ad deployed stack supports api-next

## Preview

`model-ad-build-images && model-ad-docker-start`

CT data still loaded in Model Overview CT: 

<img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/245a3e9a-2a0b-45c9-93fd-44b2f63de5d7" />

[MG-546]: https://sagebionetworks.jira.com/browse/MG-546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ