### PR TITLE
fix(bixarena): reassign ranks sequentially after filtering models by minimum evaluations

### DIFF
--- a/apps/bixarena/tools/bixarena_tools/leaderboard/leaderboard.py
+++ b/apps/bixarena/tools/bixarena_tools/leaderboard/leaderboard.py
@@ -208,6 +208,11 @@ def snapshot_add(
 
                 leaderboard_entries = filtered_entries
 
+                # Reassign ranks sequentially after filtering
+                if not significant:
+                    for new_rank, entry in enumerate(leaderboard_entries, start=1):
+                        entry["rank"] = new_rank
+
                 if skipped_models:
                     console.print(
                         f"\n[yellow]⚠ Warning: Skipped {len(skipped_models)} "


### PR DESCRIPTION
## Description

When models are filtered after computation, the displayed ranks show gaps (4, 10, 12, 14...) instead of sequential numbering (1, 2, 3, 4...). This fix reassigns ranks sequentially after filtering in BT score mode, while preserving tied ranks in significance mode.

## Changelog

- Reassign ranks sequentially after filtering models by minimum evaluations in BT score ranking mode

## Preview

| Before | After |
|--------|--------|
| <img width="844" height="323" alt="Screen Shot 2025-12-04 at 10 09 35 PM" src="https://github.com/user-attachments/assets/7ce12723-43b8-4d3b-a0ac-7a53c1284014" /> | <img width="847" height="334" alt="Screen Shot 2025-12-04 at 10 10 13 PM" src="https://github.com/user-attachments/assets/b5373aa8-5218-4c03-9ff7-31632c766b04" /> | 




