### PR TITLE
fix(model-ad): export gene expression CT name link_text in CSV (MG-703)

### DIFF
--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-table.component.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-table.component.ts
@@ -112,7 +112,13 @@ export class ComparisonToolTableComponent implements AfterViewInit {
 
     const data = this.pinnedData();
     const siteUrl = window.location.origin;
-    return this.comparisonToolHelperService.buildComparisonToolCsvRows(data, config, siteUrl);
+    return this.comparisonToolHelperService.buildComparisonToolCsvRows(
+      data,
+      config,
+      siteUrl,
+      'heatmap',
+      this.viewConfig().linkExportField,
+    );
   }
 
   pinAll() {

--- a/libs/explorers/models/src/lib/comparison-tool.ts
+++ b/libs/explorers/models/src/lib/comparison-tool.ts
@@ -69,6 +69,7 @@ export interface ComparisonToolViewConfig {
   allowPinnedImageDownload: boolean;
   defaultSort?: readonly { readonly field: string; readonly order: 1 | -1 }[];
   heatmapCircleClickTransformFn?: heatmapCircleClickTransformFn;
+  linkExportField: 'link_url' | 'link_text';
 }
 
 export interface ComparisonToolFilterOption {

--- a/libs/explorers/services/src/lib/comparison-tool.service.ts
+++ b/libs/explorers/services/src/lib/comparison-tool.service.ts
@@ -62,6 +62,7 @@ export class ComparisonToolService<T> {
     rowsPerPage: 10,
     rowIdDataKey: '_id',
     allowPinnedImageDownload: true,
+    linkExportField: 'link_url',
   };
 
   // Private State Signals

--- a/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.ts
+++ b/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.ts
@@ -141,6 +141,7 @@ export class GeneExpressionComparisonToolComponent implements OnInit, OnDestroy 
         footer: 'Significance is considered to be an adjusted p-value < 0.05',
       };
     },
+    linkExportField: 'link_text',
   };
 
   constructor() {


### PR DESCRIPTION
## Description

Export gene expression CT `name` field `link_text`  in CSV rather than `link_url`.

## Related Issue

[MG-703](https://sagebionetworks.jira.com/browse/MG-703)

## Changelog

- Export gene expression CT `name` field `link_text` in CSV rather than `link_url`
- Add `linkExportField` option to comparison tool view config to allow comparison tools to configure whether link columns export 'link_url' (default) or 'link_text' in CSV exports. Allows for future extension to `ui_config` to allow specifying a `link_export_field` for each link column definition

## Preview

`model-ad-build-images && model-ad-docker-start`

1. Navigate to the CT
2. Pin any row
3. Click Download
4. Click CSV data
5. Click Download
6. Open CSV

### Gene Expression CT 

Before (dev) -- `name` uses `link_url`: 

<img width="1184" height="83" alt="image" src="https://github.com/user-attachments/assets/7c9e619a-abfe-4bd9-b8ab-0eebd6d1cb2a" />

After (this PR) -- `name` uses `link_text`: 
<img width="1015" height="77" alt="image" src="https://github.com/user-attachments/assets/b8ad7a29-df8a-4b58-b523-9906ec3ec600" />

### Model overview CT 

Unchanged in this PR, still uses `link_url` -- see `gene_expression`, `disease_correlation`, `jax_strain`, etc...

<img width="2130" height="54" alt="image" src="https://github.com/user-attachments/assets/11021c9f-66bc-4548-9c2a-fa55e4618a75" />

[MG-703]: https://sagebionetworks.jira.com/browse/MG-703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ