### PR TITLE
fix(model-ad): fix border styling of last CT column header

### DIFF
--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-columns/comparison-tool-columns.component.scss
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-columns/comparison-tool-columns.component.scss
@@ -16,10 +16,6 @@
       border-right: none !important;
     }
 
-    &:last-child {
-      border-right: none !important;
-    }
-
     .column-header {
       display: flex;
       align-items: center;


### PR DESCRIPTION
## Description
Fixes the border styling of the last column in the CTs.

## Related Issue

[MG-741](https://sagebionetworks.jira.com/browse/MG-741)

## Changelog

- Update css to fix last column header border styling

## Preview
Before:
<img width="440" height="250" alt="image" src="https://github.com/user-attachments/assets/576ef312-e204-4251-8cd9-3547ea0edbcb" />

After:
<img width="422" height="350" alt="image" src="https://github.com/user-attachments/assets/b6ce6b09-14d2-41d5-94cd-027be4788233" />


[MG-741]: https://sagebionetworks.jira.com/browse/MG-741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ