### PR TITLE
fix(agora): fix for hydration and enabledBlocking error (AG-1920)

### DIFF
--- a/apps/agora/app/src/app/app.config.ts
+++ b/apps/agora/app/src/app/app.config.ts
@@ -7,12 +7,7 @@ import {
   provideZoneChangeDetection,
 } from '@angular/core';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
-import {
-  provideRouter,
-  UrlSerializer,
-  withEnabledBlockingInitialNavigation,
-  withInMemoryScrolling,
-} from '@angular/router';
+import { provideRouter, UrlSerializer, withInMemoryScrolling } from '@angular/router';
 import { BASE_PATH as API_CLIENT_BASE_PATH } from '@sagebionetworks/agora/api-client';
 import { configFactory, ConfigService } from '@sagebionetworks/agora/config';
 import { BASE_PATH as SYNAPSE_API_CLIENT_BASE_PATH } from '@sagebionetworks/synapse/api-client';
@@ -69,7 +64,6 @@ export const appConfig: ApplicationConfig = {
     provideMarkdown(),
     provideRouter(
       routes,
-      withEnabledBlockingInitialNavigation(),
       withInMemoryScrolling({
         scrollPositionRestoration: 'enabled',
       }),


### PR DESCRIPTION
## Description

This fixes the runtime error:
`NG05001: Configuration error: found both hydration and enabledBlocking initial navigation in the same application, which is a contradiction.`

This removes `withEnabledBlockingInitialNavigation()` from the router configuration since `provideClientHydration()` already handles the initial navigation blocking needed for SSR hydration.

## Related Issue

[AG-1920](https://sagebionetworks.jira.com/browse/AG-1920)

## Changelog
- Fix the error in app.config.ts

[AG-1920]: https://sagebionetworks.jira.com/browse/AG-1920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ