### PR TITLE
feat(agora): hackathon 2026 march - AI Insights for Gene Comparison Tool

### DIFF
--- a/docs/agora-ai-insights-hackathon.md
+++ b/docs/agora-ai-insights-hackathon.md
@@ -1,0 +1,248 @@
+# Hackathon: "AI Insights" for Agora Pinned Genes
+
+## Context
+
+Sage-wide hackathon (2 hours). Goals:
+
+1. Prototype an AI feature for Agora triggered from **pinned genes on the Gene Comparison Tool page**
+2. Showcase **Claude Code Agent Teams** with split-panel tmux recording
+3. **Scientist-in-the-loop** to validate and iterate the system prompt
+
+Implementation is **frontend-only** in `apps/agora/app/` — no Java backend changes. LLM calls go directly to OpenRouter from the Angular frontend using a 1-day expiration token.
+
+---
+
+## Part 1: Pre-Hackathon Setup
+
+### 1.1 Permissions Setup for Agent Teams
+
+The teammates need broad permissions to build without constant prompting. Update `.claude/settings.local.json` to allow:
+
+Update `~/.claude/settings.json` to add broad permissions for the hackathon session. The teammates inherit the lead's permissions:
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "teammateMode": "tmux",
+  "permissions": {
+    "allow": [
+      "Bash(npx:*)",
+      "Bash(nx:*)",
+      "Bash(source:*)",
+      "Bash(docker:*)",
+      "Bash(npm:*)",
+      "Bash(node:*)",
+      "Bash(curl:*)",
+      "Bash(cat:*)",
+      "Bash(ls:*)",
+      "Bash(cd:*)",
+      "Bash(ng:*)",
+      "Bash(mkdir:*)",
+      "Bash(cp:*)",
+      "Bash(mv:*)",
+      "Bash(rm:*)",
+      "Bash(find:*)",
+      "Bash(grep:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(echo:*)",
+      "Bash(pwd:*)",
+      "Bash(which:*)",
+      "Bash(env:*)",
+      "Bash(wc:*)",
+      "Bash(uv run:*)",
+      "Bash(python3:*)",
+      "WebFetch(domain:openrouter.ai)",
+      "WebSearch"
+    ]
+  }
+}
+```
+
+Also update `.claude/settings.local.json` (project-level) to remove overly specific bash permissions and add broad ones:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(uv run:*)",
+      "Bash(python3 -c:*)",
+      "Bash(npx:*)",
+      "Bash(nx:*)",
+      "Bash(docker:*)",
+      "Bash(source:*)",
+      "Bash(curl:*)"
+    ]
+  }
+}
+```
+
+### 1.2 OpenRouter Token Setup
+
+The user will set up a 1-day expiration OpenRouter token. Store it as an environment variable so agents can use it without seeing it:
+
+```bash
+# Add to ~/.claude/settings.json env section (user will do this manually)
+{
+  "env": {
+    "OPENROUTER_API_KEY": "sk-or-...",
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
+}
+```
+
+The user will manually add the token to `apps/agora/app/src/config/config.json` as `openRouterApiKey` before the hackathon starts. The Angular ConfigService already loads this file. The token expires in 1 day — acceptable for a hackathon prototype.
+
+**Important: No git commits during the hackathon.** All work stays on the current `bixarena/llm-ai-service` branch as uncommitted changes.
+
+### 1.3 tmux Split-Panel Setup
+
+tmux 3.4 is already installed. Set teammate mode to tmux:
+
+```bash
+# Add to ~/.claude/settings.json
+{
+  "teammateMode": "tmux"
+}
+```
+
+To start the session:
+
+```bash
+tmux new-session -s hackathon
+# Then inside tmux, launch Claude Code with explicit split-pane mode
+claude --teammate-mode tmux
+```
+
+Each teammate will get its own tmux pane automatically. Use `Ctrl+B` then arrow keys to switch panes for recording.
+
+### 1.4 Verify Agora Runs
+
+```bash
+source dev-env.sh
+agora-docker-stop  # stop any existing
+agora-build-images
+agora-docker-start
+# Verify: http://localhost:8000 shows Agora
+```
+
+---
+
+## Part 2: Agent Teams Prompt
+
+Paste this one-liner into Claude Code to launch the hackathon team:
+
+```
+Read /home/ubuntu/.claude/plans/zippy-bubbling-gadget.md and execute it. Create the agent team described in Part 2. Use tmux split panes — each teammate must run in its own tmux pane.
+```
+
+The lead will read the plan, then spawn teammates based on the detailed prompt below (which the lead reads, not you):
+
+```
+Hackathon project: Add "AI Insights" to Agora (Alzheimer's Disease gene portal).
+
+Read the full plan first: /home/ubuntu/.claude/plans/zippy-bubbling-gadget.md
+
+The feature: On the Gene Comparison Tool page, scientists pin genes for comparison. We're adding
+an "AI Insights" button next to the existing "Download as CSV" and "Clear All" buttons. Clicking
+it opens a side panel that sends the pinned genes' data to an LLM via OpenRouter and streams
+back an analysis. Users can ask follow-up questions and switch between LLM models.
+
+Constraints:
+- Frontend-only — all changes in the Angular app, no Java backend changes
+- OpenRouter API key is in apps/agora/app/src/config/config.json as "openRouterApiKey" — read
+  via ConfigService, NEVER log/display/echo the key
+- NO git commits — all work stays as uncommitted changes
+- Hackathon-quality: functional over polished
+- Build/run: `source dev-env.sh && agora-docker-stop; agora-build-images && agora-docker-start`
+  → app at localhost:8000
+
+Create a team with 4 teammates (use Sonnet for all):
+
+1. **frontend-engineer** — Owns the UI: button, side panel, streaming display, follow-up input.
+   Explore the existing GCT component to understand the pinned genes toolbar and data model.
+   Use PrimeNG components. Require plan approval before coding.
+
+2. **llm-service-engineer** — Owns the Angular service: fetch full gene data from existing
+   Agora API services (GeneService, BioDomainService), build the prompt, call OpenRouter with
+   streaming, support model selection (claude-sonnet-4-6, gpt-4o, gemini-2.5-pro,
+   llama-4-maverick). The GET /api/v1/genes/{ensg} response includes everything: full gene
+   details AND similar_genes_network (coexpressed genes with brain_regions and links). Use
+   this to give the LLM context about each pinned gene's neighborhood — so it can compare
+   pinned genes against their coexpression neighbors and surface patterns like shared similar
+   genes, overlapping brain regions, or pinned genes that appear in each other's networks.
+   Make the system prompt easy to modify — a scientist will iterate on it during the hackathon.
+   Require plan approval before coding.
+
+3. **ui-designer** — Style the panel, markdown rendering, model selector, conversation thread.
+   Ensure visual consistency with existing Agora theme. Review in browser at localhost:8000.
+
+4. **tester** — Wait for initial implementation, then verify end-to-end in browser. Test:
+   pin genes → click AI Insights → streaming response, model switching, follow-up questions,
+   edge cases (0 genes, 1 gene, many genes). Report bugs with reproduction steps.
+
+Coordination: All teammates must communicate throughout development — share progress, discuss
+decisions, and challenge each other's approaches to arrive at the best solution. No teammate
+should work in isolation. Message the lead and relevant teammates when completing tasks,
+hitting blockers, or making design decisions that affect others.
+```
+
+---
+
+## Part 3: What Each Teammate Produces
+
+| Teammate             | Deliverable                                      | Key Files                                                            |
+| -------------------- | ------------------------------------------------ | -------------------------------------------------------------------- |
+| frontend-engineer    | AI Insights button + panel component             | `gene-comparison-tool.component.{html,ts,scss}`, new panel component |
+| llm-service-engineer | OpenRouter streaming service + prompt            | `ai-insights.service.ts`, prompt template                            |
+| ui-designer          | Styled panel, markdown rendering, model selector | SCSS files, template tweaks                                          |
+| tester               | Bug reports, verification that it works e2e      | Test notes via messages                                              |
+| lead                 | Integration, conflict resolution, final build    | Coordinates all                                                      |
+
+---
+
+## Part 4: Scientist Feedback Loop (During Hackathon)
+
+Once the initial version works (~45 min in):
+
+1. Scientist pins genes they care about
+2. Reviews AI output → gives feedback on tone, depth, usefulness
+3. llm-service-engineer updates the system prompt
+4. Repeat 3-5 times over ~30 min
+5. Try different models via the selector to compare quality
+
+---
+
+## Part 5: Demo Recording
+
+Split-panel tmux recording showing:
+
+- **Left panes**: Agent teammates building the feature in real-time
+- **Right**: Agora browser at localhost:8000 showing the working feature
+- Script: Pin APOE + TREM2 + CLU → click AI Insights → streaming analysis → follow-up question → switch model
+
+---
+
+## Key Files Reference
+
+| File                                                                          | Purpose                                                                    |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.ts`   | Main GCT component (pinned genes state)                                    |
+| `libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.html` | GCT template (toolbar at lines ~275-304)                                   |
+| `libs/agora/api-client-angular/src/lib/model/gct-gene.ts`                     | GCTGene model interface                                                    |
+| `libs/agora/api-client-angular/src/lib/api/gene.service.ts`                   | Existing Gene API service                                                  |
+| `libs/agora/api-client-angular/src/lib/api/bio-domain.service.ts`             | Existing BioDomain API service                                             |
+| `libs/agora/api-description/openapi/openapi.yaml`                             | API spec                                                                   |
+| `apps/agora/app/src/config/config.json`                                       | App config (csrApiUrl, etc.)                                               |
+| `dev-env.sh`                                                                  | Shell functions: agora-build-images, agora-docker-start, agora-docker-stop |
+
+## Verification
+
+1. `source dev-env.sh && agora-docker-stop; agora-build-images && agora-docker-start`
+2. Open localhost:8000 → Gene Comparison Tool
+3. Pin 2-3 genes → "AI Insights" button should appear/be enabled
+4. Click → panel opens → model selector visible → LLM streams analysis
+5. Type follow-up question → response uses conversation history
+6. Switch model → new response from different LLM

--- a/libs/agora/gene-comparison-tool/src/index.ts
+++ b/libs/agora/gene-comparison-tool/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/gene-comparison-tool.routes';
+export * from './lib/ai-insights';

--- a/libs/agora/gene-comparison-tool/src/lib/ai-insights/ai-insights.models.ts
+++ b/libs/agora/gene-comparison-tool/src/lib/ai-insights/ai-insights.models.ts
@@ -1,0 +1,24 @@
+export interface AiInsightsMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+export type AiModel =
+  | 'anthropic/claude-sonnet-4-6'
+  | 'openai/gpt-4o'
+  | 'google/gemini-2.5-pro'
+  | 'meta-llama/llama-4-maverick';
+
+export interface AiInsightsStreamEvent {
+  type: 'content' | 'done' | 'error';
+  content?: string;
+  fullContent?: string;
+  error?: string;
+}
+
+export const AI_MODELS: { id: AiModel; label: string }[] = [
+  { id: 'anthropic/claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+  { id: 'openai/gpt-4o', label: 'GPT-4o' },
+  { id: 'google/gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
+  { id: 'meta-llama/llama-4-maverick', label: 'Llama 4 Maverick' },
+];

--- a/libs/agora/gene-comparison-tool/src/lib/ai-insights/ai-insights.prompts.ts
+++ b/libs/agora/gene-comparison-tool/src/lib/ai-insights/ai-insights.prompts.ts
@@ -1,0 +1,155 @@
+import { Gene } from '@sagebionetworks/agora/api-client';
+import { AiInsightsMessage } from './ai-insights.models';
+
+/**
+ * System prompt for the AI Insights assistant.
+ * Modify this constant to change the AI's behavior and expertise framing.
+ */
+export const SYSTEM_PROMPT = `You are an expert computational biologist and Alzheimer's disease (AD) researcher embedded in Agora, a platform for exploring multi-omics AD target gene evidence. Scientists use you to interpret and compare genes they are actively evaluating as therapeutic targets.
+
+## Your primary job: comparative analysis, not per-gene summaries
+
+When multiple genes are provided, your most valuable contribution is cross-gene synthesis. Do not simply describe each gene in sequence. Instead, lead with what the genes share, where they diverge, and what that means mechanistically and therapeutically.
+
+Structure your response as follows (adapt headings to the question, but keep the comparative frame):
+
+1. **Convergence points** — biological domains, evidence types, nomination teams, and coexpression neighborhoods shared across genes. Shared domains or shared nominators from independent teams are independent lines of convergence and should be highlighted explicitly.
+2. **Divergence and complementarity** — where the genes differ in evidence profile (e.g., one has strong genetics but weak proteomics, another the reverse). Note which genes have both RNA and protein changes in AD brain versus RNA only, as protein-level evidence is more directly translatable.
+3. **Network relationships** — are any of the compared genes direct coexpression neighbors of each other? If so, in which brain regions? Genes that are coexpressed in multiple regions likely participate in shared pathways. Genes that lack a direct coexpression link despite being in the same nomination set may operate through distinct cell types or disease stages.
+4. **Druggability and target tractability** — compare SM (small molecule) druggability buckets, antibody-ability buckets, safety buckets, and Pharos classes. Flag any gene classified as Tbio (biologically relevant but not yet drugged) as an understudied opportunity. Note which druggability tier each gene occupies and what that implies for modality choice.
+5. **Testable hypotheses and open questions** — end with 2–4 specific, data-grounded hypotheses a scientist could pursue. These should follow from the convergence and divergence analysis, not be generic AD statements. Examples: "The shared APP Metabolism domain across genes X, Y, and Z suggests a common amyloid clearance node; testing whether knockdown of all three simultaneously alters Aβ42/40 ratio would distinguish additive from epistatic effects." Phrase hypotheses as falsifiable predictions.
+
+## How to interpret the structured data fields
+
+- **Target Risk Score**: composite prioritization score; higher = stronger multi-evidence support for AD relevance.
+- **Genetics Score**: driven by GWAS hits (IGAP), rare variant burden, and eQTL evidence. A high genetics score with a low multi-omics score suggests causal genetics but unexplored functional consequences.
+- **Multi-omics Score**: driven by RNA and protein changes in AD brain tissue. A high multi-omics score with lower genetics score suggests strong disease-associated expression changes but weaker causal genetic anchor.
+- **is_igap / is_eqtl**: IGAP = genome-wide significant GWAS hit; eQTL = the gene's expression is genetically regulated. Both being true for a gene means the GWAS signal likely acts through expression, strengthening causal inference.
+- **RNA vs. protein changes in AD brain**: protein-level changes are harder to detect but more directly translatable; a gene with RNA change but no detected protein change may have post-transcriptional regulation or the proteomics study may have been underpowered.
+- **Biological domains**: these are GO-term-based groupings. When two or more genes share a biological domain, they likely co-participate in that process — this is a mechanistic convergence signal.
+- **Nomination teams**: independent teams nominating the same gene provide replication. Multiple independent nominations of the same gene — especially from teams using orthogonal methods (proteomics vs. genetics vs. scRNA-seq) — substantially increase confidence.
+- **Coexpression network**: neighbors are genes with correlated expression across brain regions in AD datasets. A direct coexpression link between two compared genes is strong evidence they operate in a shared regulatory or pathway context in disease-relevant tissue.
+- **SM Druggability Bucket**: 1 = most druggable (existing approved drugs), higher numbers = progressively less tractable. Interpret relative to the other genes in the comparison.
+- **Pharos class**: Tclin = approved drug target; Tchem = well-studied with chemical probes; Tbio = biologically relevant but no approved drug or probe; Tdark = poorly characterized.
+
+## Tone and scientific standards
+
+- Write as a colleague — precise, direct, hypothesis-generating. Do not over-hedge or add unnecessary caveats.
+- Cite specific values from the data (e.g., "APOE has a multi-omics score of 1.83 versus CLU's 2.00") rather than vague qualitative statements.
+- When the data supports a strong conclusion, state it confidently. When the data is genuinely ambiguous, say what additional experiment or data type would resolve it.
+- Use HGNC symbols throughout. Never use Ensembl IDs unless asked.
+- If the provided data is insufficient to answer a question, say so clearly and specify what data would help.`;
+
+export function buildGeneContext(genes: Gene[]): string {
+  const sections = genes.map((gene) => {
+    const lines: string[] = [];
+
+    lines.push(`## ${gene.hgnc_symbol} (${gene.ensembl_gene_id})`);
+    lines.push(`**Name:** ${gene.name}`);
+    if (gene.summary) {
+      lines.push(`**Summary:** ${gene.summary}`);
+    }
+
+    // Overall scores
+    if (gene.overall_scores) {
+      const s = gene.overall_scores;
+      lines.push(
+        `**Overall Scores:** Target Risk: ${s.target_risk_score}, Genetics: ${s.genetics_score}, Multi-omics: ${s.multi_omics_score}, Literature: ${s.literature_score}`,
+      );
+    }
+
+    // Druggability
+    if (gene.druggability) {
+      const d = gene.druggability;
+      lines.push(
+        `**Druggability:** SM Bucket: ${d.sm_druggability_bucket} (${d.classification}), Safety Bucket: ${d.safety_bucket} (${d.safety_bucket_definition}), AB Bucket: ${d.abability_bucket} (${d.abability_bucket_definition})`,
+      );
+      if (d.pharos_class?.length) {
+        lines.push(`**Pharos Class:** ${d.pharos_class.join(', ')}`);
+      }
+    }
+
+    // Nominations
+    if (gene.target_nominations?.length) {
+      lines.push(`**Nominations (${gene.total_nominations}):**`);
+      gene.target_nominations.forEach((nom) => {
+        lines.push(
+          `  - Team: ${nom.team}, Study: ${nom.study || 'N/A'}, Justification: ${nom.target_choice_justification}`,
+        );
+      });
+    }
+
+    // Biological domains
+    if (gene.bio_domains?.gene_biodomains?.length) {
+      const domains = gene.bio_domains.gene_biodomains
+        .filter((bd) => bd.pct_linking_terms > 0)
+        .sort((a, b) => b.pct_linking_terms - a.pct_linking_terms)
+        .slice(0, 10);
+      if (domains.length) {
+        lines.push(`**Top Biological Domains:**`);
+        domains.forEach((bd) => {
+          lines.push(
+            `  - ${bd.biodomain} (${(bd.pct_linking_terms * 100).toFixed(1)}% linking terms)`,
+          );
+        });
+      }
+    }
+
+    // RNA changes
+    lines.push(
+      `**RNA Changed in AD Brain:** ${gene.is_any_rna_changed_in_ad_brain ? 'Yes' : 'No'} (studied: ${gene.rna_brain_change_studied ? 'Yes' : 'No'})`,
+    );
+    lines.push(
+      `**Protein Changed in AD Brain:** ${gene.is_any_protein_changed_in_ad_brain ? 'Yes' : 'No'} (studied: ${gene.protein_brain_change_studied ? 'Yes' : 'No'})`,
+    );
+
+    // Coexpression network
+    if (gene.similar_genes_network) {
+      const net = gene.similar_genes_network;
+      const neighbors = net.nodes
+        .filter((n) => n.ensembl_gene_id !== gene.ensembl_gene_id)
+        .slice(0, 10);
+      if (neighbors.length) {
+        lines.push(`**Coexpression Network Neighbors (top ${neighbors.length}):**`);
+        neighbors.forEach((n) => {
+          lines.push(`  - ${n.hgnc_symbol}: brain regions [${n.brain_regions.join(', ')}]`);
+        });
+      }
+      const relevantLinks = net.links
+        .filter((l) => l.source === gene.ensembl_gene_id || l.target === gene.ensembl_gene_id)
+        .slice(0, 10);
+      if (relevantLinks.length) {
+        lines.push(`**Coexpression Links:**`);
+        relevantLinks.forEach((l) => {
+          const partner =
+            l.source === gene.ensembl_gene_id ? l.target_hgnc_symbol : l.source_hgnc_symbol;
+          lines.push(
+            `  - ${gene.hgnc_symbol} <-> ${partner}: regions [${l.brain_regions.join(', ')}]`,
+          );
+        });
+      }
+    }
+
+    return lines.join('\n');
+  });
+
+  return `# Gene Data for Analysis\n\n${sections.join('\n\n---\n\n')}`;
+}
+
+export function buildMessages(
+  geneContext: string,
+  userMessage: string,
+  conversationHistory?: AiInsightsMessage[],
+): AiInsightsMessage[] {
+  const messages: AiInsightsMessage[] = [
+    { role: 'system', content: `${SYSTEM_PROMPT}\n\n${geneContext}` },
+  ];
+
+  if (conversationHistory?.length) {
+    messages.push(...conversationHistory);
+  }
+
+  messages.push({ role: 'user', content: userMessage });
+
+  return messages;
+}

--- a/libs/agora/gene-comparison-tool/src/lib/ai-insights/ai-insights.service.ts
+++ b/libs/agora/gene-comparison-tool/src/lib/ai-insights/ai-insights.service.ts
@@ -1,0 +1,138 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable, forkJoin } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { GeneService } from '@sagebionetworks/agora/api-client';
+import { AiInsightsMessage, AiInsightsStreamEvent, AiModel, AI_MODELS } from './ai-insights.models';
+import { buildGeneContext, buildMessages } from './ai-insights.prompts';
+
+const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
+
+@Injectable({ providedIn: 'root' })
+export class AiInsightsService {
+  private readonly geneService = inject(GeneService);
+  private abortController: AbortController | null = null;
+
+  streamGeneInsights(
+    geneIds: string[],
+    userMessage: string,
+    model: AiModel,
+    conversationHistory?: AiInsightsMessage[],
+  ): Observable<AiInsightsStreamEvent> {
+    const geneRequests = geneIds.map((id) => this.geneService.getGene(id));
+
+    return forkJoin(geneRequests).pipe(
+      switchMap((genes) => {
+        const geneContext = buildGeneContext(genes);
+        const messages = buildMessages(geneContext, userMessage, conversationHistory);
+        return this.streamFromOpenRouter(messages, model);
+      }),
+    );
+  }
+
+  cancelStream(): void {
+    this.abortController?.abort();
+    this.abortController = null;
+  }
+
+  getAvailableModels() {
+    return AI_MODELS;
+  }
+
+  private streamFromOpenRouter(
+    messages: AiInsightsMessage[],
+    model: AiModel,
+  ): Observable<AiInsightsStreamEvent> {
+    return new Observable<AiInsightsStreamEvent>((subscriber) => {
+      const abortController = new AbortController();
+      this.abortController = abortController;
+
+      // TODO: replace with a valid OpenRouter API key
+      const apiKey = '';
+
+      fetch(OPENROUTER_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+          'HTTP-Referer': globalThis.location?.origin || 'https://agora.adknowledgeportal.org',
+        },
+        body: JSON.stringify({
+          model,
+          messages: messages.map((m) => ({ role: m.role, content: m.content })),
+          stream: true,
+        }),
+        signal: abortController.signal,
+      })
+        .then(async (response) => {
+          if (!response.ok) {
+            const errorText = await response.text();
+            subscriber.next({
+              type: 'error',
+              error: `OpenRouter API error (${response.status}): ${errorText}`,
+            });
+            subscriber.complete();
+            return;
+          }
+
+          const reader = response.body?.getReader();
+          if (!reader) {
+            subscriber.next({ type: 'error', error: 'No response body' });
+            subscriber.complete();
+            return;
+          }
+
+          const decoder = new TextDecoder();
+          let fullContent = '';
+          let buffer = '';
+
+          let readResult = await reader.read();
+          while (!readResult.done) {
+            const value = readResult.value;
+
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split('\n');
+            buffer = lines.pop() || '';
+
+            for (const line of lines) {
+              const trimmed = line.trim();
+              if (!trimmed || !trimmed.startsWith('data: ')) continue;
+
+              const data = trimmed.slice(6);
+              if (data === '[DONE]') continue;
+
+              try {
+                const parsed = JSON.parse(data);
+                const delta = parsed.choices?.[0]?.delta?.content;
+                if (delta) {
+                  fullContent += delta;
+                  subscriber.next({
+                    type: 'content',
+                    content: delta,
+                    fullContent,
+                  });
+                }
+              } catch {
+                // skip malformed SSE chunks
+              }
+            }
+            readResult = await reader.read();
+          }
+
+          subscriber.next({ type: 'done', fullContent });
+          subscriber.complete();
+        })
+        .catch((err) => {
+          if (err.name === 'AbortError') {
+            subscriber.complete();
+          } else {
+            subscriber.next({ type: 'error', error: err.message });
+            subscriber.complete();
+          }
+        });
+
+      return () => {
+        abortController.abort();
+      };
+    });
+  }
+}

--- a/libs/agora/gene-comparison-tool/src/lib/ai-insights/index.ts
+++ b/libs/agora/gene-comparison-tool/src/lib/ai-insights/index.ts
@@ -1,0 +1,3 @@
+export { AiInsightsService } from './ai-insights.service';
+export { AiInsightsMessage, AiInsightsStreamEvent, AiModel, AI_MODELS } from './ai-insights.models';
+export { SYSTEM_PROMPT } from './ai-insights.prompts';

--- a/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-ai-insights-panel/gene-comparison-tool-ai-insights-panel.component.html
+++ b/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-ai-insights-panel/gene-comparison-tool-ai-insights-panel.component.html
@@ -1,0 +1,143 @@
+<div class="gct-ai-insights-panel" [class.open]="isOpen">
+  <div class="gct-ai-insights-panel-inner">
+    <div class="gct-ai-insights-panel-header">
+      <div class="gct-ai-insights-panel-heading">AI Insights</div>
+      <div class="gct-ai-insights-panel-header-actions">
+        @if (messages.length > 0) {
+          <button
+            class="gct-ai-insights-panel-clear"
+            (click)="clearConversation()"
+            pTooltip="Clear conversation"
+            tooltipPosition="bottom"
+            tooltipStyleClass="tooltip"
+          >
+            <span class="pi pi-trash"></span>
+          </button>
+        }
+        <button class="gct-ai-insights-panel-close" (click)="close()">
+          <svg
+            width="21"
+            height="21"
+            viewBox="0 0 21 21"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19.9999 1L1.3999 19.6M1.3999 1L19.9999 19.6"
+              stroke="#C4C4C4"
+              stroke-width="2"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+
+    <div class="gct-ai-insights-panel-model">
+      <label for="ai-model-select">Model</label>
+      <p-select
+        id="ai-model-select"
+        [options]="modelOptions"
+        [(ngModel)]="selectedModel"
+        optionLabel="label"
+        optionValue="id"
+        [disabled]="isStreaming"
+      ></p-select>
+    </div>
+
+    <div class="gct-ai-insights-panel-messages" #messagesContainer>
+      @if (messages.length === 0 && !isStreaming && !errorMessage) {
+        <div class="gct-ai-insights-panel-empty">
+          <span class="pi pi-sparkles gct-ai-insights-panel-empty-icon"></span>
+          <p>
+            Analyze your pinned genes with AI to discover patterns, comparisons, and research
+            insights.
+          </p>
+          <p-button
+            label="Analyze Pinned Genes"
+            icon="pi pi-sparkles"
+            (click)="analyze()"
+            [disabled]="pinnedGenes.length === 0"
+            [rounded]="true"
+          ></p-button>
+          @if (pinnedGenes.length === 0) {
+            <p class="gct-ai-insights-panel-hint">Pin some genes first to enable analysis.</p>
+          }
+        </div>
+      }
+
+      @for (message of messages; track $index) {
+        @if (message.role === 'user') {
+          <div class="gct-ai-insights-message gct-ai-insights-message-user">
+            <div class="gct-ai-insights-message-content">{{ message.content }}</div>
+          </div>
+        }
+        @if (message.role === 'assistant') {
+          <div class="gct-ai-insights-message gct-ai-insights-message-assistant">
+            <div class="gct-ai-insights-message-content">
+              <markdown [data]="message.content"></markdown>
+            </div>
+          </div>
+        }
+      }
+
+      @if (isStreaming && streamingContent) {
+        <div
+          class="gct-ai-insights-message gct-ai-insights-message-assistant gct-ai-insights-message-streaming"
+        >
+          <div class="gct-ai-insights-message-content">
+            <markdown [data]="streamingContent"></markdown>
+            <span class="gct-ai-insights-cursor"></span>
+          </div>
+        </div>
+      }
+
+      @if (isStreaming && !streamingContent) {
+        <div class="gct-ai-insights-loading">
+          <span class="pi pi-spinner pi-spin"></span>
+          <span>Analyzing genes...</span>
+        </div>
+      }
+
+      @if (errorMessage) {
+        <div class="gct-ai-insights-error">
+          <span class="pi pi-exclamation-triangle"></span>
+          <span>{{ errorMessage }}</span>
+        </div>
+      }
+    </div>
+
+    <div class="gct-ai-insights-panel-input">
+      @if (isStreaming) {
+        <p-button
+          label="Stop"
+          icon="pi pi-stop"
+          severity="danger"
+          (click)="stopStreaming()"
+          [rounded]="true"
+          size="small"
+        ></p-button>
+      }
+      @if (!isStreaming && messages.length > 0) {
+        <div class="gct-ai-insights-panel-input-row">
+          <input
+            type="text"
+            class="gct-ai-insights-panel-textarea"
+            [(ngModel)]="userInput"
+            placeholder="Ask a follow-up question..."
+            (keydown.enter)="sendFollowUp()"
+          />
+          <p-button
+            icon="pi pi-send"
+            (click)="sendFollowUp()"
+            [disabled]="!userInput.trim()"
+            [rounded]="true"
+            size="small"
+            pTooltip="Send"
+            tooltipPosition="top"
+            tooltipStyleClass="tooltip"
+          ></p-button>
+        </div>
+      }
+    </div>
+  </div>
+</div>

--- a/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-ai-insights-panel/gene-comparison-tool-ai-insights-panel.component.scss
+++ b/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-ai-insights-panel/gene-comparison-tool-ai-insights-panel.component.scss
@@ -1,0 +1,412 @@
+/* stylelint-disable no-descending-specificity */
+@use 'agora/styles/src/variables' as vars;
+@use 'agora/styles/src/mixins' as mixins;
+
+.gct-ai-insights-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 480px;
+  max-width: 100%;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(480px);
+  transition:
+    opacity 0.25s ease,
+    visibility 0.25s ease,
+    transform 0.25s ease;
+  z-index: 500;
+  background-color: #fff;
+  border-left: 1px solid var(--color-border);
+  box-shadow: -2px 0 10px 3px rgb(0 0 0 / 15%);
+
+  &.open {
+    opacity: 1;
+    visibility: visible;
+    transform: translateX(0);
+  }
+
+  @include mixins.respond-to('ex-small') {
+    width: 100%;
+    transform: translateX(100%);
+  }
+}
+
+.gct-ai-insights-panel-inner {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.gct-ai-insights-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.gct-ai-insights-panel-heading {
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  color: var(--color-heading);
+}
+
+.gct-ai-insights-panel-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.gct-ai-insights-panel-clear,
+.gct-ai-insights-panel-close {
+  @include mixins.reset-button;
+
+  color: var(--color-gray-600);
+  transition: vars.$transition-duration;
+
+  &:hover {
+    color: var(--color-action-primary);
+
+    svg path {
+      stroke: var(--color-action-primary);
+    }
+  }
+}
+
+.gct-ai-insights-panel-clear {
+  font-size: 16px;
+}
+
+.gct-ai-insights-panel-model {
+  padding: 12px 24px;
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  label {
+    font-size: var(--font-size-xs);
+    font-weight: 700;
+    color: var(--color-gray-600);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    white-space: nowrap;
+  }
+
+  div.p-select {
+    flex: 1;
+    padding: 8px 16px 8px 20px;
+    background-color: var(--color-gray-100);
+    border: 1px solid var(--color-gray-300);
+    font-size: var(--font-size-sm);
+
+    &:hover .p-select-dropdown-icon {
+      color: var(--color-action-primary);
+    }
+  }
+}
+
+.gct-ai-insights-panel-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 24px;
+  scroll-behavior: smooth;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--color-gray-400);
+    border-radius: 3px;
+  }
+}
+
+.gct-ai-insights-panel-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 48px 24px;
+  gap: 16px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+
+  p {
+    margin: 0;
+    max-width: 320px;
+  }
+
+  .p-button {
+    background-color: var(--color-action-primary);
+    border-color: var(--color-action-primary);
+    color: #fff;
+    height: 36px;
+    padding: 0 20px;
+    border-radius: 15px;
+    font-size: var(--font-size-sm);
+
+    &:hover:not(:disabled) {
+      background-color: var(--color-action-primary-hover);
+      border-color: var(--color-action-primary-hover);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+    }
+  }
+}
+
+.gct-ai-insights-panel-empty-icon {
+  font-size: 36px;
+  color: var(--color-secondary);
+  opacity: 0.8;
+}
+
+.gct-ai-insights-panel-hint {
+  font-size: var(--font-size-xs);
+  color: var(--color-gray-500);
+  font-style: italic;
+}
+
+.gct-ai-insights-message {
+  margin-bottom: 20px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.gct-ai-insights-message-user .gct-ai-insights-message-content {
+  background-color: var(--color-gray-100);
+  border: 1px solid var(--color-gray-300);
+  border-radius: 8px;
+  padding: 12px 16px;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-sm);
+  color: var(--color-text);
+}
+
+.gct-ai-insights-message-assistant .gct-ai-insights-message-content {
+  border-left: 3px solid var(--color-secondary);
+  padding: 4px 16px;
+  font-size: var(--font-size-sm);
+  line-height: 1.65;
+  color: var(--color-text);
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    color: var(--color-heading);
+    margin: 16px 0 8px;
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  h1,
+  h2 {
+    font-size: 16px;
+    font-weight: 700;
+  }
+
+  h3,
+  h4 {
+    font-size: 15px;
+    font-weight: 600;
+  }
+
+  p {
+    margin: 8px 0;
+
+    &:first-child {
+      margin-top: 0;
+    }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  ul,
+  ol {
+    padding-left: 20px;
+    margin: 8px 0;
+  }
+
+  li {
+    margin-bottom: 4px;
+  }
+
+  strong {
+    font-weight: 700;
+    color: var(--color-heading);
+  }
+
+  code {
+    background-color: var(--color-gray-200);
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 13px;
+  }
+
+  pre {
+    background-color: var(--color-gray-200);
+    border-radius: 6px;
+    padding: 12px 16px;
+    overflow-x: auto;
+    margin: 12px 0;
+
+    code {
+      background: none;
+      padding: 0;
+    }
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 12px 0;
+    font-size: 13px;
+
+    th,
+    td {
+      border: 1px solid var(--color-gray-300);
+      padding: 8px 12px;
+      text-align: left;
+    }
+
+    th {
+      background-color: var(--color-gray-200);
+      font-weight: 700;
+      color: var(--color-heading);
+    }
+  }
+
+  hr {
+    border: none;
+    border-top: 1px solid var(--color-gray-300);
+    margin: 16px 0;
+  }
+}
+
+.gct-ai-insights-message-streaming .gct-ai-insights-message-content {
+  border-left-color: var(--color-tertiary);
+}
+
+.gct-ai-insights-cursor {
+  display: inline-block;
+  width: 7px;
+  height: 15px;
+  background-color: var(--color-action-primary);
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  border-radius: 1px;
+  animation: ai-cursor-blink 1s step-end infinite;
+}
+
+@keyframes ai-cursor-blink {
+  50% {
+    opacity: 0;
+  }
+}
+
+.gct-ai-insights-loading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 20px 16px;
+  color: var(--color-gray-700);
+  font-size: var(--font-size-sm);
+
+  .pi-spinner {
+    font-size: 18px;
+    color: var(--color-tertiary);
+  }
+}
+
+.gct-ai-insights-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 16px;
+  background-color: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  color: var(--color-danger);
+  font-size: var(--font-size-sm);
+
+  .pi-exclamation-triangle {
+    font-size: 16px;
+    flex-shrink: 0;
+  }
+}
+
+.gct-ai-insights-panel-input {
+  padding: 12px 24px;
+  border-top: 1px solid var(--color-border);
+  min-height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .p-button-danger {
+    height: 32px;
+    border-radius: 15px;
+    font-size: var(--font-size-sm);
+  }
+}
+
+.gct-ai-insights-panel-input-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+
+  .gct-ai-insights-panel-textarea {
+    flex: 1;
+    border: 1px solid var(--color-gray-300);
+    border-radius: 20px;
+    padding: 8px 16px;
+    font-size: var(--font-size-sm);
+    font-family: inherit;
+    color: var(--color-text);
+    background-color: #fff;
+    outline: none;
+    transition: vars.$transition-duration;
+
+    &::placeholder {
+      color: var(--color-gray-600);
+    }
+
+    &:focus {
+      border-color: var(--color-action-primary);
+      box-shadow: 0 0 0 2px rgb(80 129 167 / 15%);
+    }
+  }
+
+  .p-button {
+    background-color: var(--color-action-primary);
+    border-color: var(--color-action-primary);
+    color: #fff;
+    width: 32px;
+    height: 32px;
+
+    &:hover:not(:disabled) {
+      background-color: var(--color-action-primary-hover);
+      border-color: var(--color-action-primary-hover);
+    }
+
+    &:disabled {
+      opacity: 0.4;
+    }
+  }
+}

--- a/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-ai-insights-panel/gene-comparison-tool-ai-insights-panel.component.spec.ts
+++ b/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-ai-insights-panel/gene-comparison-tool-ai-insights-panel.component.spec.ts
@@ -1,0 +1,44 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideMarkdown } from 'ngx-markdown';
+import { GeneComparisonToolAiInsightsPanelComponent } from './gene-comparison-tool-ai-insights-panel.component';
+
+describe('GeneComparisonToolAiInsightsPanelComponent', () => {
+  let component: GeneComparisonToolAiInsightsPanelComponent;
+  let fixture: ComponentFixture<GeneComparisonToolAiInsightsPanelComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [GeneComparisonToolAiInsightsPanelComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideMarkdown()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(GeneComparisonToolAiInsightsPanelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should toggle panel visibility', () => {
+    expect(component.isOpen).toBe(false);
+    component.toggle();
+    expect(component.isOpen).toBe(true);
+    component.toggle();
+    expect(component.isOpen).toBe(false);
+  });
+
+  it('should clear conversation', () => {
+    component.messages = [
+      { role: 'user', content: 'test' },
+      { role: 'assistant', content: 'response' },
+    ];
+    component.errorMessage = 'some error';
+    component.clearConversation();
+    expect(component.messages.length).toBe(0);
+    expect(component.errorMessage).toBe('');
+  });
+});

--- a/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-ai-insights-panel/gene-comparison-tool-ai-insights-panel.component.ts
+++ b/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-ai-insights-panel/gene-comparison-tool-ai-insights-panel.component.ts
@@ -1,0 +1,148 @@
+import { Component, ElementRef, Input, ViewChild, ViewEncapsulation, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Subscription } from 'rxjs';
+import { MarkdownModule } from 'ngx-markdown';
+import { ButtonModule } from 'primeng/button';
+import { SelectModule } from 'primeng/select';
+import { TooltipModule } from 'primeng/tooltip';
+import { GCTGene } from '@sagebionetworks/agora/api-client';
+import { AiInsightsService, AiInsightsMessage, AiModel, AI_MODELS } from '../../ai-insights';
+
+@Component({
+  selector: 'agora-gene-comparison-tool-ai-insights-panel',
+  imports: [CommonModule, FormsModule, MarkdownModule, ButtonModule, SelectModule, TooltipModule],
+  templateUrl: './gene-comparison-tool-ai-insights-panel.component.html',
+  styleUrls: ['./gene-comparison-tool-ai-insights-panel.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+})
+export class GeneComparisonToolAiInsightsPanelComponent {
+  @Input() pinnedGenes: GCTGene[] = [];
+  @Input() category = '';
+  @Input() subCategory = '';
+
+  @ViewChild('messagesContainer') messagesContainer!: ElementRef;
+
+  private readonly aiInsightsService = inject(AiInsightsService);
+  private streamSubscription: Subscription | null = null;
+
+  isOpen = false;
+  messages: AiInsightsMessage[] = [];
+  streamingContent = '';
+  isStreaming = false;
+  selectedModel: AiModel = 'anthropic/claude-sonnet-4-6';
+  modelOptions = AI_MODELS;
+  userInput = '';
+  errorMessage = '';
+
+  open() {
+    this.isOpen = true;
+  }
+
+  close() {
+    this.isOpen = false;
+  }
+
+  toggle() {
+    if (this.isOpen) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+
+  analyze() {
+    if (this.isStreaming || this.pinnedGenes.length === 0) return;
+
+    const geneIds = this.pinnedGenes.map((g) => g.ensembl_gene_id);
+    const userMessage =
+      'Analyze these pinned genes. Highlight commonalities, key differences, and potential research directions.';
+
+    this.messages.push({ role: 'user', content: userMessage });
+    this.startStream(geneIds, userMessage);
+  }
+
+  sendFollowUp() {
+    const input = this.userInput.trim();
+    if (!input || this.isStreaming) return;
+
+    this.messages.push({ role: 'user', content: input });
+    this.userInput = '';
+
+    const geneIds = this.pinnedGenes.map((g) => g.ensembl_gene_id);
+    this.startStream(geneIds, input, this.messages.slice(0, -1));
+  }
+
+  stopStreaming() {
+    this.aiInsightsService.cancelStream();
+    this.streamSubscription?.unsubscribe();
+    this.streamSubscription = null;
+
+    if (this.streamingContent) {
+      this.messages.push({
+        role: 'assistant',
+        content: this.streamingContent,
+      });
+      this.streamingContent = '';
+    }
+    this.isStreaming = false;
+  }
+
+  clearConversation() {
+    this.messages = [];
+    this.streamingContent = '';
+    this.errorMessage = '';
+  }
+
+  private startStream(
+    geneIds: string[],
+    userMessage: string,
+    conversationHistory?: AiInsightsMessage[],
+  ) {
+    this.isStreaming = true;
+    this.streamingContent = '';
+    this.errorMessage = '';
+
+    this.streamSubscription = this.aiInsightsService
+      .streamGeneInsights(geneIds, userMessage, this.selectedModel, conversationHistory)
+      .subscribe({
+        next: (event) => {
+          switch (event.type) {
+            case 'content':
+              this.streamingContent = event.fullContent || '';
+              this.scrollToBottom();
+              break;
+            case 'done':
+              this.messages.push({
+                role: 'assistant',
+                content: event.fullContent || '',
+              });
+              this.streamingContent = '';
+              this.isStreaming = false;
+              this.scrollToBottom();
+              break;
+            case 'error':
+              this.errorMessage = event.error || 'An error occurred';
+              this.isStreaming = false;
+              break;
+          }
+        },
+        error: () => {
+          this.errorMessage = 'Failed to connect to AI service';
+          this.isStreaming = false;
+        },
+        complete: () => {
+          this.isStreaming = false;
+        },
+      });
+  }
+
+  private scrollToBottom() {
+    setTimeout(() => {
+      const el = this.messagesContainer?.nativeElement;
+      if (el) {
+        el.scrollTop = el.scrollHeight;
+      }
+    });
+  }
+}

--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.html
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.html
@@ -300,6 +300,18 @@
                   <div class="clear-all-button">
                     <button (click)="onClearAllClick()">Clear All</button>
                   </div>
+                  <div class="ai-insights-button">
+                    <p-button
+                      label="AI Insights"
+                      icon="pi pi-sparkles"
+                      (click)="aiInsightsPanel.toggle()"
+                      [rounded]="true"
+                      size="small"
+                      pTooltip="Get AI-powered analysis of pinned genes"
+                      tooltipPosition="top"
+                      tooltipStyleClass="tooltip"
+                    ></p-button>
+                  </div>
                 </div>
               </div>
             }
@@ -636,6 +648,12 @@
     </div>
   </div>
 
+  <agora-gene-comparison-tool-ai-insights-panel
+    #aiInsightsPanel
+    [pinnedGenes]="pinnedItems"
+    [category]="category"
+    [subCategory]="subCategory"
+  ></agora-gene-comparison-tool-ai-insights-panel>
   <agora-gene-comparison-tool-details-panel
     #detailsPanel
     (onShowLegend)="comparisonToolService.toggleLegend()"

--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.scss
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.scss
@@ -707,6 +707,10 @@
   }
 }
 
+.ai-insights-button {
+  margin-left: auto;
+}
+
 .gct-category-panel {
   width: 425px;
   background: #fff;

--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.ts
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.ts
@@ -45,6 +45,7 @@ import { combineLatest, Subscription } from 'rxjs';
 import * as helpers from './gene-comparison-tool.helpers';
 import * as variables from './gene-comparison-tool.variables';
 
+import { GeneComparisonToolAiInsightsPanelComponent } from './components/gene-comparison-tool-ai-insights-panel/gene-comparison-tool-ai-insights-panel.component';
 import { GeneComparisonToolDetailsPanelComponent } from './components/gene-comparison-tool-details-panel/gene-comparison-tool-details-panel.component';
 import { GeneComparisonToolFilterPanelComponent } from './components/gene-comparison-tool-filter-panel/gene-comparison-tool-filter-panel.component';
 import { GeneComparisonToolPinnedGenesModalComponent } from './components/gene-comparison-tool-pinned-genes-modal/gene-comparison-tool-pinned-genes-modal.component';
@@ -78,6 +79,7 @@ import { GeneComparisonToolFilterListComponent } from './components/gene-compari
     SvgIconComponent,
     HelpLinksComponent,
     Paginator,
+    GeneComparisonToolAiInsightsPanelComponent,
     GeneComparisonToolFilterListComponent,
     GeneComparisonToolScorePanelComponent,
     GeneComparisonToolDetailsPanelComponent,
@@ -182,6 +184,7 @@ export class GeneComparisonToolComponent implements OnInit, AfterViewInit, OnDes
   @ViewChild('pinnedTable', { static: true }) pinnedTable!: Table;
   @ViewChild('genesTable', { static: true }) genesTable!: Table;
 
+  @ViewChild('aiInsightsPanel') aiInsightsPanel!: GeneComparisonToolAiInsightsPanelComponent;
   @ViewChild('filterPanel') filterPanel!: GeneComparisonToolFilterPanelComponent;
   @ViewChild('detailsPanel') detailsPanel!: GeneComparisonToolDetailsPanelComponent;
   @ViewChild('scorePanel') scorePanel!: GeneComparisonToolScorePanelComponent;


### PR DESCRIPTION
## Description

Adds an AI-powered insights panel to the Agora Gene Comparison Tool, enabling AI-based scientists to analyze pinned genes using LLMs via OpenRouter. Built during the Sage-wide March 2026 hackathon to demonstrate how AI can synthesize cross-gene patterns from Agora's multi-omic AD data — including risk scores, biological domains, coexpression networks, and nomination history — that would otherwise require tedious manual cross-referencing.

## Changelog

- Add "AI Insights" button to the pinned genes toolbar on the Gene Comparison Tool page
- Create streaming AI insights panel with model selector (Claude, GPT-4o, Gemini, Llama), conversation thread, and follow-up question support
- Build Angular service that fetches full gene data (details, bio domains, similar genes network) from Agora API and streams LLM responses via OpenRouter
- Design expert-level system prompt for comparative gene analysis covering convergence, divergence, network relationships, druggability, and testable hypotheses
- Add hackathon plan documenting the feature design, agent team setup, and AI-based scientist feedback loop

## Preview

The Gene Comparison Tool now has:

- AI Insights button in the pinned genes toolbar that opens a side panel for LLM-powered cross-gene analysis
- Multi-model support via OpenRouter with streaming markdown responses and follow-up chat
- Rich gene context pipeline that feeds risk scores, bio domains, coexpression networks, druggability, and nomination data to the LLM
- AI-based scientist-validated system prompt tuned for comparative analysis and hypothesis generation