### PR TITLE
fix(agora): ensure explorers hero styling aligns with other agora hero pages (AG-1962)

### DIFF
--- a/libs/agora/styles/src/_index.scss
+++ b/libs/agora/styles/src/_index.scss
@@ -7,6 +7,7 @@
 @import './lib/components/chart_d3';
 @import './lib/components/dialog';
 @import './lib/components/dropdown';
+@import './lib/components/explorers_overrides';
 @import './lib/components/fonts';
 @import './lib/components/radio';
 @import './lib/components/section';

--- a/libs/agora/styles/src/lib/components/_explorers_overrides.scss
+++ b/libs/agora/styles/src/lib/components/_explorers_overrides.scss
@@ -1,0 +1,5 @@
+.hero-container {
+  h1 {
+    margin-bottom: 0;
+  }
+}

--- a/libs/explorers/ui/src/lib/components/hero/hero.component.scss
+++ b/libs/explorers/ui/src/lib/components/hero/hero.component.scss
@@ -6,6 +6,7 @@
   justify-content: center;
   align-items: center;
   height: clamp(100px, 15vw, 200px);
+  background-size: cover;
 
   @media (width < vars.$main-content-total-width) {
     padding: 0 vars.$main-content-margin;


### PR DESCRIPTION
## Description

The hero background image on Agora's Terms of Service page appeared differently positioned compared to other pages (e.g., Agora News) that use the same image since the shared explorers hero component did not set `background-size`, causing the image to render at its natural dimensions. This PR ensures that the shared explorers hero styling is aligned with other Agora hero pages. 

## Related Issue

[AG-1962](https://sagebionetworks.jira.com/browse/AG-1962)

## Changelog

- Ensure explorers hero scales background image to cover the container
- Ensure Agora's styling does not add unnecessary padding to explorers hero heading

## Preview

app | dev (current) | this pr (updated) | comment
:---: | :---: | :---: | :---: 
agora | <img width="1624" height="1056" alt="AG-1962_agoraTos_dev" src="https://github.com/user-attachments/assets/55a928d6-ff05-42e4-bef5-c6e473734e1e" /> | <img width="1624" height="1056" alt="AG-1962_agoraTos_pr" src="https://github.com/user-attachments/assets/282ec2b7-2f15-4b94-bba4-1d01f22be9af" /> | style aligned with other agora hero pages
model-ad | <img width="1624" height="1056" alt="AG-1962_modelAdTos_dev" src="https://github.com/user-attachments/assets/6c02054e-d70d-4d8a-81c8-2408a755ff97" /> | <img width="1624" height="1056" alt="AG-1962_modelAdTos_pr" src="https://github.com/user-attachments/assets/e5c1735a-f488-4ce5-9ba3-a96fef0f65b6" /> | minimal change

[AG-1962]: https://sagebionetworks.jira.com/browse/AG-1962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ