### PR TITLE
chore(model-ad): remove gene details link for mvp release (MG-589)

### DIFF
--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/primary-identifier-controls/primary-identifier-controls.component.html
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/primary-identifier-controls/primary-identifier-controls.component.html
@@ -4,20 +4,23 @@
   </div>
 
   <div class="primary-control-icons">
-    <button
-      type="button"
-      (click)="viewDetailsWasClicked()"
-      [pTooltip]="viewConfig().viewDetailsTooltip"
-      tooltipPosition="top"
-      tooltipStyleClass="tooltip"
-      [ariaLabel]="'View Details'"
-    >
-      <explorers-svg-icon
-        imagePath="/explorers-assets/icons/external-link.svg"
-        [enableHoverEffects]="false"
-        altText="link"
-      />
-    </button>
+    <!--- TODO this conditional logic can be removed once view details functionality is implemented in MG-588 -->
+    @if (viewConfig().viewDetailsTooltip) {
+      <button
+        type="button"
+        (click)="viewDetailsWasClicked()"
+        [pTooltip]="viewConfig().viewDetailsTooltip"
+        tooltipPosition="top"
+        tooltipStyleClass="tooltip"
+        [ariaLabel]="'View Details'"
+      >
+        <explorers-svg-icon
+          imagePath="/explorers-assets/icons/external-link.svg"
+          [enableHoverEffects]="false"
+          altText="link"
+        />
+      </button>
+    }
 
     <button
       type="button"

--- a/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.ts
+++ b/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.ts
@@ -97,6 +97,10 @@ export class GeneExpressionComparisonToolComponent implements OnInit, OnDestroy 
     selectorsWikiParams: this.selectorsWikiParams,
     headerTitle: ComparisonToolPage.GeneExpression,
     filterResultsButtonTooltip: 'Filter results by Model, Biological Domain, and more',
+    viewDetailsTooltip: '',
+    viewDetailsClick: () => {
+      // TODO add logic to display details pages MG-588
+    },
     legendPanelConfig: this.legendPanelConfig,
     visualizationOverviewPanes: this.visualizationOverviewPanes,
     rowsPerPage: 10,


### PR DESCRIPTION
## Description
For the MVP release, we don't have the data yet for the gene details so we will hide the gene details button until we do.

## Related Issue
[MG-589](https://sagebionetworks.jira.com/browse/MG-589)

## Changelog
- Add conditional logic to remove the link to see gene details pages

## Preview

<!-- Demonstrate the feature or bug fix implemented in this PR. For example, -->
<!-- - a screencast that illustrates a new UI feature (e.g. using https://gifcap.dev) -->
<!-- - a request example and its response from a new/updated REST API endpoint -->


[MG-589]: https://sagebionetworks.jira.com/browse/MG-589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ