### PR TITLE
infra(bixarena): deploy the API gateway before the web app

### DIFF
--- a/apps/bixarena/infra/cdk/bixarena_infra_cdk/stage/app.py
+++ b/apps/bixarena/infra/cdk/bixarena_infra_cdk/stage/app.py
@@ -243,28 +243,8 @@ def main() -> None:
             "container at runtime. Never exposed in CloudFormation or logs."
         )
 
-    # Create web stack (depends on ECS cluster and ALB)
-    # Uses ALB DNS name by default, or custom FQDN if provided
+    # Determine HTTPS usage for service URLs
     use_https = certificate_arn is not None and certificate_arn.strip() != ""
-    web_stack = WebStack(
-        app,
-        f"{stack_prefix}-web",
-        stack_prefix=stack_prefix,
-        environment=environment,
-        developer_name=developer_name,
-        vpc=vpc_stack.vpc_construct.vpc,
-        cluster=ecs_cluster_stack.cluster_construct.cluster,
-        target_group=alb_stack.web_target_group,
-        app_version=app_version,
-        alb_dns_name=alb_stack.alb_construct.alb.load_balancer_dns_name,
-        fqdn=fqdn if fqdn else None,
-        use_https=use_https,
-        openrouter_api_key=os.getenv("OPENROUTER_API_KEY", ""),
-        gtm_container_id=gtm_container_id,
-        description=f"Web client for BixArena {environment} environment",
-    )
-    web_stack.add_dependency(ecs_cluster_stack)
-    web_stack.add_dependency(alb_stack)
 
     # Create API service stack (depends on database, valkey, and ECS cluster)
     # Database secret is guaranteed to exist since we use from_generated_secret()
@@ -341,6 +321,29 @@ def main() -> None:
     # This ensures backend services are available when Gateway starts
     api_gateway_stack.add_dependency(_api_service_stack)
     api_gateway_stack.add_dependency(_auth_service_stack)
+
+    # Create web stack (depends on ECS cluster, ALB, and API Gateway)
+    # Uses ALB DNS name by default, or custom FQDN if provided
+    web_stack = WebStack(
+        app,
+        f"{stack_prefix}-web",
+        stack_prefix=stack_prefix,
+        environment=environment,
+        developer_name=developer_name,
+        vpc=vpc_stack.vpc_construct.vpc,
+        cluster=ecs_cluster_stack.cluster_construct.cluster,
+        target_group=alb_stack.web_target_group,
+        app_version=app_version,
+        alb_dns_name=alb_stack.alb_construct.alb.load_balancer_dns_name,
+        fqdn=fqdn if fqdn else None,
+        use_https=use_https,
+        openrouter_api_key=os.getenv("OPENROUTER_API_KEY", ""),
+        gtm_container_id=gtm_container_id,
+        description=f"Web client for BixArena {environment} environment",
+    )
+    web_stack.add_dependency(ecs_cluster_stack)
+    web_stack.add_dependency(alb_stack)
+    web_stack.add_dependency(api_gateway_stack)
 
     # Note: Security group rules are configured within the constructs to allow
     # connections from the VPC CIDR range, avoiding cyclic dependencies


### PR DESCRIPTION
## Description

This PR establishes an explicit deployment dependency between the BioArena web app and API gateway in the CDK infrastructure across all environments (dev, stage, prod). Previously, the web stack could deploy independently of the API gateway, leading to potential runtime errors when the web app attempted to make API calls before the gateway was ready. By adding this dependency, we ensure the API gateway is fully deployed and healthy before the web app container starts, improving deployment reliability and preventing API connectivity issues during stack updates.

## Changelog

- Add explicit CDK stack dependency so web stack waits for API gateway deployment
- Reorder stack creation to deploy API gateway before web app across all environments
- Move `use_https` variable initialization earlier to support backend service configuration

## Preview

The BioArena infrastructure now has:

- Guaranteed deployment ordering ensuring API gateway is ready before web app starts
- Improved reliability during stack updates and initial deployments
- Consistent deployment behavior across dev, stage, and production environments
