### PR TITLE
fix(agora): prevent layout shift from inactive tabs during scroll (AG-1948)

### DIFF
--- a/apps/agora/app/e2e/gene-details.spec.ts
+++ b/apps/agora/app/e2e/gene-details.spec.ts
@@ -1,4 +1,5 @@
 import { expect, Page, test } from '@playwright/test';
+import { waitForScrollToStop } from '@sagebionetworks/explorers/testing/e2e';
 import { baseURL } from '../playwright.config';
 import { GCT_RNA_SUBCATEGORIES } from './helpers/constants';
 import { waitForSpinnerNotVisible } from './helpers/utils';
@@ -25,6 +26,7 @@ test.describe('gene details', () => {
     await page.goto('/genes/ENSG00000178209/evidence/rna#consistency-of-change');
 
     await waitForSpinnerNotVisible(page);
+    await waitForScrollToStop(page);
 
     const header = page.getByRole('heading', { name: 'Consistency of Change in Expression' });
     await expect(header).toBeInViewport();

--- a/apps/model-ad/app/e2e/model-details.spec.ts
+++ b/apps/model-ad/app/e2e/model-details.spec.ts
@@ -1,4 +1,5 @@
 import { expect, Page, test } from '@playwright/test';
+import { waitForScrollToStop } from '@sagebionetworks/explorers/testing/e2e';
 import { baseURL } from '../playwright.config';
 import { searchAndGetSearchListItems } from './helpers/search';
 
@@ -12,30 +13,6 @@ async function expectPageAtTop(page: Page) {
 
 async function expectPageNotAtTop(page: Page) {
   expect(await isPageAtTop(page)).toBe(false);
-}
-
-async function waitForScrollToStop(page: Page, timeout = 5000) {
-  let previousOffset = await page.evaluate(() => window.pageYOffset);
-  let stableCount = 0;
-  const requiredStableChecks = 10;
-
-  await expect
-    .poll(
-      async () => {
-        const currentOffset = await page.evaluate(() => window.pageYOffset);
-
-        if (currentOffset === previousOffset) {
-          stableCount++;
-          return stableCount >= requiredStableChecks;
-        } else {
-          stableCount = 0;
-          previousOffset = currentOffset;
-          return false;
-        }
-      },
-      { timeout, intervals: [200] },
-    )
-    .toBe(true);
 }
 
 test.describe('model details', () => {

--- a/libs/agora/genes/src/lib/components/gene-details/gene-details.component.html
+++ b/libs/agora/genes/src/lib/components/gene-details/gene-details.component.html
@@ -7,7 +7,7 @@
           <button
             class="gene-details-nav-scroll gene-details-nav-scroll-prev"
             (click)="slideNavigation(-1)"
-            >
+          >
             <fa-icon [icon]="faAngleLeft"></fa-icon>
           </button>
         }
@@ -20,7 +20,7 @@
                   [ngClass]="{
                     active: activePanel === item.name || activeParent === item.name,
                   }"
-                  >
+                >
                   <a (click)="onNavigationItemClick(item)">
                     {{ item.label }}
                     <span class="gene-details-nav-icon"></span>
@@ -33,7 +33,7 @@
                             <li
                               class="gene-details-subnav-item"
                               [ngClass]="{ active: activePanel === subItem.name }"
-                              >
+                            >
                               <a (click)="onNavigationItemClick(subItem)">
                                 {{ subItem.label }}
                                 <span class="gene-details-nav-icon"></span>
@@ -53,7 +53,7 @@
           <button
             class="gene-details-nav-scroll gene-details-nav-scroll-next"
             (click)="slideNavigation(1)"
-            >
+          >
             <fa-icon [icon]="faAngleRight"></fa-icon>
           </button>
         }
@@ -61,58 +61,46 @@
     </div>
 
     <div class="gene-details-body">
-      <ng-template #panelTemplate let-panel>
-        @if (!panel.disabled) {
-          <div
-            class="gene-details-panel"
-            [ngClass]="{
-              active: activePanel === panel.name,
-            }"
-            >
-            @if (panel.name === 'summary') {
-              <agora-gene-soe [gene]="gene"></agora-gene-soe>
-            }
+      @if (activePanel === 'summary') {
+        <div class="gene-details-panel active">
+          <agora-gene-soe [gene]="gene"></agora-gene-soe>
+        </div>
+      }
 
-            @if (panel.name === 'rna') {
-              <agora-gene-evidence-rna [gene]="gene"></agora-gene-evidence-rna>
-            }
+      @if (activePanel === 'rna') {
+        <div class="gene-details-panel active">
+          <agora-gene-evidence-rna [gene]="gene"></agora-gene-evidence-rna>
+        </div>
+      }
 
-            @if (panel.name === 'protein') {
-              <agora-gene-evidence-proteomics [gene]="gene"></agora-gene-evidence-proteomics>
-            }
+      @if (activePanel === 'protein') {
+        <div class="gene-details-panel active">
+          <agora-gene-evidence-proteomics [gene]="gene"></agora-gene-evidence-proteomics>
+        </div>
+      }
 
-            @if (panel.name === 'metabolomics') {
-              <agora-gene-evidence-metabolomics [gene]="gene"></agora-gene-evidence-metabolomics>
-            }
+      @if (activePanel === 'metabolomics') {
+        <div class="gene-details-panel active">
+          <agora-gene-evidence-metabolomics [gene]="gene"></agora-gene-evidence-metabolomics>
+        </div>
+      }
 
-            @if (panel.name === 'resources') {
-              <agora-gene-resources [gene]="gene"></agora-gene-resources>
-            }
+      @if (activePanel === 'resources') {
+        <div class="gene-details-panel active">
+          <agora-gene-resources [gene]="gene"></agora-gene-resources>
+        </div>
+      }
 
-            @if (panel.name === 'nominations') {
-              <agora-gene-nominations [gene]="gene"></agora-gene-nominations>
-            }
+      @if (activePanel === 'nominations') {
+        <div class="gene-details-panel active">
+          <agora-gene-nominations [gene]="gene"></agora-gene-nominations>
+        </div>
+      }
 
-            @if (panel.name === 'experimental-validation') {
-              <agora-gene-experimental-validation
-                [gene]="gene"
-              ></agora-gene-experimental-validation>
-            }
-          </div>
-        }
-      </ng-template>
-
-      @for (panel of panels; track panel) {
-        <ng-container
-          *ngTemplateOutlet="panelTemplate; context: { $implicit: panel }"
-        ></ng-container>
-        @if (panel.children) {
-          @for (childPanel of panel.children; track childPanel) {
-            <ng-container
-              *ngTemplateOutlet="panelTemplate; context: { $implicit: childPanel }"
-            ></ng-container>
-          }
-        }
+      @if (activePanel === 'experimental-validation') {
+        <div class="gene-details-panel active">
+          <agora-gene-experimental-validation [gene]="gene"></agora-gene-experimental-validation>
+        </div>
       }
     </div>
   </div>

--- a/libs/agora/genes/src/lib/components/gene-details/gene-details.component.scss
+++ b/libs/agora/genes/src/lib/components/gene-details/gene-details.component.scss
@@ -152,23 +152,12 @@
 .gene-details-body {
   position: relative;
   overflow: hidden;
+  min-height: 1000px;
 }
 
 .gene-details-panel {
-  position: absolute;
+  position: relative;
   width: 100%;
-  top: 0;
-  opacity: 0;
-  visibility: hidden;
-  z-index: 100;
-
-  &.active {
-    opacity: 1;
-    visibility: visible;
-    position: relative;
-    top: auto;
-    z-index: 200;
-  }
 }
 
 .gene-details-nav:not(.scrollable) {

--- a/libs/agora/genes/src/lib/components/gene-details/gene-details.component.ts
+++ b/libs/agora/genes/src/lib/components/gene-details/gene-details.component.ts
@@ -109,7 +109,7 @@ export class GeneDetailsComponent implements OnInit, AfterViewInit, AfterViewChe
   activeParent = '';
   navSlideIndex = 0;
 
-  @HostListener('window:scroll', ['$event'])
+  @HostListener('window:scroll')
   onWindowScroll() {
     if (isPlatformBrowser(this.platformId)) {
       const nav = document.querySelector<HTMLElement>('.gene-details-nav');
@@ -123,7 +123,7 @@ export class GeneDetailsComponent implements OnInit, AfterViewInit, AfterViewChe
     }
   }
 
-  @HostListener('window:resize', ['$event'])
+  @HostListener('window:resize')
   onWindowResize() {
     if (isPlatformBrowser(this.platformId)) {
       const nav = document.querySelector<HTMLElement>('.gene-details-nav');

--- a/libs/explorers/testing/src/lib/e2e/index.ts
+++ b/libs/explorers/testing/src/lib/e2e/index.ts
@@ -3,3 +3,4 @@ export * from './comparison-tool-filter';
 export * from './comparison-tool-panels';
 export * from './comparison-tool-search';
 export * from './comparison-tool-sort';
+export * from './scroll-helpers';

--- a/libs/explorers/testing/src/lib/e2e/scroll-helpers.ts
+++ b/libs/explorers/testing/src/lib/e2e/scroll-helpers.ts
@@ -1,0 +1,32 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Waits for the page scroll position to stabilize.
+ * Useful for detecting and waiting out phantom scrolls or layout shifts.
+ *
+ * @param page - The Playwright page instance
+ * @param timeout - Maximum time to wait for stability (default: 5000ms)
+ */
+export async function waitForScrollToStop(page: Page, timeout = 5000) {
+  let previousOffset = await page.evaluate(() => window.pageYOffset);
+  let stableCount = 0;
+  const requiredStableChecks = 10;
+
+  await expect
+    .poll(
+      async () => {
+        const currentOffset = await page.evaluate(() => window.pageYOffset);
+
+        if (currentOffset === previousOffset) {
+          stableCount++;
+          return stableCount >= requiredStableChecks;
+        } else {
+          stableCount = 0;
+          previousOffset = currentOffset;
+          return false;
+        }
+      },
+      { timeout, intervals: [200] },
+    )
+    .toBe(true);
+}


### PR DESCRIPTION
## Description

The "View all brain regions" link scrolled to the correct header in the gene details RNA evidence tab, but then immediately scrolled a bit further so the header was off the screen. Investigation revealed that the extra scroll was due to inactive tabs that were hydrating and rendering concurrently during SSR, with the Summary tab's barchart component expanding asynchronously, which pushed active tab content downward. This PR eliminates the phantom scroll issue by ensuring only the active tab exists in the DOM, preventing background rendering from affecting visible content.

## Related Issue

[AG-1948](https://sagebionetworks.jira.com/browse/AG-1948)

## Changelog

- Ensures that "View all brain regions" link scrolls to correct position by replacing CSS-based tab visibility with Angular structural directives to render only active tab
- Add minimum height to tab container to prevent layout collapse during tab transitions

## Preview

`agora-build-images && agora-docker-start`

https://github.com/user-attachments/assets/e62033f7-1b71-4e1e-8507-8caecaeda251

[AG-1948]: https://sagebionetworks.jira.com/browse/AG-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ