### PR TITLE
fix(model-ad): change local mongo image to 5.x (MG-684)

### DIFF
--- a/apps/model-ad/mongo/Dockerfile
+++ b/apps/model-ad/mongo/Dockerfile
@@ -1,1 +1,1 @@
-FROM mirror.gcr.io/mongo:6.0.3
+FROM mirror.gcr.io/mongo:5.0.32


### PR DESCRIPTION
## Description
Matching mongo image major version with DocumentDB major version to align with best practices and lead to less mismatches in deployment behavior between Mongo and DocumentDB.

## Related Issue

[MG-684](https://sagebionetworks.jira.com/browse/MG-684)

## Changelog
- Changed version to 5.0.32

## Testing
Note that the docker volume must be removed before rebuilding the stack.

[MG-684]: https://sagebionetworks.jira.com/browse/MG-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ