### PR TITLE
feat(bixarena): illustrate when the leaderboard was last updated (SMR-633)

### DIFF
--- a/apps/bixarena/app/bixarena_app/page/bixarena_leaderboard.py
+++ b/apps/bixarena/app/bixarena_app/page/bixarena_leaderboard.py
@@ -30,26 +30,20 @@ class LeaderboardView:
         ]
 
 
-def create_subtitle_row_html(updated_at: str | datetime | None) -> str:
+def create_subtitle_row_html(updated_at: datetime | None) -> str:
     """Create HTML for subtitle row with optional time badge
 
     Args:
-        updated_at: ISO format date string or datetime when the leaderboard
-                    was last updated, or None if no timestamp available
+        updated_at: datetime when the leaderboard was last updated,
+                    or None if no timestamp available
 
     Returns:
         HTML string containing subtitle and time badge (if timestamp provided)
     """
     time_badge_html = ""
     if updated_at is not None:
-        # Convert to datetime if it's a string
-        if isinstance(updated_at, str):
-            dt = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
-        else:
-            dt = updated_at
-
         # Format date, e.g. "Dec 4, 2025"
-        formatted_date = dt.strftime("%b %-d, %Y")
+        formatted_date = updated_at.strftime("%b %-d, %Y")
 
         time_badge_html = f"""
         <div style="


### PR DESCRIPTION
## Description

This PR adds a "Last Updated" badge to the leaderboard page that displays when the leaderboard data was last fetched.

## Related Issue
[SMR-633](https://sagebionetworks.jira.com/browse/SMR-633)

## Changelog

- Add "Last Updated" badge with formatted date display in two-line layout


## Preview
<img width="969" height="556" alt="Screen Shot 2025-12-04 at 3 28 09 PM" src="https://github.com/user-attachments/assets/e72d417a-b79e-48d2-8f8f-51c1acc78f59" />


[SMR-633]: https://sagebionetworks.jira.com/browse/SMR-633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ