### PR TITLE
chore(devcontainer): install Claude Code natively and add devcontainer rule (SMR-738)

### DIFF
--- a/.claude/rules/devcontainer.md
+++ b/.claude/rules/devcontainer.md
@@ -1,0 +1,29 @@
+---
+paths:
+  - .github/.devcontainer/**
+  - .devcontainer/**
+---
+
+# Dev Container
+
+Full documentation: [`docs/develop/maintenance/dev-container.md`](docs/develop/maintenance/dev-container.md)
+
+## Two-PR workflow (critical)
+
+Dev container changes always follow a **BUILD → ACTIVATE** split. Never collapse into one PR.
+
+| Step                | Branch pattern                      | Files touched                                                                 |
+| ------------------- | ----------------------------------- | ----------------------------------------------------------------------------- |
+| 1 — BUILD & PUBLISH | `chore/devcontainer/build-<date>`   | `.github/.devcontainer/Dockerfile`, `.github/.devcontainer/devcontainer.json` |
+| 2 — ACTIVATE        | `chore/devcontainer/activate-<sha>` | `.devcontainer/devcontainer.json`                                             |
+
+There are **two different `devcontainer.json` files** with distinct roles:
+
+- `.github/.devcontainer/devcontainer.json` — build recipe (used by CI to bake the image; never referenced by VS Code directly)
+- `.devcontainer/devcontainer.json` — active definition (what VS Code opens; points to a published GHCR image tag)
+
+## Adding tools
+
+- New tools go in `.github/.devcontainer/Dockerfile`, not in `dev-env.sh`
+- `dev-env.sh` is sourced on every terminal session — it is for environment configuration only
+- Tools installed after the `USER $user` switch (as `ubuntu`) install to `~/.local/` — this works because no volume mount shadows `/home/ubuntu` in the devcontainer setup, and `~/.local/bin` is already on PATH (added by `pipx ensurepath`)

--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -177,7 +177,7 @@ RUN pipx ensurepath \
   && pipx install uv=="${uvVersion}"
 
 # Install Claude Code.
-RUN curl -fsSL https://claude.ai/install.sh | bash
+RUN curl -fsSL https://claude.ai/install.sh | bash -s stable
 
 # Prepare the user's environment.
 RUN usermod --shell /bin/bash $user \

--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -176,6 +176,9 @@ RUN corepack install --global pnpm@"${pnpmVersion}"
 RUN pipx ensurepath \
   && pipx install uv=="${uvVersion}"
 
+# Install Claude Code.
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
 # Prepare the user's environment.
 RUN usermod --shell /bin/bash $user \
   && printf "%s\n" \

--- a/.github/workflows/build-and-push-devcontainer-image.yml
+++ b/.github/workflows/build-and-push-devcontainer-image.yml
@@ -107,10 +107,6 @@ jobs:
           # devcontainer.json used to build the image.
           export DEVCONTAINER_VERSION="${GITHUB_SHA}"
 
-          # Disable BuildKit's default provenance attestations
-          # See https://github.com/Sage-Bionetworks/sage-monorepo/issues/3904
-          export BUILDX_NO_DEFAULT_ATTESTATIONS=1
-
           # Convert the comma-separated list into the desired format
           images=""
           for image in ${IMAGES}; do


### PR DESCRIPTION
## Description

Publish devcontainer with Claude Code installed natively. Add Claude rule to support devcontainer development.

> [!NOTE] 
> A follow up PR will activate the devcontainer published by this PR and remove `@anthropic-ai/claude-code` from `devDependencies` in `package.json`

## Related Issue

- [SMR-738](https://sagebionetworks.jira.com/browse/SMR-738)
- [SMR-695](https://sagebionetworks.jira.com/browse/SMR-695)

## Changelog

- Install Claude Code natively in devcontainer image
- Restore default provenance attestations in devcontainer workflow to prevent SBOM attestation error, see this [comment](https://sagebionetworks.jira.com/browse/SMR-695?focusedCommentId=316104) for more context
- Add Claude rule to support devcontainer development

[SMR-738]: https://sagebionetworks.jira.com/browse/SMR-738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SMR-695]: https://sagebionetworks.jira.com/browse/SMR-695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ