### PR TITLE
chore(bixarena): add double quotes around the GTM container id in env files

### DIFF
--- a/apps/bixarena/infra/cdk/.env.prod.example
+++ b/apps/bixarena/infra/cdk/.env.prod.example
@@ -11,4 +11,4 @@ ENV=prod
 # Use different container IDs for different environments to track traffic separately
 # Format: GTM-XXXXXXX (obtain from Google Tag Manager console)
 # Leave empty to disable analytics tracking
-GTM_CONTAINER_ID=GTM-5T42RNXT
+GTM_CONTAINER_ID="GTM-5T42RNXT"

--- a/apps/bixarena/infra/cdk/.env.stage.example
+++ b/apps/bixarena/infra/cdk/.env.stage.example
@@ -64,4 +64,4 @@ OPENROUTER_API_KEY=
 # Use different container IDs for different environments to track traffic separately
 # Format: GTM-XXXXXXX (obtain from Google Tag Manager console)
 # Leave empty to disable analytics tracking
-GTM_CONTAINER_ID=GTM-PHN25DCP
+GTM_CONTAINER_ID="GTM-PHN25DCP"


### PR DESCRIPTION
## Description

Add double quotes around the GTM container id in env files.