### PR TITLE
fix(explorers): fallback to default hero image path when no value provided via route data for ToS (MG-705)

### DIFF
--- a/libs/explorers/shared/src/lib/components/terms-of-service/terms-of-service.component.html
+++ b/libs/explorers/shared/src/lib/components/terms-of-service/terms-of-service.component.html
@@ -1,7 +1,7 @@
 <div id="terms-of-service-container">
   <explorers-hero
     title="Terms of Service"
-    [backgroundImagePath]="effectiveHeroBackgroundImagePath()"
+    [backgroundImagePath]="heroBackgroundImagePathOrDefault()"
   />
   <div class="terms-of-service">
     @if (isLoading) {

--- a/libs/explorers/shared/src/lib/components/terms-of-service/terms-of-service.component.spec.ts
+++ b/libs/explorers/shared/src/lib/components/terms-of-service/terms-of-service.component.spec.ts
@@ -57,22 +57,22 @@ describe('TermsOfServiceComponent', () => {
     );
   });
 
-  it('uses default for effectiveHeroBackgroundImagePath when heroBackgroundImagePath is undefined', async () => {
+  it('uses default for heroBackgroundImagePathOrDefault when heroBackgroundImagePath is undefined', async () => {
     const { renderResult } = await setup();
     const component = renderResult.fixture.componentInstance;
 
     expect(component.heroBackgroundImagePath()).toBeUndefined();
-    expect(component.effectiveHeroBackgroundImagePath()).toBe(
+    expect(component.heroBackgroundImagePathOrDefault()).toBe(
       'explorers-assets/images/background.svg',
     );
   });
 
-  it('uses provided value for effectiveHeroBackgroundImagePath when heroBackgroundImagePath is set', async () => {
+  it('uses provided value for heroBackgroundImagePathOrDefault when heroBackgroundImagePath is set', async () => {
     const { renderResult } = await setup();
     const component = renderResult.fixture.componentInstance;
 
     renderResult.fixture.componentRef.setInput('heroBackgroundImagePath', 'custom-assets/hero.svg');
 
-    expect(component.effectiveHeroBackgroundImagePath()).toBe('custom-assets/hero.svg');
+    expect(component.heroBackgroundImagePathOrDefault()).toBe('custom-assets/hero.svg');
   });
 });

--- a/libs/explorers/shared/src/lib/components/terms-of-service/terms-of-service.component.ts
+++ b/libs/explorers/shared/src/lib/components/terms-of-service/terms-of-service.component.ts
@@ -31,7 +31,7 @@ export class TermsOfServiceComponent implements OnInit {
   isLoading = true;
   heroBackgroundImagePath = input<string | undefined>();
 
-  effectiveHeroBackgroundImagePath = computed(
+  heroBackgroundImagePathOrDefault = computed(
     () => this.heroBackgroundImagePath() ?? 'explorers-assets/images/background.svg',
   );
 


### PR DESCRIPTION
## Description

The ToS component automatically binds route data to component inputs, but when a route doesn't define `heroBackgroundImagePath` (like Model AD's routes), Angular binds `undefined` to the input, overriding the component's default value and causing the hero to render with a missing background image. This fix changes the component to use a fallback when the input is `undefined`, ensuring the default background is used when no value is provided via route data.

## Related Issue

[MG-705](https://sagebionetworks.jira.com/browse/MG-705)

## Changelog

- Fallback to default hero image path when no value provided via route data for ToS

## Preview

`model-ad-build-images && model-ad-docker-start` 

`http://localhost:8000/terms-of-service`

<img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/eeb785a1-4ff4-4e16-ae46-e762d5181bb2" />


[MG-705]: https://sagebionetworks.jira.com/browse/MG-705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ