### PR TITLE
refactor(bixarena): update home page tagline to specify target audience

### DIFF
--- a/apps/bixarena/app/bixarena_app/page/bixarena_home.py
+++ b/apps/bixarena/app/bixarena_app/page/bixarena_home.py
@@ -61,7 +61,7 @@ def create_intro_section():
             gr.HTML(f"""
             <div style="display: flex; align-items: center; justify-content: center; gap: 3rem; padding: 2.5rem 1.5rem; flex-wrap: wrap;">
                 <!-- Text Content -->
-                <div style="flex: 1; min-width: 300px; max-width: 600px;">
+                <div style="flex: 1; min-width: 300px; max-width: 620px;">
                     <p style="font-size: var(--text-xl); margin-bottom: 1.5rem; color: var(--body-text-color-subdued);">
                         Welcome to BioArena
                     </p>
@@ -71,8 +71,7 @@ def create_intro_section():
 
                     <p style="font-size: var(--text-xl); line-height: 1.75; color: var(--body-text-color-subdued);">
                         BioArena crowdsources the benchmarking of AI models to unlock the
-                        next breakthrough in biomedicine, inviting a global community of
-                        digital contributors.
+                        next breakthrough in biomedicine, inviting a global community of researchers, clinicians, and biomedical enthusiasts.
                     </p>
                 </div>
 


### PR DESCRIPTION
## Description

This PR updates the home page tagline.

## Changelog

- Update home page tagline to replace "digital contributors" with "researchers, clinicians, and biomedical enthusiasts"
- Adjust intro section text container max-width from 600px to 620px for improved text flow with the longer tagline

## Preview

<img width="1410" height="781" alt="Screen Shot 2025-12-05 at 11 06 14 AM" src="https://github.com/user-attachments/assets/0dcd96f5-ce1a-4796-90cc-37a6d9f7bd52" />
