### PR TITLE
chore: add dependency `mdx-truly-sane-lists` to the docs build workflow (SMR-666)

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -27,5 +27,5 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material mkdocstrings mkdocstrings-python termynal
+      - run: pip install mkdocs-material mkdocstrings mkdocstrings-python termynal mdx-truly-sane-lists
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
## Description

Add the dependency `mdx-truly-sane-lists` to the docs build workflow.

We should consider to build the docs site using the dev container like we do in other workflow. This will remove this kind of issues that occur because updated dependencies must be specified in two places. Another benefit would be to use the same version of these dependencies thanks to the lock file, which is currently not used in the GitHub workflow.

Moreover, we are only building the docs after merging to `main`. We should also run it in PRs that modify the docs files. For example, we do this when updating the dev container.

## Related Issue

Fixes [SMR-666](https://sagebionetworks.jira.com/browse/SMR-666)

## Changelog

- Add the dependency `mdx-truly-sane-lists` to the docs build workflow


[SMR-666]: https://sagebionetworks.jira.com/browse/SMR-666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ