### PR TITLE
fix(agora): change local mongo image to 5.x (AG-1924)

### DIFF
--- a/apps/agora/mongo/Dockerfile
+++ b/apps/agora/mongo/Dockerfile
@@ -1,1 +1,1 @@
-FROM mirror.gcr.io/mongo:6.0.3
+FROM mirror.gcr.io/mongo:5.0.32


### PR DESCRIPTION
## Description
Matching mongo image major version with DocumentDB major version to align with best practices and lead to less mismatches in deployment behavior between Mongo and DocumentDB.

## Related Issue

[AG-1924](https://sagebionetworks.jira.com/browse/AG-1924)

## Changelog
- Changed version to 5.0.32

## Testing
Note that the docker volume must be removed before rebuilding the stack.

[AG-1924]: https://sagebionetworks.jira.com/browse/AG-1924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ