### PR TITLE
fix(model-ad): use `model_group` to build Model Detail page link on Gene Expr CT page (MG-784)

### DIFF
--- a/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.spec.ts
+++ b/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.spec.ts
@@ -9,13 +9,38 @@ import {
   provideExplorersConfig,
 } from '@sagebionetworks/explorers/services';
 import { provideLoadingIconColors } from '@sagebionetworks/explorers/testing';
-import { ComparisonToolConfigService } from '@sagebionetworks/model-ad/api-client';
+import {
+  ComparisonToolConfigService,
+  GeneExpression,
+  GeneExpressionService,
+  GeneExpressionsPage,
+  SexCohort,
+} from '@sagebionetworks/model-ad/api-client';
 import { MODEL_AD_LOADING_ICON_COLORS } from '@sagebionetworks/model-ad/config';
 import { render } from '@testing-library/angular';
 import { MessageService } from 'primeng/api';
 import { of } from 'rxjs';
 import { GeneExpressionComparisonToolComponent } from './gene-expression-comparison-tool.component';
 import { GeneExpressionComparisonToolService } from './services/gene-expression-comparison-tool.service';
+
+const mockRow: GeneExpression = {
+  composite_id: 'test-id',
+  ensembl_gene_id: 'ENSG00000001',
+  gene_symbol: 'ABCA7',
+  biodomains: [],
+  name: { link_text: 'Abca7*V1599M.5xFAD', link_url: 'models/Abca7*V1599M.5xFAD' },
+  matched_control: '5xFAD',
+  model_group: 'Abca7*V1599M',
+  model_type: 'Familial AD',
+  tissue: 'Hippocampus',
+  sex_cohort: SexCohort.FemalesMales,
+};
+
+const mockRowNoModelGroup: GeneExpression = {
+  ...mockRow,
+  name: { link_text: '5xFAD (UCI)', link_url: 'models/5xFAD (UCI)' },
+  model_group: null,
+};
 
 async function setup() {
   const { fixture } = await render(GeneExpressionComparisonToolComponent, {
@@ -44,12 +69,86 @@ async function setup() {
   });
 
   const component = fixture.componentInstance;
-  return { component };
+  const comparisonToolService = fixture.debugElement.injector.get(
+    GeneExpressionComparisonToolService,
+  );
+  const geneExpressionService = fixture.debugElement.injector.get(GeneExpressionService);
+  return { component, comparisonToolService, geneExpressionService };
 }
 
 describe('GeneExpressionComparisonToolComponent', () => {
   it('should create', async () => {
     const { component } = await setup();
     expect(component).toBeTruthy();
+  });
+
+  describe('model link override', () => {
+    it('should use model_group to build link_url when model_group is non-null', async () => {
+      const { component, comparisonToolService, geneExpressionService } = await setup();
+
+      const page: GeneExpressionsPage = {
+        geneExpressions: [mockRow],
+        page: {
+          number: 0,
+          size: 10,
+          totalElements: 1,
+          totalPages: 1,
+          hasNext: false,
+          hasPrevious: false,
+        },
+      };
+      jest.spyOn(geneExpressionService, 'getGeneExpressions').mockReturnValue(of(page) as any);
+      const setUnpinnedSpy = jest.spyOn(comparisonToolService, 'setUnpinnedData');
+
+      component.getUnpinnedData({
+        pinnedItems: [],
+        multiSortMeta: [],
+        pageNumber: 0,
+        pageSize: 10,
+        searchTerm: '',
+        categories: [],
+        filters: [],
+      });
+
+      expect(setUnpinnedSpy).toHaveBeenCalledWith([
+        expect.objectContaining({
+          name: expect.objectContaining({ link_url: 'models/Abca7*V1599M' }),
+        }),
+      ]);
+    });
+
+    it('should leave link_url unchanged when model_group is null', async () => {
+      const { component, comparisonToolService, geneExpressionService } = await setup();
+
+      const page: GeneExpressionsPage = {
+        geneExpressions: [mockRowNoModelGroup],
+        page: {
+          number: 0,
+          size: 10,
+          totalElements: 1,
+          totalPages: 1,
+          hasNext: false,
+          hasPrevious: false,
+        },
+      };
+      jest.spyOn(geneExpressionService, 'getGeneExpressions').mockReturnValue(of(page) as any);
+      const setUnpinnedSpy = jest.spyOn(comparisonToolService, 'setUnpinnedData');
+
+      component.getUnpinnedData({
+        pinnedItems: [],
+        multiSortMeta: [],
+        pageNumber: 0,
+        pageSize: 10,
+        searchTerm: '',
+        categories: [],
+        filters: [],
+      });
+
+      expect(setUnpinnedSpy).toHaveBeenCalledWith([
+        expect.objectContaining({
+          name: expect.objectContaining({ link_url: 'models/5xFAD (UCI)' }),
+        }),
+      ]);
+    });
   });
 });

--- a/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.ts
+++ b/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.ts
@@ -191,7 +191,11 @@ export class GeneExpressionComparisonToolComponent implements OnInit, OnDestroy 
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (response: GeneExpressionsPage) => {
-          const data = response.geneExpressions;
+          const data = response.geneExpressions.map((row) =>
+            row.model_group
+              ? { ...row, name: { ...row.name, link_url: `models/${row.model_group}` } }
+              : row,
+          );
           this.comparisonToolService.setUnpinnedData(data);
           this.comparisonToolService.totalResultsCount.set(response.page.totalElements);
         },
@@ -221,7 +225,11 @@ export class GeneExpressionComparisonToolComponent implements OnInit, OnDestroy 
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (response: GeneExpressionsPage) => {
-          const data = response.geneExpressions;
+          const data = response.geneExpressions.map((row) =>
+            row.model_group
+              ? { ...row, name: { ...row.name, link_url: `models/${row.model_group}` } }
+              : row,
+          );
           this.comparisonToolService.setPinnedData(data);
           this.comparisonToolService.pinnedResultsCount.set(data.length);
         },


### PR DESCRIPTION
## Description

Clicking some model names in the Gene Expression CT( e.g. `Abca7*V1599M.5xFAD`) navigated to a 404 page because `name.link_url` in the DB includes the variant suffix, which has no corresponding model details page. Since `model_group` always equals the base model name that does have a page, we now use it to construct the link URL when present.

## Related Issue

Fixes [MG-784](https://sagebionetworks.jira.com/browse/MG-784)

## Changelog

- Override `name.link_url` with `models/{model_group}` for rows where `model_group` is non-null
- Add unit tests covering both the override and the no-op (null `model_group`) cases

## Preview



[MG-784]: https://sagebionetworks.jira.com/browse/MG-784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ