### PR TITLE
fix(agora): use large runner to prevent agora e2e tests from running out of disk space (AG-1921)

### DIFF
--- a/.github/workflows/e2e-explorer.yaml
+++ b/.github/workflows/e2e-explorer.yaml
@@ -70,7 +70,7 @@ jobs:
     environment: ${{ github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository && format('{0}-pr', inputs.explorer) || inputs.explorer }}
     timeout-minutes: 60
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-4core-16GBRAM-150GBSSD
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

The Agora e2e jobs have been failing after running out of disk space. Here, we use the large GitHub runner instead so the jobs have more disk space available. For debugging info, see #3757.

## Related Issue

[AG-1921](https://sagebionetworks.jira.com/browse/AG-1921)

## Changelog

- Use large GitHub runner for e2e jobs

[AG-1921]: https://sagebionetworks.jira.com/browse/AG-1921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ