### PR TITLE
fix(model-ad): fix fetching pinned data in gene expression CT and update e2e tests to catch similar issues in the future (MG-642)

### DIFF
--- a/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.ts
+++ b/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.ts
@@ -128,7 +128,7 @@ export class GeneExpressionComparisonToolComponent implements OnInit, OnDestroy 
       const categories = this.query().categories;
       const pinnedItems = this.query().pinnedItems;
       const sortMeta = this.query().multiSortMeta;
-      this.getPinnedData(pinnedItems, categories, sortMeta);
+      this.getPinnedData(categories, pinnedItems, sortMeta);
     }
   });
 


### PR DESCRIPTION
## Description

This PR fixes a critical bug in the Gene Expression Comparison Tool where pinned data was not being fetched correctly due to incorrect parameter ordering.

## Related Issue

[MG-642](https://sagebionetworks.jira.com/browse/MG-642)

## Changelog

- Fix parameter order in `getPinnedData` method call to correctly pass categories before pinned items
- Update Gene Expression e2e tests to catch similar issues in the future

## Preview

`model-ad-build-images && model-ad-docker-start`

https://github.com/user-attachments/assets/febfd831-0444-4c30-8325-db890aae2619

[MG-642]: https://sagebionetworks.jira.com/browse/MG-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ