### PR TITLE
chore(agora): bump to mv75 (AG-1893)

### DIFF
--- a/apps/agora/data/.env.example
+++ b/apps/agora/data/.env.example
@@ -7,6 +7,6 @@ DB_HOST="agora-mongo" # must match mongo service name
 
 # specifies data release manifest and team images folder
 DATA_FILE="syn13363290"
-DATA_VERSION="74"
+DATA_VERSION="75"
 TEAM_IMAGES_ID="syn12861877"
 SYNAPSE_AUTH_TOKEN="agora-service-user-pat-here"


### PR DESCRIPTION
## Description

Bump `agora-data` to mv75 to align with latest data release.

## Related Issue

[AG-1893](https://sagebionetworks.jira.com/browse/AG-1893)

## Changelog

- Bump `agora-data` to mv75


[AG-1893]: https://sagebionetworks.jira.com/browse/AG-1893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ