### PR TITLE
feat(model-ad): adding ability to override the hero image (AG-1870)

### DIFF
--- a/apps/agora/app/src/app/app.config.ts
+++ b/apps/agora/app/src/app/app.config.ts
@@ -7,7 +7,12 @@ import {
   provideZoneChangeDetection,
 } from '@angular/core';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
-import { provideRouter, UrlSerializer, withInMemoryScrolling } from '@angular/router';
+import {
+  provideRouter,
+  UrlSerializer,
+  withComponentInputBinding,
+  withInMemoryScrolling,
+} from '@angular/router';
 import { BASE_PATH as API_CLIENT_BASE_PATH } from '@sagebionetworks/agora/api-client';
 import { configFactory, ConfigService } from '@sagebionetworks/agora/config';
 import { BASE_PATH as SYNAPSE_API_CLIENT_BASE_PATH } from '@sagebionetworks/synapse/api-client';
@@ -64,6 +69,7 @@ export const appConfig: ApplicationConfig = {
     provideMarkdown(),
     provideRouter(
       routes,
+      withComponentInputBinding(),
       withInMemoryScrolling({
         scrollPositionRestoration: 'enabled',
       }),

--- a/apps/agora/app/src/app/app.routes.ts
+++ b/apps/agora/app/src/app/app.routes.ts
@@ -108,6 +108,7 @@ export const routes: Route[] = [
       title: 'Agora | Terms of Service',
       description:
         'Agora is powered by Synapse, a platform for supporting scientific collaborations centered around shared biomedical data sets. Our goal is to make biomedical research more transparent, more reproducible, and more accessible to a broader audience of scientists.',
+      heroBackgroundImagePath: 'agora-assets/images/hero-background.svg',
     },
   },
   {

--- a/libs/explorers/shared/src/lib/components/terms-of-service/terms-of-service.component.html
+++ b/libs/explorers/shared/src/lib/components/terms-of-service/terms-of-service.component.html
@@ -1,8 +1,5 @@
 <div id="terms-of-service-container">
-  <explorers-hero
-    title="Terms of Service"
-    backgroundImagePath="explorers-assets/images/background.svg"
-  />
+  <explorers-hero title="Terms of Service" [backgroundImagePath]="heroBackgroundImagePath()" />
   <div class="terms-of-service">
     @if (isLoading) {
       <div class="loading-icon">

--- a/libs/explorers/shared/src/lib/components/terms-of-service/terms-of-service.component.spec.ts
+++ b/libs/explorers/shared/src/lib/components/terms-of-service/terms-of-service.component.spec.ts
@@ -26,12 +26,12 @@ describe('TermsOfServiceComponent', () => {
       mockService.getTermsOfService.mockReturnValue(of(mockMarkdown));
     }
 
-    await render(TermsOfServiceComponent, {
+    const renderResult = await render(TermsOfServiceComponent, {
       componentProviders: [{ provide: SynapseApiService, useValue: mockService }],
       imports: [MockHeroComponent, MockLoadingIconComponent, MarkdownModule.forRoot()],
     });
 
-    return { mockService };
+    return { mockService, renderResult };
   }
 
   it('should display the terms of service content after loading', async () => {
@@ -40,5 +40,22 @@ describe('TermsOfServiceComponent', () => {
     await waitFor(() => {
       expect(screen.getByText(mockContent)).toBeInTheDocument();
     });
+  });
+
+  it('uses the default hero background when no value is provided', async () => {
+    const { renderResult } = await setup();
+    expect(renderResult.fixture.componentInstance.heroBackgroundImagePath()).toBe(
+      'explorers-assets/images/background.svg',
+    );
+  });
+
+  it('updates the hero background when input is overridden', async () => {
+    const { renderResult } = await setup();
+
+    renderResult.fixture.componentRef.setInput('heroBackgroundImagePath', 'custom-assets/hero.svg');
+
+    expect(renderResult.fixture.componentInstance.heroBackgroundImagePath()).toBe(
+      'custom-assets/hero.svg',
+    );
   });
 });

--- a/libs/explorers/shared/src/lib/components/terms-of-service/terms-of-service.component.ts
+++ b/libs/explorers/shared/src/lib/components/terms-of-service/terms-of-service.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, inject, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, DestroyRef, inject, input, OnInit, ViewEncapsulation } from '@angular/core';
 
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterModule } from '@angular/router';
@@ -21,6 +21,7 @@ export class TermsOfServiceComponent implements OnInit {
 
   content = '';
   isLoading = true;
+  heroBackgroundImagePath = input<string>('explorers-assets/images/background.svg');
 
   ngOnInit() {
     this.loadTOS();


### PR DESCRIPTION
## Description
The shared TOS component uses an explorer asset for the background image.  This PR adds the ability to override the background image asset.

## Related Issue

[AG-1870](https://sagebionetworks.jira.com/browse/AG-1870)

## Changelog
- Update Agora to use the Agora's hero background asset and not the default for the TOS page.

## Preview

Before:
<img width="2660" height="345" alt="image" src="https://github.com/user-attachments/assets/4dbf503b-ccdd-446a-84c1-c2708dc84e71" />

After:
<img width="2659" height="367" alt="image" src="https://github.com/user-attachments/assets/dd0c5528-844f-490a-8962-451b3879c5dd" />


[AG-1870]: https://sagebionetworks.jira.com/browse/AG-1870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ