### PR TITLE
fix(model-ad): update explorers default action-primary to match agora and model-ad (MG-483, MG-577)

### DIFF
--- a/libs/explorers/styles/src/lib/_variables.scss
+++ b/libs/explorers/styles/src/lib/_variables.scss
@@ -6,7 +6,7 @@ $main-colors: (
   secondary: #8b8ad1,
   tertiary: #42c7bb,
 
-  action-primary: #4f33a3,
+  action-primary: #5081a7,
   action-primary-rgb: 80 129 167,
 
   success: #6db56d,


### PR DESCRIPTION
## Description

Update explorers default `action-primary` color to match Agora and Model-AD palettes.

## Related Issue

- [MG-483](https://sagebionetworks.jira.com/browse/MG-483)
- [MG-577](https://sagebionetworks.jira.com/browse/MG-577)

## Changelog

- Update explorers default `action-primary` color to match Agora and Model-AD palettes

## Preview

`model-ad-build-images && model-ad-docker-start`

Update to search color: 

<img width="1624" height="1056" alt="MG-577" src="https://github.com/user-attachments/assets/44a751df-c7d1-4b3b-8527-99f2331bdde0" />

Update to comparison tool: 

https://github.com/user-attachments/assets/30356970-fa66-43e0-bb43-dfe604678692

[MG-483]: https://sagebionetworks.jira.com/browse/MG-483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-577]: https://sagebionetworks.jira.com/browse/MG-577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ