### PR TITLE
fix(agora): ensure that y-axis boxplot labels are visible (AG-1942)

### DIFF
--- a/libs/explorers/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/explorers/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -35,7 +35,11 @@ const defaultPointCategoryOffset = 0.3;
 const defaultPointCategoryJitterMax = 0.02;
 
 const Y_AXIS_TICK_LABELS_MAX_WIDTH = 80;
-const SPACE_FOR_Y_AXIS_NAME = 15;
+const SPACE_FOR_Y_AXIS_NAME = 18;
+// The total left margin for the y-axis. Use a hardcoded value to ensure y-axis labels and plot areas
+// are aligned across multiple charts. ECharts' `containLabel: true` will shift the plot area if tick
+// labels or axis names change, so it can't guarantee cross-chart alignment.
+const Y_AXIS_LEFT_MARGIN = Y_AXIS_TICK_LABELS_MAX_WIDTH + SPACE_FOR_Y_AXIS_NAME;
 
 export class BoxplotChart {
   chart: ECharts | undefined;
@@ -180,6 +184,12 @@ export class BoxplotChart {
       max: yAxisMax ? yAxisMax + yAxisPadding : undefined,
     };
     return yAxisOptions;
+  }
+
+  private getYAxisLeftMargin(chartStyle: string): number {
+    // Handle grayGrid's smaller font to ensure y-axis label is at the leftmost edge of the plot
+    const adjustment = chartStyle === 'grayGrid' ? -3 : 0;
+    return Y_AXIS_LEFT_MARGIN + adjustment;
   }
 
   setOptions(boxplotProps: BoxplotProps) {
@@ -387,7 +397,7 @@ export class BoxplotChart {
       },
       grid: {
         top: title ? 60 : 20,
-        left: Y_AXIS_TICK_LABELS_MAX_WIDTH + SPACE_FOR_Y_AXIS_NAME,
+        left: this.getYAxisLeftMargin(chartStyle),
         right: 20,
         containLabel: false,
       },


### PR DESCRIPTION
## Description

Ensure that y-axis boxplot labels are visible in Agora and Model-AD.

## Related Issue

[AG-1942](https://sagebionetworks.jira.com/browse/AG-1942)

## Changelog

- Ensure that y-axis boxplot labels are visible

## Preview

```
model-ad-build-images && model-ad-docker-start
workspace-docker-stop
agora-build-images && agora-docker-start
```
app | before (dev) | after (this PR) | change
:---: | :---: | :---: | :---:
Agora | <img width="1624" height="1056" alt="AG-1942_agora_dev" src="https://github.com/user-attachments/assets/8a9a7e69-027e-4934-ae37-2421851d14dd" /> | <img width="1624" height="1056" alt="AG-1942_agora_PR" src="https://github.com/user-attachments/assets/d9c2ac6b-53e0-45b4-b705-0d3f10141f5b" /> | y-axis label fully visible
Model-AD | <img width="1624" height="1056" alt="AG-1942_modelAD_dev" src="https://github.com/user-attachments/assets/04b41f17-42ee-465e-87df-7d8638d1b112" /> | <img width="1624" height="1056" alt="AG-1942_modelAd_PR" src="https://github.com/user-attachments/assets/e4d9de8e-c2a1-436f-afa4-0fe05bd4ee00" /> | unchanged

[AG-1942]: https://sagebionetworks.jira.com/browse/AG-1942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ