### PR TITLE
fix(model-ad): alignment on help links (MG-678)

### DIFF
--- a/libs/explorers/comparison-tool/src/lib/help-links/help-links.component.scss
+++ b/libs/explorers/comparison-tool/src/lib/help-links/help-links.component.scss
@@ -1,7 +1,7 @@
 .help-links {
   display: flex;
   align-items: center;
-  padding: 10px 80px 10px 275px;
+  padding: 10px 0 10px calc(var(--comparison-tool-primary-column-width));
   height: 75px;
   z-index: 100;
   pointer-events: none;


### PR DESCRIPTION
## Description
This fixes the alignment of the Help Links (Legend & Visualization Overview links)

## Related Issue
[MG-678](https://sagebionetworks.jira.com/browse/MG-678)

## Changelog

- Updated SCSS to use the correct value (based on the right edge of the primary column of the comparison table)

## Preview
Before
<img width="801" height="193" alt="image" src="https://github.com/user-attachments/assets/e0f337af-4c90-4a2e-b009-09396c9ed6a0" />

After
<img width="784" height="182" alt="image" src="https://github.com/user-attachments/assets/02ba6830-2a4f-46b5-b02b-72b2b4ca81fb" />



[MG-678]: https://sagebionetworks.jira.com/browse/MG-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ