### PR TITLE
feat(model-ad): pass selected filters to backend for gene expression and disease correlation comparison tools (MG-671, MG-672)

### DIFF
--- a/libs/model-ad/disease-correlation-comparison-tool/src/lib/disease-correlation-comparison-tool.component.ts
+++ b/libs/model-ad/disease-correlation-comparison-tool/src/lib/disease-correlation-comparison-tool.component.ts
@@ -179,6 +179,10 @@ export class DiseaseCorrelationComparisonToolComponent implements OnInit, OnDest
       currentQuery.multiSortMeta,
     );
 
+    const selectedFilters = this.comparisonToolHelperService.getSelectedFilters(
+      currentQuery.filters,
+    );
+
     const query: DiseaseCorrelationSearchQuery = {
       categories: currentQuery.categories,
       items: currentQuery.pinnedItems,
@@ -186,6 +190,11 @@ export class DiseaseCorrelationComparisonToolComponent implements OnInit, OnDest
       pageNumber: currentQuery.pageNumber,
       pageSize: currentQuery.pageSize,
       search: currentQuery.searchTerm,
+      age: selectedFilters['age'],
+      modelType: selectedFilters['model_type'],
+      modifiedGenes: selectedFilters['modified_genes'],
+      name: selectedFilters['name'],
+      sex: selectedFilters['sex'],
       sortFields,
       sortOrders,
     };

--- a/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.ts
+++ b/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.ts
@@ -185,6 +185,10 @@ export class GeneExpressionComparisonToolComponent implements OnInit, OnDestroy 
       currentQuery.multiSortMeta,
     );
 
+    const selectedFilters = this.comparisonToolHelperService.getSelectedFilters(
+      currentQuery.filters,
+    );
+
     const query: GeneExpressionSearchQuery = {
       categories: currentQuery.categories,
       items: currentQuery.pinnedItems,
@@ -192,6 +196,9 @@ export class GeneExpressionComparisonToolComponent implements OnInit, OnDestroy 
       pageNumber: currentQuery.pageNumber,
       pageSize: currentQuery.pageSize,
       search: currentQuery.searchTerm,
+      biodomains: selectedFilters['biodomains'],
+      modelType: selectedFilters['model_type'],
+      name: selectedFilters['name'],
       sortFields,
       sortOrders,
     };


### PR DESCRIPTION
## Description

Pass selected filters to backend for gene expression and disease correlation comparison tools.

## Related Issue

- [MG-671](https://sagebionetworks.jira.com/browse/MG-671)
- [MG-672](https://sagebionetworks.jira.com/browse/MG-672)

## Changelog

- Pass selected filters to backend for gene expression and disease correlation comparison tools

## Preview

`model-ad-build-images && model-ad-docker-start`

https://github.com/user-attachments/assets/6d2c36bd-95d1-4562-a792-da283e282efe


https://github.com/user-attachments/assets/7f8140f5-89f5-4df5-a18f-fa23c8ff852d




[MG-671]: https://sagebionetworks.jira.com/browse/MG-671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-672]: https://sagebionetworks.jira.com/browse/MG-672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ