### PR TITLE
fix(model-ad): prevent focus from persisting after clicking view details button (MG-629)

### DIFF
--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/primary-identifier-controls/primary-identifier-controls.component.html
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/primary-identifier-controls/primary-identifier-controls.component.html
@@ -6,7 +6,7 @@
   <div class="primary-control-icons">
     <button
       type="button"
-      (click)="viewDetailsWasClicked()"
+      (click)="viewDetailsWasClicked($event)"
       [pTooltip]="viewConfig().viewDetailsTooltip"
       tooltipPosition="top"
       tooltipStyleClass="tooltip"

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/primary-identifier-controls/primary-identifier-controls.component.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/primary-identifier-controls/primary-identifier-controls.component.ts
@@ -46,8 +46,12 @@ export class PrimaryIdentifierControlsComponent {
     return isPinned ? 'Unpin this row' : 'Pin this row to the top of the list';
   });
 
-  viewDetailsWasClicked() {
+  viewDetailsWasClicked(event: MouseEvent) {
     this.viewConfig().viewDetailsClick(this.id(), this.label());
+
+    // MG-629: Remove focus from button and its container to prevent focus-within state from persisting
+    const button = event.currentTarget as HTMLElement;
+    button.blur();
   }
 
   pinToggle() {


### PR DESCRIPTION
## Description

Prevent focus from persisting after clicking view details button.

## Related Issue

[MG-629](https://sagebionetworks.jira.com/browse/MG-629)

## Changelog

- Prevent focus from persisting after clicking view details button

## Preview

`model-ad-build-images && model-ad-docker-start`

https://github.com/user-attachments/assets/e3178f9d-0481-4ea7-9228-19eeaea67b0b

[MG-629]: https://sagebionetworks.jira.com/browse/MG-629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ