### PR TITLE
fix: restore nx alias until the Nx team fix is released and we update Nx

### DIFF
--- a/dev-env.sh
+++ b/dev-env.sh
@@ -19,6 +19,12 @@ function workspace-cd {
 # Add local npm binaries to PATH
 export PATH="$PATH:$WORKSPACE_DIR/node_modules/.bin"
 
+# Alias nx to use pnpm nx to avoid Nx CLI issues
+# See: https://github.com/nrwl/nx/issues/30470
+# Update: Nx fixed the issue via #33369, which is not released yet.
+# Keeping the alias for now to avoid issues until the fix is released.
+alias nx='pnpm nx'
+
 function workspace-install-nodejs-dependencies {
   pnpm install --frozen-lockfile
 }


### PR DESCRIPTION
## Description

This PR restore the `nx` alias until 1) the Nx team releases their fix and 2) we have adopted this new Nx release.