### PR TITLE
chore(model-ad): update gene count on home page (MG-634)

### DIFF
--- a/libs/model-ad/home/src/lib/home.component.ts
+++ b/libs/model-ad/home/src/lib/home.component.ts
@@ -24,7 +24,7 @@ export class HomeComponent {
     },
     {
       label: 'Genes',
-      value: '30K+',
+      value: '20K+',
     },
     {
       label: 'Models',


### PR DESCRIPTION
## Description

Update gene count on Model-AD home page.

## Related Issue

[MG-634](https://sagebionetworks.jira.com/browse/MG-634)

## Changelog

- Update gene count on Model-AD home page

## Preview

`model-ad-build-images && model-ad-docker-start`

dev (current - 30k) | this PR (updated - 20k)
:---: | :---: 
<img width="1624" height="1056" alt="MG-634_dev" src="https://github.com/user-attachments/assets/1c1420ea-d8b5-4821-888a-65e65170a81f" /> | <img width="1624" height="1056" alt="MG-634_feature" src="https://github.com/user-attachments/assets/dffb799a-558e-4027-99ce-9154464db7b6" />

[MG-634]: https://sagebionetworks.jira.com/browse/MG-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ