### PR TITLE
fix(sage): move useAgentSkills setting to top-level settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -85,7 +85,7 @@
     "rm": false,
     "rmdir": false,
     "wc": true,
-    "wget": false,
-    "chat.useAgentSkills": true
-  }
+    "wget": false
+  },
+  "chat.useAgentSkills": true
 }


### PR DESCRIPTION
## Description

`chat.useAgentSkills` was inadvertently nested within another settings object, rather than at the top-level of the settings file. This prevented Copilot from automatically discovering the skill. This PR moves the setting to the top-level of the settings file.

## Related Issue

N/A

## Changelog

- Move useAgentSkills setting to top-level settings