### PR TITLE
fix(explorers): prevent hamburger menu from auto-opening on comparison tool pages (MG-735)

### DIFF
--- a/libs/explorers/ui/src/lib/components/header/header.component.ts
+++ b/libs/explorers/ui/src/lib/components/header/header.component.ts
@@ -35,10 +35,17 @@ export class HeaderComponent implements OnInit {
 
   onResize() {
     if (typeof window !== 'undefined') this.isMobile = window.innerWidth < this.minDesktopWidth();
+    // Reset menu state when in desktop mode to prevent state leaking across mode transitions
+    if (!this.isMobile) {
+      this.isShown = false;
+    }
     this.refreshNavItems();
   }
 
   toggleNav() {
-    this.isShown = !this.isShown;
+    // Menu only visible to be toggled in mobile mode
+    if (this.isMobile) {
+      this.isShown = !this.isShown;
+    }
   }
 }


### PR DESCRIPTION
## Description

Fixed a state management bug in the shared header component where the hamburger menu would automatically open when narrowing the browser window on comparison tool pages. The issue occurred because navigation link clicks in desktop mode were toggling menu state that persisted when transitioning to mobile mode. This fix ensures the menu remains closed by default when entering mobile mode, providing a consistent user experience across all pages.

## Related Issue

[MG-735](https://sagebionetworks.jira.com/browse/MG-735)

## Changelog

- Add mobile mode check to `toggleNav()` to prevent state changes in desktop mode
- Reset menu state to closed when transitioning from mobile to desktop mode
- Add comprehensive unit tests covering desktop/mobile mode transitions and menu state management

## Preview

`model-ad-build-images && model-ad-docker-start`

https://github.com/user-attachments/assets/c92826ab-c64c-495f-b662-160ec39c4ab3

[MG-735]: https://sagebionetworks.jira.com/browse/MG-735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ