### PR TITLE
refactor(bixarena): reorganize arena rules and add synapse login step (SMR-636)

### DIFF
--- a/apps/bixarena/app/bixarena_app/page/bixarena_home.py
+++ b/apps/bixarena/app/bixarena_app/page/bixarena_home.py
@@ -262,11 +262,11 @@ def build_how_it_works_section():
                         <span style="color: var(--color-accent); font-weight: 600;">01</span>
                     </div>
                     <h3 style="color: var(--body-text-color); margin: 0; font-size: var(--text-lg); font-weight: 600;">
-                        Start a Battle
+                        Log in with Synapse
                     </h3>
                 </div>
                 <p style="color: var(--body-text-color-subdued); line-height: 1.5; margin: 0;">
-                    Pick a curated biomedical question or submit your own custom prompt. Two AI models are randomly chosen to face off.
+                    BioArena uses Synapse for sign-in. Synapse is Sage Bionetworks’ secure platform for biomedical researchers and includes account verification and multi-factor authentication for protection.
                 </p>
             </div>
 
@@ -277,11 +277,11 @@ def build_how_it_works_section():
                         <span style="color: var(--color-accent); font-weight: 600;">02</span>
                     </div>
                     <h3 style="color: var(--body-text-color); margin: 0; font-size: var(--text-lg); font-weight: 600;">
-                        Compare Responses
+                        Start a Battle
                     </h3>
                 </div>
                 <p style="color: var(--body-text-color-subdued); line-height: 1.5; margin: 0;">
-                    Review the two AI-generated answers side by side. The models remain anonymous so you can focus purely on the quality of the content.
+                    Pick a curated biomedical question or submit your own prompt. Two AI models are randomly chosen to face off, and their identities stay anonymous so you can focus purely on the response quality.
                 </p>
             </div>
 
@@ -296,7 +296,7 @@ def build_how_it_works_section():
                     </h3>
                 </div>
                 <p style="color: var(--body-text-color-subdued); line-height: 1.5; margin: 0;">
-                    Decide which model demonstrates clearer reasoning or insight. Your input directly shapes model performance metrics.
+                    Review the two AI-generated answers side by side and decide which model demonstrates clearer reasoning or insight. Your choice directly shapes model performance metrics.
                 </p>
             </div>
 


### PR DESCRIPTION
## Description

This PR reorganizes the Arena Rules section to prioritize Synapse login as the first step, making it clear to users that authentication is required before participating in battles and consolidating the rest rules into 3 rules.

## Related Issue

[SMR-636](https://sagebionetworks.jira.com/browse/SMR-636)

## Changelog

- Reorganize Arena Rules to prioritize Synapse login as Step 01
- Rephrase the wordings of Arena Rules to fit new steps

## Preview

### Before
<img width="1311" height="420" alt="Screen Shot 2025-12-05 at 3 56 42 PM" src="https://github.com/user-attachments/assets/9696d568-3a6e-4391-b8ce-3b0fb73c662a" />

### After 
<img width="1315" height="441" alt="Screen Shot 2025-12-05 at 3 43 13 PM" src="https://github.com/user-attachments/assets/ec4bb693-ea94-4a7a-b642-a7cee98815f5" />


[SMR-636]: https://sagebionetworks.jira.com/browse/SMR-636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ