### PR TITLE
feat(model-ad): use a comma-separated list for pinned items (MG-530)

### DIFF
--- a/libs/explorers/services/src/lib/comparison-tool-url.service.spec.ts
+++ b/libs/explorers/services/src/lib/comparison-tool-url.service.spec.ts
@@ -49,7 +49,7 @@ describe('ComparisonToolUrlService', () => {
       [],
       expect.objectContaining({
         queryParams: expect.objectContaining({
-          pinned: ['id3', 'id1', 'id2'],
+          pinned: 'id3,id1,id2',
         }),
       }),
     );
@@ -69,7 +69,7 @@ describe('ComparisonToolUrlService', () => {
   });
 
   it('should deserialize pinned items', async () => {
-    queryParamsSubject.next({ pinned: ['id1', 'id2', 'id3'] });
+    queryParamsSubject.next({ pinned: 'id1,id2,id3' });
 
     await new Promise((resolve) => setTimeout(resolve, 100));
     const params = await firstValueFrom(service.params$);

--- a/libs/explorers/services/src/lib/comparison-tool-url.service.ts
+++ b/libs/explorers/services/src/lib/comparison-tool-url.service.ts
@@ -44,7 +44,7 @@ export class ComparisonToolUrlService {
     const params: Params = {};
 
     if (state.pinnedItems && state.pinnedItems.length > 0) {
-      params['pinned'] = [...state.pinnedItems];
+      params['pinned'] = state.pinnedItems.join(',');
     } else if (state.pinnedItems !== undefined) {
       params['pinned'] = null;
     }
@@ -56,16 +56,31 @@ export class ComparisonToolUrlService {
     const result: ComparisonToolUrlParams = {};
 
     if (params['pinned']) {
-      result.pinnedItems = this.toArray(params['pinned']);
+      const pinnedItems = this.parsePinnedParam(params['pinned']);
+      if (pinnedItems.length > 0) {
+        result.pinnedItems = pinnedItems;
+      }
     }
 
     return result;
   }
 
-  private toArray(value: string | string[] | null | undefined): string[] {
-    if (Array.isArray(value)) {
-      return value.map(String);
+  private parsePinnedParam(value: string | string[] | null | undefined): string[] {
+    if (value == null) {
+      return [];
     }
-    return [String(value)];
+
+    const values = Array.isArray(value) ? value : [value];
+
+    return values
+      .flatMap((entry) => `${entry}`.split(','))
+      .map((entry) => {
+        try {
+          return decodeURIComponent(entry);
+        } catch {
+          return entry;
+        }
+      })
+      .filter((entry) => entry.length > 0);
   }
 }

--- a/libs/explorers/services/src/lib/comparison-tool.service.spec.ts
+++ b/libs/explorers/services/src/lib/comparison-tool.service.spec.ts
@@ -229,7 +229,7 @@ describe('ComparisonToolService', () => {
           [],
           expect.objectContaining({
             queryParams: expect.objectContaining({
-              pinned: ['id1'],
+              pinned: 'id1',
             }),
           }),
         );
@@ -245,14 +245,14 @@ describe('ComparisonToolService', () => {
         tick();
 
         const lastCall = getLastNavigateCall();
-        expect(lastCall?.[1]?.queryParams?.pinned).toEqual(['id3', 'id1', 'id2']);
+        expect(lastCall?.[1]?.queryParams?.pinned).toEqual('id3,id1,id2');
       }));
 
       it('should restore pinned items from URL', fakeAsync(() => {
         injectService().initialize(mockComparisonToolDataConfig);
         flushInitialUrlSync();
 
-        queryParamsSubject.next({ pinned: ['id1', 'id2'] });
+        queryParamsSubject.next({ pinned: 'id1,id2' });
         tick(COMPARISON_TOOL_URL_SYNC_DEBOUNCE_MS + 1);
         tick();
 
@@ -269,7 +269,7 @@ describe('ComparisonToolService', () => {
         tick();
 
         const lastCall = getLastNavigateCall();
-        expect(lastCall?.[1]?.queryParams?.pinned).toEqual(['id2']);
+        expect(lastCall?.[1]?.queryParams?.pinned).toEqual('id2');
       }));
 
       it('should sync when pinning list of items', fakeAsync(() => {
@@ -280,7 +280,7 @@ describe('ComparisonToolService', () => {
         tick();
 
         const lastCall = getLastNavigateCall();
-        expect(lastCall?.[1]?.queryParams?.pinned).toEqual(['id1', 'id2', 'id3']);
+        expect(lastCall?.[1]?.queryParams?.pinned).toEqual('id1,id2,id3');
       }));
 
       it('should sync when resetting pinned items', fakeAsync(() => {
@@ -289,7 +289,7 @@ describe('ComparisonToolService', () => {
 
         service.pinItem('id1');
         tick();
-        expect(getLastNavigateCall()?.[1]?.queryParams?.pinned).toEqual(['id1']);
+        expect(getLastNavigateCall()?.[1]?.queryParams?.pinned).toEqual('id1');
 
         service.resetPinnedItems();
         tick();

--- a/libs/explorers/testing/src/lib/e2e/comparison-tool.ts
+++ b/libs/explorers/testing/src/lib/e2e/comparison-tool.ts
@@ -1,8 +1,17 @@
 import { expect, Locator, Page } from '@playwright/test';
 
 export const getPinnedQueryParams = (url: string): string[] => {
-  const params = new URL(url).searchParams.getAll('pinned');
-  return params;
+  const searchParams = new URL(url).searchParams;
+  const pinnedValues = searchParams.getAll('pinned');
+
+  if (!pinnedValues.length) {
+    return [];
+  }
+
+  return pinnedValues
+    .flatMap((value) => value.split(','))
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
 };
 
 export const getPinnedTable = (page: Page): Locator => page.locator('explorers-base-table').first();


### PR DESCRIPTION
## Description

Use comma-separated list for pinned items.

## Related Issue

[MG-530](https://sagebionetworks.jira.com/browse/MG-530)

## Changelog

- Use a comma-separated list for pinned items

## Preview

`model-ad-build-images && model-ad-docker-start`

https://github.com/user-attachments/assets/b88a1e2e-2d6d-4133-a792-eab701254066


[MG-530]: https://sagebionetworks.jira.com/browse/MG-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ