### PR TITLE
chore: configure Gradle inputs to mark Java projects as affected

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -212,7 +212,10 @@
     },
     "@nx/gradle:gradle": {
       "cache": true,
-      "inputs": ["defaultGradle", "^productionGradle"]
+      "inputs": ["defaultGradle", "^productionGradle"],
+      "options": {
+        "excludeDependsOn": false
+      }
     }
   },
   "namedInputs": {


### PR DESCRIPTION
## Description

This PR configures Nx affected detection to ensure all Java/Gradle projects are properly marked as affected when workspace-level Gradle configuration files change. Previously, changes to files like `gradle/libs.versions.toml` did not trigger affected detection for Java projects, causing PR CI to miss compatibility issues that only surfaced in push CI after merging to main.

## Changelog

- Add `defaultGradle` and `productionGradle` namedInputs to track workspace-level Gradle configuration files
- Configure `@nx/gradle:gradle` executor to use Gradle-specific inputs for affected detection
- Ensure changes to `gradle/libs.versions.toml`, Gradle wrapper, buildSrc, and root build files affect all Java projects

## Preview

### Make a test change
```
echo "# test" >> gradle/libs.versions.toml
```

### Check which projects are affected
```
nx show projects --affected --uncommitted
```
```console
openchallenges-organization-service
openchallenges-challenge-service
openchallenges-api-client-java
openchallenges-mcp-server
openchallenges-image-service
openchallenges-auth-service
openchallenges-api-gateway
amp-als-app-config-data
amp-als-dataset-service
bixarena-auth-service
amp-als-user-service
bixarena-api-gateway
model-ad-api-next
shared-java-util
agora-api-next
bixarena-api
```