### PR TITLE
feat(model-ad): right align CT primary column name (MG-663)

### DIFF
--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-columns/comparison-tool-columns.component.scss
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-columns/comparison-tool-columns.component.scss
@@ -37,6 +37,16 @@
       margin-right: 22px;
     }
 
+    &.primary {
+      .column-header-text {
+        text-align: right;
+      }
+
+      .column-header-sort {
+        margin-left: 16px;
+      }
+    }
+
     span:hover {
       color: var(--color-action-primary);
     }


### PR DESCRIPTION
## Description

Right align CT primary column name.

## Related Issue

[MG-663](https://sagebionetworks.jira.com/browse/MG-663)

## Changelog

- Right align CT primary column name.

## Preview

`model-ad-build-images && model-ad-docker-start`

before (dev) | after (this PR)
:---: | :---: 
<img width="1624" height="1056" alt="MG-663_dev" src="https://github.com/user-attachments/assets/103265a7-897e-4773-a02d-8db548811140" /> | <img width="1624" height="1056" alt="MG-663_feature" src="https://github.com/user-attachments/assets/4f35de2e-6045-4945-9b41-436893629f8c" />


[MG-663]: https://sagebionetworks.jira.com/browse/MG-663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ