### PR TITLE
chore: undo nx alias now that the Nx team has solved the terminal issues (SMR-30)

### DIFF
--- a/dev-env.sh
+++ b/dev-env.sh
@@ -19,10 +19,6 @@ function workspace-cd {
 # Add local npm binaries to PATH
 export PATH="$PATH:$WORKSPACE_DIR/node_modules/.bin"
 
-# Alias nx to use pnpm nx to avoid Nx CLI issues
-# See: https://github.com/nrwl/nx/issues/30470
-alias nx='pnpm nx'
-
 function workspace-install-nodejs-dependencies {
   pnpm install --frozen-lockfile
 }
@@ -198,7 +194,7 @@ function workspace-nx-cloud-help {
 function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
 
 function check-vscode-version {
-  expected="1.91.1"
+  expected="1.108.0"
   actual="$(code --version | head -n 1)"
   if [ $(version $actual) -lt $(version $expected) ]; then
     echo "📦 Please update VS Code (${actual}) to version ${expected} or above."


### PR DESCRIPTION
## Description

Undo nx alias now that the Nx team has solved the terminal glitches.

## Related Issue

- [SMR-30](https://sagebionetworks.jira.com/browse/SMR-30)
- https://github.com/Sage-Bionetworks/sage-monorepo/pull/3649

## Changelog

- Undo the `nx` alias now that the Nx team has solved the terminal issues
- Update the minimal version of VS Code that developers should use 



[SMR-30]: https://sagebionetworks.jira.com/browse/SMR-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ