### PR TITLE
fix(agora): clean up docker build cache and add logs to track disk usage during e2e tests (AG-1921)

### DIFF
--- a/.github/workflows/e2e-explorer.yaml
+++ b/.github/workflows/e2e-explorer.yaml
@@ -115,6 +115,27 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
               && ${cmd}"
 
+      - name: Snapshot disk usage before Prune unused Docker build cache
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+              && echo 'Disk usage for root filesystem:' \
+              && df -h / \
+              && echo 'Disk usage for /var/lib/docker:' \
+              && (df -h /var/lib/docker || echo '/var/lib/docker not mounted')"
+
+      - name: Prune unused Docker build cache
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+              && docker builder prune -af || true"
+
+      - name: Snapshot disk usage before Explorer start
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+              && echo 'Disk usage for root filesystem:' \
+              && df -h / \
+              && echo 'Disk usage for /var/lib/docker:' \
+              && (df -h /var/lib/docker || echo '/var/lib/docker not mounted')"
+
       - name: Write Synapse PAT for Explorer
         run: |
           env_filename="apps/${{ inputs.explorer }}/data/.env"
@@ -132,6 +153,14 @@ jobs:
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
               && ${cmd}"
+
+      - name: Snapshot disk usage after Explorer start
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+              && echo 'Disk usage for root filesystem:' \
+              && df -h / \
+              && echo 'Disk usage for /var/lib/docker:' \
+              && (df -h /var/lib/docker || echo '/var/lib/docker not mounted')"
 
       - name: Write out Explorer data logs
         if: ${{ failure() }}
@@ -155,6 +184,14 @@ jobs:
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
               && ${cmd}"
+
+      - name: Snapshot disk usage before e2e tests
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+              && echo 'Disk usage for root filesystem:' \
+              && df -h / \
+              && echo 'Disk usage for /var/lib/docker:' \
+              && (df -h /var/lib/docker || echo '/var/lib/docker not mounted')"
 
       - name: Stop Explorer
         run: |

--- a/apps/agora/data/README.md
+++ b/apps/agora/data/README.md
@@ -2,8 +2,7 @@
 
 ## Introduction
 
-This Python project downloads an Agora data release from Synapse, then seeds and indexes the data in
-MongoDB.
+This Python project downloads an Agora data release from Synapse, then seeds and indexes the data in MongoDB.
 
 ## Usage
 


### PR DESCRIPTION
## Description

Clean up docker build cache and add logs to track disk usage during e2e tests.

## Related Issue

[AG-1921](https://sagebionetworks.jira.com/browse/AG-1921)

## Changelog

- Add debugging logs
- Clean up docker build cache


[AG-1921]: https://sagebionetworks.jira.com/browse/AG-1921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ