### PR TITLE
feat(bixarena): implement battle page with new design to angular app (SMR-733)

### DIFF
--- a/apps/bixarena/app-angular/project.json
+++ b/apps/bixarena/app-angular/project.json
@@ -54,8 +54,8 @@
           "budgets": [
             {
               "type": "initial",
-              "maximumWarning": "500kb",
-              "maximumError": "1mb"
+              "maximumWarning": "1mb",
+              "maximumError": "1.5mb"
             },
             {
               "type": "anyComponentStyle",

--- a/apps/bixarena/app-angular/src/app/app.component.scss
+++ b/apps/bixarena/app-angular/src/app/app.component.scss
@@ -8,4 +8,6 @@
 
 main {
   flex: 1;
+  display: flex;
+  flex-direction: column;
 }

--- a/apps/bixarena/app-angular/src/app/app.component.spec.ts
+++ b/apps/bixarena/app-angular/src/app/app.component.spec.ts
@@ -22,6 +22,7 @@ describe('AppComponent', () => {
                 sageBionetworks: '',
               },
               auth: { baseUrls: { csr: '' } },
+              battle: { promptLengthLimit: 5000, roundLimit: 20, promptUseLimit: 5 },
               analytics: {
                 googleTagManager: { enabled: false, id: '' },
               },

--- a/apps/bixarena/app-angular/src/app/app.config.ts
+++ b/apps/bixarena/app-angular/src/app/app.config.ts
@@ -6,7 +6,7 @@ import {
   provideAppInitializer,
   provideZoneChangeDetection,
 } from '@angular/core';
-import { provideClientHydration } from '@angular/platform-browser';
+import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideRouter, withComponentInputBinding, withInMemoryScrolling } from '@angular/router';
 import { BASE_PATH } from '@sagebionetworks/bixarena/api-client';
@@ -40,7 +40,7 @@ export const appConfig: ApplicationConfig = {
       },
     }),
     provideHttpClient(withFetch()),
-    provideClientHydration(),
+    provideClientHydration(withEventReplay()),
     provideZoneChangeDetection({ eventCoalescing: true }),
     { provide: APP_ID, useValue: 'bixarena-app' },
     provideRouter(

--- a/apps/bixarena/app-angular/src/app/app.config.ts
+++ b/apps/bixarena/app-angular/src/app/app.config.ts
@@ -15,6 +15,7 @@ import { BixArenaPreset } from '@sagebionetworks/bixarena/styles';
 import { AuthService, ThemeService } from '@sagebionetworks/bixarena/services';
 import { provideGtmConfig, provideGtmId } from '@sagebionetworks/web-shared/angular/analytics/gtm';
 import { providePrimeNG } from 'primeng/config';
+import { provideMarkdown } from 'ngx-markdown';
 import { appRoutes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
@@ -64,5 +65,6 @@ export const appConfig: ApplicationConfig = {
       [ConfigService],
     ),
     provideGtmId(),
+    provideMarkdown(),
   ],
 };

--- a/apps/bixarena/app-angular/src/config/application.yaml
+++ b/apps/bixarena/app-angular/src/config/application.yaml
@@ -18,7 +18,7 @@ auth:
 battle:
   promptLengthLimit: 5000
   roundLimit: 20
-  promptUseLimit: 2 # TODO: revert to 5 before merging
+  promptUseLimit: 5
 
 analytics:
   googleTagManager:

--- a/apps/bixarena/app-angular/src/config/application.yaml
+++ b/apps/bixarena/app-angular/src/config/application.yaml
@@ -15,6 +15,11 @@ auth:
   baseUrls:
     csr: http://127.0.0.1:8111
 
+battle:
+  promptLengthLimit: 5000
+  roundLimit: 20
+  promptUseLimit: 5
+
 analytics:
   googleTagManager:
     enabled: true

--- a/apps/bixarena/app-angular/src/config/application.yaml
+++ b/apps/bixarena/app-angular/src/config/application.yaml
@@ -18,7 +18,7 @@ auth:
 battle:
   promptLengthLimit: 5000
   roundLimit: 20
-  promptUseLimit: 5
+  promptUseLimit: 2 # TODO: revert to 5 before merging
 
 analytics:
   googleTagManager:

--- a/libs/bixarena/battle/src/lib/battle-errors.ts
+++ b/libs/bixarena/battle/src/lib/battle-errors.ts
@@ -1,0 +1,32 @@
+// Typed error thrown by BattleStreamService when the HTTP response is not OK
+export class StreamHttpError extends Error {
+  constructor(public readonly status: number) {
+    super(`Stream request failed: ${status}`);
+  }
+}
+
+// Map HTTP status codes to user-facing error messages and retry eligibility
+export function mapStreamHttpError(status: number): {
+  message: string;
+  retryable: boolean;
+} {
+  switch (status) {
+    case 400:
+      return {
+        message: 'This question could not be processed. Try a new question',
+        retryable: false,
+      };
+    case 401:
+      return { message: 'Please log in to continue', retryable: false };
+    case 403:
+      return { message: 'Please log in to continue', retryable: false };
+    case 404:
+      return { message: 'This battle is no longer available. Try a new battle', retryable: false };
+    case 429:
+      return { message: 'Too many requests — please wait a moment', retryable: true };
+    case 500:
+      return { message: 'Something went wrong', retryable: true };
+    default:
+      return { message: 'Something went wrong', retryable: true };
+  }
+}

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -39,18 +39,18 @@
       </div>
       <div class="panels">
         <bixarena-model-panel
-          [label]="state.model1DisplayName()"
+          [anonymousName]="state.model1DisplayName()"
           modelId="model1"
           [streamState]="state.model1Stream()"
-          [revealedName]="state.phase() === 'reveal' ? (state.model1()?.name ?? null) : null"
+          [modelName]="state.phase() === 'reveal' ? (state.model1()?.name ?? null) : null"
           [selectedOutcome]="state.selectedOutcome()"
           [hoveredModel]="hoverSide()"
         />
         <bixarena-model-panel
-          [label]="state.model2DisplayName()"
+          [anonymousName]="state.model2DisplayName()"
           modelId="model2"
           [streamState]="state.model2Stream()"
-          [revealedName]="state.phase() === 'reveal' ? (state.model2()?.name ?? null) : null"
+          [modelName]="state.phase() === 'reveal' ? (state.model2()?.name ?? null) : null"
           [selectedOutcome]="state.selectedOutcome()"
           [hoveredModel]="hoverSide()"
         />

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -26,12 +26,16 @@
         @for (i of promptUseDots; track i) {
           <span
             class="rd"
-            [class.done]="i <= completedBattles()"
-            [class.now]="i === currentBattle()"
-            [class.fut]="i > currentBattle()"
+            [class.done]="i <= completedMatches()"
+            [class.now]="i === currentMatch() && !allMatchesComplete()"
+            [class.fut]="i > currentMatch()"
           ></span>
         }
-        <span class="rl">Battle {{ currentBattle() }} of {{ promptUseLimit }}</span>
+        @if (allMatchesComplete()) {
+          <span class="rl complete">Mission Complete! You've stress-tested this question</span>
+        } @else {
+          <span class="rl">Match {{ currentMatch() }} / {{ promptUseLimit }}</span>
+        }
       </div>
       <div class="panels">
         <bixarena-model-panel
@@ -64,7 +68,7 @@
       <div class="btm">
         <bixarena-prompt-composer
           placeholder="Ask a follow-up..."
-          [disabled]="state.phase() === 'streaming' || state.phase() === 'creating'"
+          [disabled]="state.phase() !== 'voting'"
           (promptSubmit)="onPromptSubmit($event)"
         />
       </div>

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -36,15 +36,19 @@
       <div class="panels">
         <bixarena-model-panel
           [label]="state.model1DisplayName()"
+          modelId="model1"
           [streamState]="state.model1Stream()"
           [revealedName]="state.phase() === 'reveal' ? (state.model1()?.name ?? null) : null"
-          [isWinner]="state.selectedOutcome() === 'model1'"
+          [selectedOutcome]="state.selectedOutcome()"
+          [hoveredModel]="hoverSide()"
         />
         <bixarena-model-panel
           [label]="state.model2DisplayName()"
+          modelId="model2"
           [streamState]="state.model2Stream()"
           [revealedName]="state.phase() === 'reveal' ? (state.model2()?.name ?? null) : null"
-          [isWinner]="state.selectedOutcome() === 'model2'"
+          [selectedOutcome]="state.selectedOutcome()"
+          [hoveredModel]="hoverSide()"
         />
       </div>
       <bixarena-voting-bar
@@ -53,6 +57,7 @@
         [canReuse]="state.canReuse()"
         [promptUsesRemaining]="state.promptUsesRemaining()"
         (vote)="onVote($event)"
+        (hoverSide)="hoverSide.set($event)"
         (newBattle)="onNewBattle()"
         (samePrompt)="onSamePrompt()"
       />

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -6,6 +6,7 @@
         Discover how different AIs answer biomedical questions. Submit a prompt, compare two
         anonymous models side-by-side, then vote for the best response.
       </p>
+      <bixarena-example-prompts (promptSelect)="onPromptSubmit($event)" />
     </div>
   }
 

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -14,6 +14,9 @@
         [disabled]="state.phase() === 'creating'"
         (promptSubmit)="onPromptSubmit($event)"
       />
+      <p class="disclaimer">
+        AI may make mistakes. Do not include sensitive or personal information.
+      </p>
     </section>
   }
 

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -70,7 +70,7 @@
           placeholder="Ask a follow-up..."
           [maxLength]="state.promptLengthLimit"
           [disabled]="state.phase() !== 'voting'"
-          (promptSubmit)="onPromptSubmit($event)"
+          (promptSubmit)="onFollowUpSubmit($event)"
         />
       </div>
       <p class="disclaimer">

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -45,6 +45,7 @@
           [modelName]="state.phase() === 'reveal' ? (state.model1()?.name ?? null) : null"
           [selectedOutcome]="state.selectedOutcome()"
           [hoveredModel]="hoverSide()"
+          (retry)="state.retry()"
         />
         <bixarena-model-panel
           modelId="model2"
@@ -52,6 +53,7 @@
           [modelName]="state.phase() === 'reveal' ? (state.model2()?.name ?? null) : null"
           [selectedOutcome]="state.selectedOutcome()"
           [hoveredModel]="hoverSide()"
+          (retry)="state.retry()"
         />
       </div>
       <bixarena-voting-bar

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -1,3 +1,52 @@
 <div class="page-content">
-  <p>Battle is coming soon</p>
+  @if (state.phase() === 'landing') {
+    <div class="landing">
+      <h1 class="title">BioArena</h1>
+      <p class="subtitle">
+        Discover how different AIs answer biomedical questions. Submit a prompt, compare two
+        anonymous models side-by-side, then vote for the best response.
+      </p>
+    </div>
+  }
+
+  @if (state.phase() !== 'landing') {
+    <div class="battle-view">
+      <div class="panels">
+        <bixarena-model-panel
+          [label]="state.model1DisplayName()"
+          [streamState]="state.model1Stream()"
+          [revealedName]="state.phase() === 'reveal' ? (state.model1()?.name ?? null) : null"
+          [isWinner]="state.selectedOutcome() === 'model1'"
+        />
+        <bixarena-model-panel
+          [label]="state.model2DisplayName()"
+          [streamState]="state.model2Stream()"
+          [revealedName]="state.phase() === 'reveal' ? (state.model2()?.name ?? null) : null"
+          [isWinner]="state.selectedOutcome() === 'model2'"
+        />
+      </div>
+
+      <bixarena-voting-bar
+        [phase]="state.phase()"
+        [canVote]="state.canVote()"
+        [canReuse]="state.canReuse()"
+        [promptUsesRemaining]="state.promptUsesRemaining()"
+        (vote)="onVote($event)"
+        (newBattle)="onNewBattle()"
+        (samePrompt)="onSamePrompt()"
+      />
+    </div>
+  }
+
+  <bixarena-prompt-composer
+    [placeholder]="
+      state.phase() === 'landing' ? 'Ask anything biomedical...' : 'Ask a follow-up...'
+    "
+    [disabled]="state.phase() === 'streaming' || state.phase() === 'creating'"
+    (promptSubmit)="onPromptSubmit($event)"
+  />
+
+  <p class="disclaimer">
+    AI responses may be inaccurate. Do not share personal health information.
+  </p>
 </div>

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -23,23 +23,22 @@
   @if (state.phase() !== 'landing') {
     <section class="battle-view">
       <div class="rail">
-        @for (i of promptUseDots; track i) {
+        @for (i of state.promptUseDots; track i) {
           <span
             class="rd"
-            [class.done]="i <= completedMatches()"
-            [class.now]="i === currentMatch() && !allMatchesComplete()"
-            [class.fut]="i > currentMatch()"
+            [class.done]="i <= state.completedMatches()"
+            [class.now]="i === state.currentMatch() && !state.allMatchesComplete()"
+            [class.fut]="i > state.currentMatch()"
           ></span>
         }
-        @if (allMatchesComplete()) {
-          <span class="rl complete">Mission Complete! You've stress-tested this question</span>
+        @if (state.allMatchesComplete()) {
+          <span class="rl complete">You've stress-tested this question! Try a new one.</span>
         } @else {
-          <span class="rl">Match {{ currentMatch() }} / {{ promptUseLimit }}</span>
+          <span class="rl">Match {{ state.currentMatch() }} / {{ state.promptUseLimit }}</span>
         }
       </div>
       <div class="panels">
         <bixarena-model-panel
-          [anonymousName]="state.model1DisplayName()"
           modelId="model1"
           [streamState]="state.model1Stream()"
           [modelName]="state.phase() === 'reveal' ? (state.model1()?.name ?? null) : null"
@@ -47,7 +46,6 @@
           [hoveredModel]="hoverSide()"
         />
         <bixarena-model-panel
-          [anonymousName]="state.model2DisplayName()"
           modelId="model2"
           [streamState]="state.model2Stream()"
           [modelName]="state.phase() === 'reveal' ? (state.model2()?.name ?? null) : null"
@@ -63,7 +61,7 @@
         (vote)="onVote($event)"
         (hoverSide)="hoverSide.set($event)"
         (newBattle)="onNewBattle()"
-        (samePrompt)="onSamePrompt()"
+        (samePrompt)="onSamePromptSubmit()"
       />
       <div class="btm">
         <bixarena-prompt-composer

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -11,6 +11,7 @@
       <bixarena-example-prompts (promptSelect)="onPromptSubmit($event)" />
       <bixarena-prompt-composer
         placeholder="Ask anything biomedical..."
+        [maxLength]="state.promptLengthLimit"
         [disabled]="state.phase() === 'creating'"
         (promptSubmit)="onPromptSubmit($event)"
       />
@@ -66,6 +67,7 @@
       <div class="btm">
         <bixarena-prompt-composer
           placeholder="Ask a follow-up..."
+          [maxLength]="state.promptLengthLimit"
           [disabled]="state.phase() !== 'voting'"
           (promptSubmit)="onPromptSubmit($event)"
         />

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -1,17 +1,35 @@
-<div class="page-content">
+<div class="page-content shell">
   @if (state.phase() === 'landing') {
-    <div class="landing">
-      <h1 class="title">BioArena</h1>
-      <p class="subtitle">
-        Discover how different AIs answer biomedical questions. Submit a prompt, compare two
-        anonymous models side-by-side, then vote for the best response.
-      </p>
+    <section class="landing">
+      <div class="hero">
+        <h1 class="title">Bio<em>Arena</em></h1>
+        <p class="subtitle">
+          Discover how different AIs answer biomedical questions.<br />
+          No expertise needed — just vote for the response you trust.
+        </p>
+      </div>
       <bixarena-example-prompts (promptSelect)="onPromptSubmit($event)" />
-    </div>
+      <bixarena-prompt-composer
+        placeholder="Ask anything biomedical..."
+        [disabled]="state.phase() === 'creating'"
+        (promptSubmit)="onPromptSubmit($event)"
+      />
+    </section>
   }
 
   @if (state.phase() !== 'landing') {
-    <div class="battle-view">
+    <section class="battle-view">
+      <div class="rail">
+        @for (i of promptUseDots; track i) {
+          <span
+            class="rd"
+            [class.done]="i < currentBattleNumber()"
+            [class.now]="i === currentBattleNumber()"
+            [class.fut]="i > currentBattleNumber()"
+          ></span>
+        }
+        <span class="rl">Battle {{ currentBattleNumber() }} of {{ promptUseLimit }}</span>
+      </div>
       <div class="panels">
         <bixarena-model-panel
           [label]="state.model1DisplayName()"
@@ -26,7 +44,6 @@
           [isWinner]="state.selectedOutcome() === 'model2'"
         />
       </div>
-
       <bixarena-voting-bar
         [phase]="state.phase()"
         [canVote]="state.canVote()"
@@ -36,18 +53,16 @@
         (newBattle)="onNewBattle()"
         (samePrompt)="onSamePrompt()"
       />
-    </div>
+      <div class="btm">
+        <bixarena-prompt-composer
+          placeholder="Ask a follow-up..."
+          [disabled]="state.phase() === 'streaming' || state.phase() === 'creating'"
+          (promptSubmit)="onPromptSubmit($event)"
+        />
+      </div>
+      <p class="disclaimer">
+        AI responses may be inaccurate. Do not share personal health information.
+      </p>
+    </section>
   }
-
-  <bixarena-prompt-composer
-    [placeholder]="
-      state.phase() === 'landing' ? 'Ask anything biomedical...' : 'Ask a follow-up...'
-    "
-    [disabled]="state.phase() === 'streaming' || state.phase() === 'creating'"
-    (promptSubmit)="onPromptSubmit($event)"
-  />
-
-  <p class="disclaimer">
-    AI responses may be inaccurate. Do not share personal health information.
-  </p>
 </div>

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -64,7 +64,7 @@
         />
       </div>
       <p class="disclaimer">
-        AI responses may be inaccurate. Do not share personal health information.
+        AI may make mistakes. Do not include sensitive or personal information.
       </p>
     </section>
   }

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -26,12 +26,12 @@
         @for (i of promptUseDots; track i) {
           <span
             class="rd"
-            [class.done]="i < currentBattleNumber()"
-            [class.now]="i === currentBattleNumber()"
-            [class.fut]="i > currentBattleNumber()"
+            [class.done]="i <= completedBattles()"
+            [class.now]="i === currentBattle()"
+            [class.fut]="i > currentBattle()"
           ></span>
         }
-        <span class="rl">Battle {{ currentBattleNumber() }} of {{ promptUseLimit }}</span>
+        <span class="rl">Battle {{ currentBattle() }} of {{ promptUseLimit }}</span>
       </div>
       <div class="panels">
         <bixarena-model-panel

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -58,7 +58,6 @@
         [phase]="state.phase()"
         [canVote]="state.canVote()"
         [canReuse]="state.canReuse()"
-        [promptUsesRemaining]="state.promptUsesRemaining()"
         (vote)="onVote($event)"
         (hoverSide)="hoverSide.set($event)"
         (newBattle)="onNewBattle()"

--- a/libs/bixarena/battle/src/lib/battle.component.scss
+++ b/libs/bixarena/battle/src/lib/battle.component.scss
@@ -87,6 +87,11 @@
   font-weight: 460;
   letter-spacing: -0.01em;
   margin-left: 0.375rem;
+
+  &.complete {
+    color: var(--p-primary-color);
+    font-weight: 520;
+  }
 }
 
 @keyframes dp {

--- a/libs/bixarena/battle/src/lib/battle.component.scss
+++ b/libs/bixarena/battle/src/lib/battle.component.scss
@@ -1,41 +1,123 @@
+.shell {
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100dvh - var(--nav-height));
+}
+
 .landing {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2.5rem;
+  padding-bottom: 4rem;
+}
+
+.hero {
   text-align: center;
-  padding: 3rem 0 2rem;
 }
 
 .title {
   font-family: var(--font-serif);
-  font-size: 2.5rem;
-  font-weight: 700;
+  font-size: 3rem;
+  font-weight: 400;
+  letter-spacing: -0.96px;
+  line-height: 1.08;
   margin: 0 0 0.75rem;
   color: var(--p-text-color);
+
+  em {
+    font-style: italic;
+    color: var(--p-primary-color);
+  }
 }
 
 .subtitle {
-  font-size: 1.0625rem;
-  color: var(--p-text-muted-color);
-  max-width: 520px;
+  font-size: var(--text-lg);
+  color: var(--p-surface-600);
+  max-width: 37.5rem;
   margin: 0 auto;
-  line-height: 1.6;
+  line-height: 1.55;
 }
 
 .battle-view {
-  padding: 1rem 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  gap: 0.5rem;
+}
+
+.rail {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 0;
+  flex-shrink: 0;
+}
+
+.rd {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+
+  &.done {
+    background: var(--p-primary-500);
+    box-shadow: 0 0 6px rgb(249 115 22 / 30%);
+  }
+
+  &.now {
+    background: var(--p-primary-color);
+    box-shadow: 0 0 0 4px rgb(249 115 22 / 12%);
+    animation: dp 2s ease-in-out infinite;
+  }
+
+  &.fut {
+    background: rgb(134 128 123 / 12%);
+  }
+}
+
+.rl {
+  font-size: var(--text-xs);
+  color: var(--p-surface-500);
+  font-weight: 460;
+  letter-spacing: -0.01em;
+  margin-left: 0.375rem;
+}
+
+@keyframes dp {
+  0%,
+  100% {
+    box-shadow: 0 0 0 4px rgb(249 115 22 / 12%);
+  }
+
+  50% {
+    box-shadow: 0 0 0 8px rgb(249 115 22 / 4%);
+  }
 }
 
 .panels {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1rem;
+  gap: 0.75rem;
+  flex: 1;
+  min-height: 0;
 
   @media (width <= 768px) {
     grid-template-columns: 1fr;
   }
 }
 
+.btm bixarena-prompt-composer {
+  max-width: 100%;
+}
+
 .disclaimer {
   text-align: center;
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--p-text-muted-color);
-  margin: 1rem 0 0;
+  margin: 0.5rem 0 0;
 }

--- a/libs/bixarena/battle/src/lib/battle.component.scss
+++ b/libs/bixarena/battle/src/lib/battle.component.scss
@@ -107,7 +107,6 @@
   gap: 0.75rem;
   flex: 1;
   min-height: 0;
-  overflow: hidden;
 
   @media (width <= 768px) {
     grid-template-columns: 1fr;

--- a/libs/bixarena/battle/src/lib/battle.component.scss
+++ b/libs/bixarena/battle/src/lib/battle.component.scss
@@ -1,0 +1,41 @@
+.landing {
+  text-align: center;
+  padding: 3rem 0 2rem;
+}
+
+.title {
+  font-family: var(--font-serif);
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin: 0 0 0.75rem;
+  color: var(--p-text-color);
+}
+
+.subtitle {
+  font-size: 1.0625rem;
+  color: var(--p-text-muted-color);
+  max-width: 520px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.battle-view {
+  padding: 1rem 0;
+}
+
+.panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+
+  @media (width <= 768px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.disclaimer {
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--p-text-muted-color);
+  margin: 1rem 0 0;
+}

--- a/libs/bixarena/battle/src/lib/battle.component.scss
+++ b/libs/bixarena/battle/src/lib/battle.component.scss
@@ -1,7 +1,7 @@
 .shell {
   display: flex;
   flex-direction: column;
-  min-height: calc(100dvh - var(--nav-height));
+  height: calc(100dvh - var(--nav-height));
 }
 
 .landing {
@@ -46,6 +46,7 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  overflow: hidden;
   gap: 0.5rem;
 }
 
@@ -102,9 +103,11 @@
 .panels {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr;
   gap: 0.75rem;
   flex: 1;
   min-height: 0;
+  overflow: hidden;
 
   @media (width <= 768px) {
     grid-template-columns: 1fr;

--- a/libs/bixarena/battle/src/lib/battle.component.scss
+++ b/libs/bixarena/battle/src/lib/battle.component.scss
@@ -1,7 +1,7 @@
 .shell {
   display: flex;
   flex-direction: column;
-  height: calc(100dvh - var(--nav-height));
+  min-height: calc(100dvh - var(--nav-height));
 }
 
 .landing {
@@ -41,8 +41,9 @@
   line-height: 1.55;
 }
 
+// Fixed height so panels scroll internally instead of growing infinitely
 .battle-view {
-  flex: 1;
+  height: calc(100dvh - var(--nav-height));
   display: flex;
   flex-direction: column;
   min-height: 0;

--- a/libs/bixarena/battle/src/lib/battle.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.spec.ts
@@ -1,13 +1,42 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PLATFORM_ID } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { EMPTY } from 'rxjs';
+import { BattleService as BattleApiService, BASE_PATH } from '@sagebionetworks/bixarena/api-client';
+import { ConfigService } from '@sagebionetworks/bixarena/config';
 import { BattleComponent } from './battle.component';
+
+const mockConfig = {
+  config: {
+    battle: { promptLengthLimit: 5000, roundLimit: 20, promptUseLimit: 5 },
+  },
+};
 
 describe('BattleComponent', () => {
   let component: BattleComponent;
   let fixture: ComponentFixture<BattleComponent>;
 
   beforeEach(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    globalThis.fetch = jest.fn().mockReturnValue(new Promise(() => {}));
+
     await TestBed.configureTestingModule({
       imports: [BattleComponent],
+      providers: [
+        provideHttpClient(),
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: BASE_PATH, useValue: 'http://test/api/v1' },
+        { provide: ConfigService, useValue: mockConfig },
+        {
+          provide: BattleApiService,
+          useValue: {
+            createBattle: jest.fn().mockReturnValue(EMPTY),
+            createBattleRound: jest.fn().mockReturnValue(EMPTY),
+            createBattleEvaluation: jest.fn().mockReturnValue(EMPTY),
+            updateBattle: jest.fn().mockReturnValue(EMPTY),
+          },
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(BattleComponent);
@@ -17,5 +46,9 @@ describe('BattleComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should start in landing phase', () => {
+    expect(component.state.phase()).toBe('landing');
   });
 });

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -28,14 +28,15 @@ export class BattleComponent implements OnDestroy {
   readonly hoverSide = signal<'model1' | 'model2' | 'tie' | null>(null);
   readonly promptUseLimit = inject(ConfigService).config.battle.promptUseLimit;
   readonly promptUseDots = Array.from({ length: this.promptUseLimit }, (_, i) => i + 1);
-  readonly currentBattleNumber = computed(() => {
-    const remaining = this.state.promptUsesRemaining();
-    const phase = this.state.phase();
-    // After voting, remaining decrements but the next battle hasn't started yet
-    if (phase === 'reveal' || phase === 'error') {
-      return this.promptUseLimit - remaining;
-    }
-    return this.promptUseLimit - remaining + 1;
+
+  readonly completedBattles = computed(
+    () => this.promptUseLimit - this.state.promptUsesRemaining(),
+  );
+
+  readonly currentBattle = computed(() => {
+    const completed = this.completedBattles();
+    // On reveal, remaining already decremented — show the just-completed battle
+    return this.state.phase() === 'reveal' ? completed : completed + 1;
   });
 
   onPromptSubmit(prompt: string): void {
@@ -47,12 +48,12 @@ export class BattleComponent implements OnDestroy {
   }
 
   onNewBattle(): void {
-    this.state.newBattle();
+    this.state.reset();
   }
 
   onSamePrompt(): void {
     const prompt = this.state.lastPrompt();
-    if (prompt) {
+    if (prompt && this.state.promptUsesRemaining() > 0) {
       this.state.newBattle(prompt);
     }
   }

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -30,6 +30,10 @@ export class BattleComponent implements OnDestroy {
     void this.state.submitPrompt(prompt);
   }
 
+  onFollowUpSubmit(prompt: string): void {
+    void this.state.submitFollowUp(prompt);
+  }
+
   onVote(outcome: BattleEvaluationOutcome): void {
     void this.state.submitVote(outcome);
   }
@@ -39,10 +43,7 @@ export class BattleComponent implements OnDestroy {
   }
 
   onSamePromptSubmit(): void {
-    const prompt = this.state.lastPrompt();
-    if (prompt && this.state.promptUsesRemaining() > 0) {
-      this.state.newBattle(prompt);
-    }
+    void this.state.newMatchup();
   }
 
   ngOnDestroy(): void {

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -33,9 +33,10 @@ export class BattleComponent implements OnDestroy {
     () => this.promptUseLimit - this.state.promptUsesRemaining(),
   );
 
+  // On reveal, promptUsesRemaining already decremented so completedMatches is accurate.
+  // During active phases, add 1 to show the in-progress match number.
   readonly currentMatch = computed(() => {
     const completed = this.completedMatches();
-    // On reveal, remaining already decremented — show the just-completed match
     return this.state.phase() === 'reveal' ? completed : completed + 1;
   });
 

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -8,10 +8,16 @@ import { BattleStreamService } from './services/battle-stream.service';
 import { PromptComposerComponent } from './prompt-composer/prompt-composer.component';
 import { ModelPanelComponent } from './model-panel/model-panel.component';
 import { VotingBarComponent } from './voting-bar/voting-bar.component';
+import { ExamplePromptsComponent } from './example-prompts/example-prompts.component';
 
 @Component({
   selector: 'bixarena-battle',
-  imports: [PromptComposerComponent, ModelPanelComponent, VotingBarComponent],
+  imports: [
+    PromptComposerComponent,
+    ModelPanelComponent,
+    VotingBarComponent,
+    ExamplePromptsComponent,
+  ],
   providers: [BattleStateService, BattleStreamService, BattleApiService],
   templateUrl: './battle.component.html',
   styleUrl: './battle.component.scss',

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -25,7 +25,7 @@ import { ExamplePromptsComponent } from './example-prompts/example-prompts.compo
 })
 export class BattleComponent implements OnDestroy {
   readonly state = inject(BattleStateService);
-  readonly hoverSide = signal<'model1' | 'model2' | 'tie' | null>(null);
+  readonly hoverSide = signal<BattleEvaluationOutcome | null>(null);
   readonly promptUseLimit = inject(ConfigService).config.battle.promptUseLimit;
   readonly promptUseDots = Array.from({ length: this.promptUseLimit }, (_, i) => i + 1);
 

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -42,11 +42,11 @@ export class BattleComponent implements OnDestroy {
   readonly allMatchesComplete = computed(() => this.completedMatches() >= this.promptUseLimit);
 
   onPromptSubmit(prompt: string): void {
-    this.state.submitPrompt(prompt);
+    void this.state.submitPrompt(prompt);
   }
 
   onVote(outcome: BattleEvaluationOutcome): void {
-    this.state.submitVote(outcome);
+    void this.state.submitVote(outcome);
   }
 
   onNewBattle(): void {

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -1,9 +1,44 @@
-import { Component } from '@angular/core';
+import { Component, inject, OnDestroy } from '@angular/core';
+import {
+  BattleService as BattleApiService,
+  BattleEvaluationOutcome,
+} from '@sagebionetworks/bixarena/api-client';
+import { BattleStateService } from './services/battle.service';
+import { BattleStreamService } from './services/battle-stream.service';
+import { PromptComposerComponent } from './prompt-composer/prompt-composer.component';
+import { ModelPanelComponent } from './model-panel/model-panel.component';
+import { VotingBarComponent } from './voting-bar/voting-bar.component';
 
 @Component({
   selector: 'bixarena-battle',
-  imports: [],
+  imports: [PromptComposerComponent, ModelPanelComponent, VotingBarComponent],
+  providers: [BattleStateService, BattleStreamService, BattleApiService],
   templateUrl: './battle.component.html',
   styleUrl: './battle.component.scss',
 })
-export class BattleComponent {}
+export class BattleComponent implements OnDestroy {
+  readonly state = inject(BattleStateService);
+
+  onPromptSubmit(prompt: string): void {
+    this.state.submitPrompt(prompt);
+  }
+
+  onVote(outcome: BattleEvaluationOutcome): void {
+    this.state.submitVote(outcome);
+  }
+
+  onNewBattle(): void {
+    this.state.newBattle();
+  }
+
+  onSamePrompt(): void {
+    const prompt = this.state.lastPrompt();
+    if (prompt) {
+      this.state.newBattle(prompt);
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.state.reset();
+  }
+}

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, OnDestroy } from '@angular/core';
+import { Component, computed, inject, OnDestroy, signal } from '@angular/core';
 import {
   BattleService as BattleApiService,
   BattleEvaluationOutcome,
@@ -25,6 +25,7 @@ import { ExamplePromptsComponent } from './example-prompts/example-prompts.compo
 })
 export class BattleComponent implements OnDestroy {
   readonly state = inject(BattleStateService);
+  readonly hoverSide = signal<'model1' | 'model2' | 'tie' | null>(null);
   readonly promptUseLimit = inject(ConfigService).config.battle.promptUseLimit;
   readonly promptUseDots = Array.from({ length: this.promptUseLimit }, (_, i) => i + 1);
   readonly currentBattleNumber = computed(() => {

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -1,9 +1,8 @@
-import { Component, computed, inject, OnDestroy, signal } from '@angular/core';
+import { Component, inject, OnDestroy, signal } from '@angular/core';
 import {
   BattleService as BattleApiService,
   BattleEvaluationOutcome,
 } from '@sagebionetworks/bixarena/api-client';
-import { ConfigService } from '@sagebionetworks/bixarena/config';
 import { BattleStateService } from './services/battle.service';
 import { BattleStreamService } from './services/battle-stream.service';
 import { PromptComposerComponent } from './prompt-composer/prompt-composer.component';
@@ -26,21 +25,6 @@ import { ExamplePromptsComponent } from './example-prompts/example-prompts.compo
 export class BattleComponent implements OnDestroy {
   readonly state = inject(BattleStateService);
   readonly hoverSide = signal<BattleEvaluationOutcome | null>(null);
-  readonly promptUseLimit = inject(ConfigService).config.battle.promptUseLimit;
-  readonly promptUseDots = Array.from({ length: this.promptUseLimit }, (_, i) => i + 1);
-
-  readonly completedMatches = computed(
-    () => this.promptUseLimit - this.state.promptUsesRemaining(),
-  );
-
-  // On reveal, promptUsesRemaining already decremented so completedMatches is accurate.
-  // During active phases, add 1 to show the in-progress match number.
-  readonly currentMatch = computed(() => {
-    const completed = this.completedMatches();
-    return this.state.phase() === 'reveal' ? completed : completed + 1;
-  });
-
-  readonly allMatchesComplete = computed(() => this.completedMatches() >= this.promptUseLimit);
 
   onPromptSubmit(prompt: string): void {
     void this.state.submitPrompt(prompt);
@@ -54,7 +38,7 @@ export class BattleComponent implements OnDestroy {
     this.state.reset();
   }
 
-  onSamePrompt(): void {
+  onSamePromptSubmit(): void {
     const prompt = this.state.lastPrompt();
     if (prompt && this.state.promptUsesRemaining() > 0) {
       this.state.newBattle(prompt);

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -1,8 +1,5 @@
 import { Component, inject, OnDestroy, signal } from '@angular/core';
-import {
-  BattleService as BattleApiService,
-  BattleEvaluationOutcome,
-} from '@sagebionetworks/bixarena/api-client';
+import { BattleEvaluationOutcome } from '@sagebionetworks/bixarena/api-client';
 import { BattleStateService } from './services/battle.service';
 import { BattleStreamService } from './services/battle-stream.service';
 import { PromptComposerComponent } from './prompt-composer/prompt-composer.component';
@@ -18,7 +15,7 @@ import { ExamplePromptsComponent } from './example-prompts/example-prompts.compo
     VotingBarComponent,
     ExamplePromptsComponent,
   ],
-  providers: [BattleStateService, BattleStreamService, BattleApiService],
+  providers: [BattleStateService, BattleStreamService],
   templateUrl: './battle.component.html',
   styleUrl: './battle.component.scss',
 })

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -1,8 +1,9 @@
-import { Component, inject, OnDestroy } from '@angular/core';
+import { Component, computed, inject, OnDestroy } from '@angular/core';
 import {
   BattleService as BattleApiService,
   BattleEvaluationOutcome,
 } from '@sagebionetworks/bixarena/api-client';
+import { ConfigService } from '@sagebionetworks/bixarena/config';
 import { BattleStateService } from './services/battle.service';
 import { BattleStreamService } from './services/battle-stream.service';
 import { PromptComposerComponent } from './prompt-composer/prompt-composer.component';
@@ -24,6 +25,17 @@ import { ExamplePromptsComponent } from './example-prompts/example-prompts.compo
 })
 export class BattleComponent implements OnDestroy {
   readonly state = inject(BattleStateService);
+  readonly promptUseLimit = inject(ConfigService).config.battle.promptUseLimit;
+  readonly promptUseDots = Array.from({ length: this.promptUseLimit }, (_, i) => i + 1);
+  readonly currentBattleNumber = computed(() => {
+    const remaining = this.state.promptUsesRemaining();
+    const phase = this.state.phase();
+    // After voting, remaining decrements but the next battle hasn't started yet
+    if (phase === 'reveal' || phase === 'error') {
+      return this.promptUseLimit - remaining;
+    }
+    return this.promptUseLimit - remaining + 1;
+  });
 
   onPromptSubmit(prompt: string): void {
     this.state.submitPrompt(prompt);

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -29,15 +29,17 @@ export class BattleComponent implements OnDestroy {
   readonly promptUseLimit = inject(ConfigService).config.battle.promptUseLimit;
   readonly promptUseDots = Array.from({ length: this.promptUseLimit }, (_, i) => i + 1);
 
-  readonly completedBattles = computed(
+  readonly completedMatches = computed(
     () => this.promptUseLimit - this.state.promptUsesRemaining(),
   );
 
-  readonly currentBattle = computed(() => {
-    const completed = this.completedBattles();
-    // On reveal, remaining already decremented — show the just-completed battle
+  readonly currentMatch = computed(() => {
+    const completed = this.completedMatches();
+    // On reveal, remaining already decremented — show the just-completed match
     return this.state.phase() === 'reveal' ? completed : completed + 1;
   });
+
+  readonly allMatchesComplete = computed(() => this.completedMatches() >= this.promptUseLimit);
 
   onPromptSubmit(prompt: string): void {
     this.state.submitPrompt(prompt);

--- a/libs/bixarena/battle/src/lib/battle.constants.ts
+++ b/libs/bixarena/battle/src/lib/battle.constants.ts
@@ -1,0 +1,3 @@
+export const SLOW_MODEL_THRESHOLD_MS = 30_000;
+export const MODEL_TIMEOUT_MS = 300_000;
+export const STREAM_CURSOR = '\u258C'; // ▌

--- a/libs/bixarena/battle/src/lib/battle.types.ts
+++ b/libs/bixarena/battle/src/lib/battle.types.ts
@@ -1,0 +1,17 @@
+export type BattlePhase = 'landing' | 'creating' | 'streaming' | 'voting' | 'reveal' | 'error';
+
+export interface ModelStreamState {
+  text: string;
+  status: 'idle' | 'waiting' | 'streaming' | 'complete' | 'error';
+  finishReason: string | null;
+  errorMessage: string | null;
+  isSlowHint: boolean;
+}
+
+export const INITIAL_STREAM_STATE: ModelStreamState = {
+  text: '',
+  status: 'idle',
+  finishReason: null,
+  errorMessage: null,
+  isSlowHint: false,
+};

--- a/libs/bixarena/battle/src/lib/battle.types.ts
+++ b/libs/bixarena/battle/src/lib/battle.types.ts
@@ -1,5 +1,6 @@
 export type BattlePhase = 'landing' | 'creating' | 'streaming' | 'voting' | 'reveal' | 'error';
 
+// Per-model streaming state. 'text' holds in-progress chunks; on complete it moves to 'messages'.
 export interface ModelStreamState {
   messages: { role: 'user' | 'assistant'; content: string }[];
   text: string;

--- a/libs/bixarena/battle/src/lib/battle.types.ts
+++ b/libs/bixarena/battle/src/lib/battle.types.ts
@@ -7,6 +7,7 @@ export interface ModelStreamState {
   status: 'idle' | 'waiting' | 'streaming' | 'complete' | 'error';
   finishReason: string | null;
   errorMessage: string | null;
+  retryable: boolean;
   isSlowHint: boolean;
 }
 
@@ -16,5 +17,6 @@ export const INITIAL_STREAM_STATE: ModelStreamState = {
   status: 'idle',
   finishReason: null,
   errorMessage: null,
+  retryable: false,
   isSlowHint: false,
 };

--- a/libs/bixarena/battle/src/lib/battle.types.ts
+++ b/libs/bixarena/battle/src/lib/battle.types.ts
@@ -1,6 +1,7 @@
 export type BattlePhase = 'landing' | 'creating' | 'streaming' | 'voting' | 'reveal' | 'error';
 
 export interface ModelStreamState {
+  messages: { role: 'user' | 'assistant'; content: string }[];
   text: string;
   status: 'idle' | 'waiting' | 'streaming' | 'complete' | 'error';
   finishReason: string | null;
@@ -9,6 +10,7 @@ export interface ModelStreamState {
 }
 
 export const INITIAL_STREAM_STATE: ModelStreamState = {
+  messages: [],
   text: '',
   status: 'idle',
   finishReason: null,

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.html
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.html
@@ -1,0 +1,63 @@
+<div class="dna-section">
+  <div class="dna-label">Unwind a prompt</div>
+  <div class="dna-wrap">
+    <div class="helix">
+      <svg class="strand strand-back" viewBox="0 0 400 100" preserveAspectRatio="none">
+        <path d="M0,50 C50,10 100,90 150,50 C200,10 250,90 300,50 C350,10 400,90 450,50" />
+      </svg>
+      <svg class="strand strand-front" viewBox="0 0 400 100" preserveAspectRatio="none">
+        <path d="M0,50 C50,90 100,10 150,50 C200,90 250,10 300,50 C350,90 400,10 450,50" />
+      </svg>
+
+      @for (node of nodes; track node.label) {
+        <button
+          class="helix-node"
+          [class.active]="selectedCategory() === node.label"
+          [style.left.px]="node.left"
+          [style.top.px]="node.top"
+          (click)="onNodeClick(node)"
+          role="button"
+          tabindex="0"
+          [attr.aria-label]="'Load ' + node.label + ' prompt'"
+        >
+          <svg
+            class="node-icon"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path [attr.d]="node.icon" />
+          </svg>
+          <span class="node-label">{{ node.label }}</span>
+        </button>
+      }
+
+      <div
+        class="helix-rung"
+        style="left: 74px; top: 50px; width: 36px; transform: rotate(70deg)"
+      ></div>
+      <div
+        class="helix-rung"
+        style="left: 149px; top: 50px; width: 36px; transform: rotate(-70deg)"
+      ></div>
+      <div
+        class="helix-rung"
+        style="left: 224px; top: 50px; width: 36px; transform: rotate(70deg)"
+      ></div>
+      <div
+        class="helix-rung"
+        style="left: 299px; top: 50px; width: 36px; transform: rotate(-70deg)"
+      ></div>
+    </div>
+  </div>
+
+  @if (selectedPrompt()) {
+    <div class="dna-reveal">
+      <button class="dna-prompt" (click)="usePrompt()">{{ selectedPrompt() }}</button>
+      <div class="dna-hint">click to use this prompt</div>
+    </div>
+  }
+</div>

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.html
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.html
@@ -34,30 +34,11 @@
           <span class="node-label">{{ node.label }}</span>
         </button>
       }
-
-      <div
-        class="helix-rung"
-        style="left: 74px; top: 50px; width: 36px; transform: rotate(70deg)"
-      ></div>
-      <div
-        class="helix-rung"
-        style="left: 149px; top: 50px; width: 36px; transform: rotate(-70deg)"
-      ></div>
-      <div
-        class="helix-rung"
-        style="left: 224px; top: 50px; width: 36px; transform: rotate(70deg)"
-      ></div>
-      <div
-        class="helix-rung"
-        style="left: 299px; top: 50px; width: 36px; transform: rotate(-70deg)"
-      ></div>
     </div>
   </div>
 
-  @if (selectedPrompt()) {
-    <div class="dna-reveal">
-      <button class="dna-prompt" (click)="usePrompt()">{{ selectedPrompt() }}</button>
-      <div class="dna-hint">click to use this prompt</div>
-    </div>
-  }
+  <div class="dna-reveal" [class.show]="selectedPrompt()">
+    <button class="dna-prompt" (click)="usePrompt()">{{ selectedPrompt() }}</button>
+    <div class="dna-hint">click to use this prompt</div>
+  </div>
 </div>

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
@@ -1,0 +1,204 @@
+:host {
+  display: block;
+  width: 100%;
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.dna-section {
+  position: relative;
+}
+
+.dna-label {
+  text-align: center;
+  font-size: 0.6875rem;
+  color: var(--p-text-muted-color);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-weight: 500;
+  margin-bottom: 0.75rem;
+}
+
+.dna-wrap {
+  position: relative;
+  height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.helix {
+  position: relative;
+  width: 400px;
+  height: 100px;
+}
+
+.strand {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+
+.strand path {
+  fill: none;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  opacity: 0.2;
+}
+
+.strand-front path {
+  stroke: var(--p-teal-400);
+}
+
+.strand-back path {
+  stroke: var(--p-primary-color);
+}
+
+.helix-node {
+  position: absolute;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  z-index: 2;
+  border: none;
+  padding: 0;
+  background: none;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    background: var(--p-surface-50);
+    border: 1.5px solid var(--p-surface-200);
+    transition: all 0.3s;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: -4px;
+    border-radius: 50%;
+    background: transparent;
+    transition: all 0.3s;
+  }
+
+  &:hover {
+    transform: scale(1.15);
+
+    &::before {
+      border-color: var(--p-surface-300);
+    }
+
+    &::after {
+      background: rgb(52 212 180 / 6%);
+    }
+  }
+
+  &.active {
+    transform: scale(1.2);
+    animation: node-pulse 2s ease-in-out infinite;
+
+    &::before {
+      border-color: var(--p-teal-400);
+      background: rgb(52 212 180 / 10%);
+    }
+
+    &::after {
+      background: rgb(52 212 180 / 8%);
+    }
+  }
+}
+
+.node-icon {
+  position: relative;
+  z-index: 1;
+  width: 16px;
+  height: 16px;
+  color: var(--p-text-muted-color);
+  transition: color 0.3s;
+
+  .helix-node:hover & {
+    color: var(--p-text-color);
+  }
+
+  .helix-node.active & {
+    color: var(--p-teal-400);
+  }
+}
+
+.node-label {
+  position: absolute;
+  bottom: -20px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.5625rem;
+  color: var(--p-text-muted-color);
+  font-weight: 500;
+  white-space: nowrap;
+  letter-spacing: 0.02em;
+  transition: color 0.3s;
+  pointer-events: none;
+
+  .helix-node:hover & {
+    color: var(--p-text-color);
+  }
+
+  .helix-node.active & {
+    color: var(--p-teal-400);
+  }
+}
+
+.helix-rung {
+  position: absolute;
+  height: 1px;
+  background: var(--p-surface-200);
+  transform-origin: left center;
+  z-index: 1;
+}
+
+.dna-reveal {
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.dna-prompt {
+  display: inline-block;
+  max-width: 500px;
+  padding: 0.5rem 1rem;
+  background: var(--p-surface-50);
+  border: 1px solid var(--p-surface-200);
+  border-radius: 100px;
+  font: inherit;
+  font-size: 0.8125rem;
+  color: var(--p-text-color);
+  line-height: 1.5;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    border-color: var(--p-surface-300);
+  }
+}
+
+.dna-hint {
+  font-size: 0.625rem;
+  color: var(--p-text-muted-color);
+  margin-top: 0.25rem;
+}
+
+@keyframes node-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgb(52 212 180 / 15%);
+  }
+
+  50% {
+    box-shadow: 0 0 0 10px rgb(52 212 180 / 0%);
+  }
+}

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
@@ -177,7 +177,7 @@
   border-radius: 100px;
   font: inherit;
   font-size: var(--text-sm);
-  color: var(--p-text-muted-color);
+  color: var(--p-text-color);
   line-height: 1.5;
   cursor: pointer;
   transition: all 0.2s;

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
@@ -11,7 +11,7 @@
 
 .dna-label {
   text-align: center;
-  font-size: 0.6875rem;
+  font-size: var(--text-xs);
   color: var(--p-text-muted-color);
   text-transform: uppercase;
   letter-spacing: 0.14em;
@@ -74,7 +74,7 @@
     position: absolute;
     inset: 0;
     border-radius: 50%;
-    background: var(--p-surface-50);
+    background: var(--p-surface-100);
     border: 1.5px solid var(--p-surface-200);
     transition: all 0.3s;
   }
@@ -93,6 +93,7 @@
 
     &::before {
       border-color: var(--p-surface-300);
+      background: var(--p-surface-200);
     }
 
     &::after {
@@ -169,20 +170,22 @@
 
 .dna-prompt {
   display: inline-block;
-  max-width: 500px;
+  max-width: 31.25rem;
   padding: 0.5rem 1rem;
-  background: var(--p-surface-50);
+  background: var(--p-surface-100);
   border: 1px solid var(--p-surface-200);
   border-radius: 100px;
   font: inherit;
-  font-size: 0.8125rem;
-  color: var(--p-text-color);
+  font-size: var(--text-sm);
+  color: var(--p-text-muted-color);
   line-height: 1.5;
   cursor: pointer;
   transition: all 0.2s;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
 
   &:hover {
     border-color: var(--p-surface-300);
+    color: var(--p-text-color);
   }
 }
 

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
@@ -16,12 +16,12 @@
   text-transform: uppercase;
   letter-spacing: 0.14em;
   font-weight: 500;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.25rem;
 }
 
 .dna-wrap {
   position: relative;
-  height: 140px;
+  height: 130px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -43,7 +43,7 @@
   fill: none;
   stroke-width: 1.5;
   stroke-linecap: round;
-  opacity: 0.2;
+  opacity: 0.25;
 }
 
 .strand-front path {
@@ -68,6 +68,7 @@
   border: none;
   padding: 0;
   background: none;
+  will-change: transform;
 
   &::before {
     content: '';
@@ -92,8 +93,8 @@
     transform: scale(1.15);
 
     &::before {
-      border-color: var(--p-surface-300);
-      background: var(--p-surface-200);
+      border-color: rgb(52 212 180 / 40%);
+      background: rgb(52 212 180 / 8%);
     }
 
     &::after {
@@ -121,7 +122,7 @@
   z-index: 1;
   width: 16px;
   height: 16px;
-  color: var(--p-text-muted-color);
+  color: var(--p-surface-500);
   transition: color 0.3s;
 
   .helix-node:hover & {
@@ -135,10 +136,10 @@
 
 .node-label {
   position: absolute;
-  bottom: -20px;
+  bottom: -22px;
   left: 50%;
   transform: translateX(-50%);
-  font-size: 0.5625rem;
+  font-size: var(--text-xs);
   color: var(--p-text-muted-color);
   font-weight: 500;
   white-space: nowrap;
@@ -155,17 +156,18 @@
   }
 }
 
-.helix-rung {
-  position: absolute;
-  height: 1px;
-  background: var(--p-surface-200);
-  transform-origin: left center;
-  z-index: 1;
-}
-
 .dna-reveal {
   text-align: center;
   margin-top: 1rem;
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+
+  &.show {
+    max-height: 80px;
+    opacity: 1;
+  }
 }
 
 .dna-prompt {
@@ -185,7 +187,6 @@
 
   &:hover {
     border-color: var(--p-surface-300);
-    color: var(--p-text-color);
   }
 }
 

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.spec.ts
@@ -1,0 +1,40 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ExamplePromptsComponent } from './example-prompts.component';
+
+describe('ExamplePromptsComponent', () => {
+  let component: ExamplePromptsComponent;
+  let fixture: ComponentFixture<ExamplePromptsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ExamplePromptsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ExamplePromptsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have 5 helix nodes', () => {
+    expect(component.nodes).toHaveLength(5);
+  });
+
+  it('should select a prompt on node click', () => {
+    component.onNodeClick(component.nodes[0]);
+    expect(component.selectedPrompt()).toBeTruthy();
+    expect(component.selectedCategory()).toBe('Cardiology');
+  });
+
+  it('should emit prompt on usePrompt', () => {
+    const spy = jest.fn();
+    component.promptSelect.subscribe(spy);
+    component.onNodeClick(component.nodes[0]);
+    component.usePrompt();
+    expect(spy).toHaveBeenCalled();
+    expect(component.selectedPrompt()).toBeNull();
+  });
+});

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
@@ -1,0 +1,119 @@
+import { Component, output, signal } from '@angular/core';
+
+interface HelixNode {
+  label: string;
+  icon: string;
+  top: number;
+  left: number;
+}
+
+interface CategoryPrompt {
+  category: string;
+  prompts: string[];
+}
+
+const HELIX_NODES: HelixNode[] = [
+  {
+    label: 'Cardiology',
+    icon: 'M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z',
+    top: 32,
+    left: 55,
+  },
+  {
+    label: 'Oncology',
+    icon: 'M12 12m-10 0a10 10 0 1 0 20 0a10 10 0 1 0-20 0M16 12l-4-4-4 4M12 16V8',
+    top: 58,
+    left: 130,
+  },
+  {
+    label: 'Genetics',
+    icon: 'M2 15c6.667-6 13.333 0 20-6M9 22c1.798-1.998 2.518-3.995 2.807-5.993M15 2c-1.798 1.998-2.518 3.995-2.807 5.993',
+    top: 28,
+    left: 205,
+  },
+  {
+    label: 'Neuro',
+    icon: 'M12 2a8 8 0 0 0-8 8c0 6 8 12 8 12s8-6 8-12a8 8 0 0 0-8-8ZM12 10m-3 0a3 3 0 1 0 6 0a3 3 0 1 0-6 0',
+    top: 58,
+    left: 280,
+  },
+  {
+    label: 'Immuno',
+    icon: 'm10 20-1.25-2.5L6 18l1-3-2.5-1.5L6 12 4.5 10.5 7 9l-1-3 2.75.5L10 4l2 2 2-2 1.25 2.5L18 6l-1 3 2.5 1.5L18 12l1.5 1.5L17 15l1 3-2.75-.5L14 20l-2-2Z',
+    top: 32,
+    left: 355,
+  },
+];
+
+// Mock data — will be replaced by API with category support
+const MOCK_PROMPTS: CategoryPrompt[] = [
+  {
+    category: 'Cardiology',
+    prompts: [
+      'What are the latest guidelines for managing atrial fibrillation?',
+      'How does SGLT2 inhibitor therapy benefit heart failure patients?',
+      'What is the role of cardiac MRI in diagnosing myocarditis?',
+    ],
+  },
+  {
+    category: 'Oncology',
+    prompts: [
+      'What are the current immunotherapy options for non-small cell lung cancer?',
+      'How do checkpoint inhibitors work in cancer treatment?',
+      'What is the role of liquid biopsy in cancer diagnosis?',
+    ],
+  },
+  {
+    category: 'Genetics',
+    prompts: [
+      'How does CRISPR-Cas9 gene editing work and what are its clinical applications?',
+      'What are the ethical considerations of germline gene therapy?',
+      'How do polygenic risk scores help predict disease susceptibility?',
+    ],
+  },
+  {
+    category: 'Neuro',
+    prompts: [
+      "What are the emerging biomarkers for early detection of Alzheimer's disease?",
+      "How does deep brain stimulation work for Parkinson's disease?",
+      'What is the current understanding of long COVID neurological effects?',
+    ],
+  },
+  {
+    category: 'Immuno',
+    prompts: [
+      'How do mRNA vaccines trigger an immune response?',
+      'What is the role of T-cell exhaustion in chronic infections?',
+      'How do autoimmune diseases develop and what are common treatment approaches?',
+    ],
+  },
+];
+
+@Component({
+  selector: 'bixarena-example-prompts',
+  templateUrl: './example-prompts.component.html',
+  styleUrl: './example-prompts.component.scss',
+})
+export class ExamplePromptsComponent {
+  readonly promptSelect = output<string>();
+  readonly nodes = HELIX_NODES;
+  readonly selectedPrompt = signal<string | null>(null);
+  readonly selectedCategory = signal<string | null>(null);
+
+  onNodeClick(node: HelixNode): void {
+    const category = MOCK_PROMPTS.find((c) => c.category === node.label);
+    if (!category) return;
+    const randomPrompt = category.prompts[Math.floor(Math.random() * category.prompts.length)];
+    this.selectedPrompt.set(randomPrompt);
+    this.selectedCategory.set(node.label);
+  }
+
+  usePrompt(): void {
+    const prompt = this.selectedPrompt();
+    if (prompt) {
+      this.promptSelect.emit(prompt);
+      this.selectedPrompt.set(null);
+      this.selectedCategory.set(null);
+    }
+  }
+}

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
@@ -1,4 +1,4 @@
-import { Component, output, signal } from '@angular/core';
+import { Component, OnDestroy, output, signal } from '@angular/core';
 
 interface HelixNode {
   label: string;
@@ -94,11 +94,27 @@ const MOCK_PROMPTS: CategoryPrompt[] = [
   templateUrl: './example-prompts.component.html',
   styleUrl: './example-prompts.component.scss',
 })
-export class ExamplePromptsComponent {
+export class ExamplePromptsComponent implements OnDestroy {
   readonly promptSelect = output<string>();
   readonly nodes = HELIX_NODES;
   readonly selectedPrompt = signal<string | null>(null);
   readonly selectedCategory = signal<string | null>(null);
+
+  private readonly onDocClick = (e: MouseEvent) => {
+    const target = e.target as HTMLElement;
+    if (!target.closest('.helix-node') && !target.closest('.dna-prompt')) {
+      this.selectedPrompt.set(null);
+      this.selectedCategory.set(null);
+    }
+  };
+
+  constructor() {
+    document.addEventListener('click', this.onDocClick);
+  }
+
+  ngOnDestroy(): void {
+    document.removeEventListener('click', this.onDocClick);
+  }
 
   onNodeClick(node: HelixNode): void {
     const category = MOCK_PROMPTS.find((c) => c.category === node.label);

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnDestroy, output, signal } from '@angular/core';
+import { Component, inject, OnDestroy, output, PLATFORM_ID, signal } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 
 interface HelixNode {
   label: string;
@@ -108,12 +109,18 @@ export class ExamplePromptsComponent implements OnDestroy {
     }
   };
 
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+
   constructor() {
-    document.addEventListener('click', this.onDocClick);
+    if (this.isBrowser) {
+      document.addEventListener('click', this.onDocClick);
+    }
   }
 
   ngOnDestroy(): void {
-    document.removeEventListener('click', this.onDocClick);
+    if (this.isBrowser) {
+      document.removeEventListener('click', this.onDocClick);
+    }
   }
 
   onNodeClick(node: HelixNode): void {

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
@@ -1,0 +1,27 @@
+<div class="panel" [class.winner]="isWinner()">
+  <div class="header">
+    <span class="dot" [class]="statusClass()"></span>
+    <span class="label">{{ revealedName() ?? label() }}</span>
+    @if (statusLabel()) {
+      <span class="status">{{ statusLabel() }}</span>
+    }
+  </div>
+  <div class="body" #body aria-live="polite" (scroll)="onScroll($event)">
+    @if (streamState().status === 'waiting') {
+      <div class="skeleton">
+        <div class="skeleton-line"></div>
+        <div class="skeleton-line short"></div>
+        <div class="skeleton-line"></div>
+      </div>
+    } @else if (streamState().status === 'error') {
+      <div class="error-message">{{ streamState().errorMessage }}</div>
+    } @else {
+      <div class="content">{{ displayText() }}</div>
+    }
+  </div>
+  @if (revealedName()) {
+    <div class="footer">
+      <span class="model-name">{{ revealedName() }}</span>
+    </div>
+  }
+</div>

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
@@ -15,7 +15,9 @@
       @if (msg.role === 'user') {
         <div class="user-msg">{{ msg.content }}</div>
       } @else {
-        <div class="content">{{ msg.content }}</div>
+        <div class="content">
+          <markdown [data]="msg.content" />
+        </div>
       }
     }
     <div
@@ -45,7 +47,9 @@
     @if (streamState().status === 'error') {
       <div class="error-message">{{ streamState().errorMessage }}</div>
     } @else if (streamState().text) {
-      <div class="content">{{ displayText() }}</div>
+      <div class="content">
+        <markdown [data]="displayText()" />
+      </div>
     }
   </div>
   @if (revealedName()) {

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
@@ -6,11 +6,21 @@
 >
   <div class="header">
     <span class="header-label">
-      <span class="dot" [class]="streamState().status"></span>
+      <span
+        class="dot"
+        [class.streaming]="streamState().status === 'streaming'"
+        [class.complete]="streamState().status === 'complete'"
+        [class.error]="streamState().status === 'error'"
+      ></span>
       {{ modelName() ?? anonymousName() }}
     </span>
   </div>
-  <div class="body" #body aria-live="polite" (scroll)="onScroll($event)">
+  <div
+    class="body"
+    #body
+    [attr.aria-live]="streamState().status === 'streaming' ? 'off' : 'polite'"
+    (scroll)="onScroll($event)"
+  >
     @for (msg of streamState().messages; track $index) {
       @if (msg.role === 'user') {
         <div class="user-msg">{{ msg.content }}</div>

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
@@ -45,7 +45,24 @@
       <span class="thk-lbl">Generating response...</span>
     </div>
     @if (streamState().status === 'error') {
-      <div class="error-message">{{ streamState().errorMessage }}</div>
+      <div class="error-line">
+        @if (streamState().retryable) {
+          <button class="retry-btn" (click)="retry.emit()" title="Retry" aria-label="Retry">
+            <svg
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M13.5 8A5.5 5.5 0 1 1 10 3.07" />
+              <polyline points="13.5 2 13.5 5.5 10 5.5" />
+            </svg>
+          </button>
+        }
+        <span class="error-line-text">{{ streamState().errorMessage }}</span>
+      </div>
     } @else if (streamState().text) {
       <div class="content">
         <markdown [data]="displayText()" />

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
@@ -5,9 +5,9 @@
   [class.hovered]="isHovered()"
 >
   <div class="header">
-    <span class="mt">
-      <span class="dot" [class]="statusClass()"></span>
-      {{ revealedName() ?? label() }}
+    <span class="header-label">
+      <span class="dot" [class]="streamState().status"></span>
+      {{ modelName() ?? anonymousName() }}
     </span>
   </div>
   <div class="body" #body aria-live="polite" (scroll)="onScroll($event)">
@@ -52,7 +52,7 @@
       </div>
     }
   </div>
-  @if (revealedName()) {
-    <div class="footer">{{ revealedName() }}</div>
+  @if (modelName()) {
+    <div class="footer">{{ modelName() }}</div>
   }
 </div>

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
@@ -11,6 +11,13 @@
     </span>
   </div>
   <div class="body" #body aria-live="polite" (scroll)="onScroll($event)">
+    @for (msg of streamState().messages; track $index) {
+      @if (msg.role === 'user') {
+        <div class="user-msg">{{ msg.content }}</div>
+      } @else {
+        <div class="content">{{ msg.content }}</div>
+      }
+    }
     <div
       class="thk"
       [class.done]="

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
@@ -1,4 +1,9 @@
-<div class="panel" [class.winner]="isWinner()">
+<div
+  class="panel"
+  [class.selected]="isSelected()"
+  [class.unselected]="isUnselected()"
+  [class.hovered]="isHovered()"
+>
   <div class="header">
     <span class="mt">
       <span class="dot" [class]="statusClass()"></span>

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
@@ -6,15 +6,33 @@
     </span>
   </div>
   <div class="body" #body aria-live="polite" (scroll)="onScroll($event)">
-    @if (streamState().status === 'waiting') {
-      <div class="skeleton">
-        <div class="skeleton-line"></div>
-        <div class="skeleton-line short"></div>
-        <div class="skeleton-line"></div>
-      </div>
-    } @else if (streamState().status === 'error') {
+    <div
+      class="thk"
+      [class.done]="
+        streamState().text ||
+        streamState().status === 'complete' ||
+        streamState().status === 'error'
+      "
+    >
+      <svg
+        class="thk-ico"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path
+          d="M12 3v2m0 14v2m9-9h-2M5 12H3m14.5-6.5L16 7M8 16l-1.5 1.5M18 18l-1.5-1.5M7 7 5.5 5.5"
+        />
+        <circle cx="12" cy="12" r="3" />
+      </svg>
+      <span class="thk-lbl">Generating response...</span>
+    </div>
+    @if (streamState().status === 'error') {
       <div class="error-message">{{ streamState().errorMessage }}</div>
-    } @else {
+    } @else if (streamState().text) {
       <div class="content">{{ displayText() }}</div>
     }
   </div>

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
@@ -1,10 +1,9 @@
 <div class="panel" [class.winner]="isWinner()">
   <div class="header">
-    <span class="dot" [class]="statusClass()"></span>
-    <span class="label">{{ revealedName() ?? label() }}</span>
-    @if (statusLabel()) {
-      <span class="status">{{ statusLabel() }}</span>
-    }
+    <span class="mt">
+      <span class="dot" [class]="statusClass()"></span>
+      {{ revealedName() ?? label() }}
+    </span>
   </div>
   <div class="body" #body aria-live="polite" (scroll)="onScroll($event)">
     @if (streamState().status === 'waiting') {
@@ -20,8 +19,6 @@
     }
   </div>
   @if (revealedName()) {
-    <div class="footer">
-      <span class="model-name">{{ revealedName() }}</span>
-    </div>
+    <div class="footer">{{ revealedName() }}</div>
   }
 </div>

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
@@ -102,6 +102,7 @@
   gap: 0.5rem;
   margin-bottom: 0.875rem;
   transition: all 0.4s;
+  clear: both;
 
   &.done {
     max-height: 0;
@@ -138,9 +139,28 @@
   }
 }
 
+.user-msg {
+  background: var(--p-surface-200);
+  border: 1px solid var(--p-surface-300);
+  border-radius: 18px 18px 4px;
+  padding: 0.5rem 1rem;
+  margin-bottom: 1rem;
+  max-width: 78%;
+  float: right;
+  clear: both;
+  font-size: var(--text-sm);
+  color: var(--p-text-color);
+}
+
 .content {
+  clear: both;
   white-space: pre-wrap;
   word-break: break-word;
+  margin-bottom: 1rem;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .error-message {

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
@@ -2,7 +2,6 @@
   display: block;
   min-width: 0;
   min-height: 0;
-  overflow: hidden;
 }
 
 .panel {
@@ -16,16 +15,18 @@
   max-height: 100%;
   transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 
-  &:hover {
-    border-color: var(--p-surface-300);
+  &.selected {
+    border-color: var(--p-primary-color);
   }
 
-  &.winner {
-    border-color: rgb(249 115 22 / 25%);
+  &.unselected {
+    opacity: 0.6;
   }
 
-  &.tie {
-    border-color: rgb(253 252 251 / 12%);
+  &.hovered {
+    border-color: var(--p-surface-400);
+    box-shadow: 0 4px 16px rgb(0 0 0 / 25%);
+    transform: translateY(-2px);
   }
 }
 

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
@@ -190,12 +190,41 @@
   }
 }
 
-.error-message {
-  color: #ef4444;
-  font-size: var(--text-md);
+.error-line {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.25rem;
+  clear: both;
+}
 
-  &::before {
-    content: '\26A0 ';
+.error-line-text {
+  font-size: var(--text-sm);
+  color: var(--p-surface-500);
+}
+
+.retry-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--p-surface-400);
+  cursor: pointer;
+  border-radius: 50%;
+  transition: color 0.15s;
+  flex-shrink: 0;
+
+  svg {
+    width: 13px;
+    height: 13px;
+  }
+
+  &:hover {
+    color: var(--p-surface-600);
   }
 }
 

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
@@ -91,6 +91,48 @@
   }
 }
 
+.thk {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.875rem;
+  transition: all 0.4s;
+
+  &.done {
+    max-height: 0;
+    opacity: 0;
+    margin: 0;
+    overflow: hidden;
+  }
+}
+
+.thk-ico {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  color: var(--p-surface-500);
+  animation: tp 1.5s ease-in-out infinite;
+}
+
+.thk-lbl {
+  font-size: var(--text-sm);
+  font-weight: 480;
+  color: var(--p-surface-500);
+}
+
+@keyframes tp {
+  0%,
+  100% {
+    opacity: 0.4;
+    transform: rotate(0deg);
+  }
+
+  50% {
+    opacity: 1;
+    transform: rotate(180deg);
+  }
+}
+
 .content {
   white-space: pre-wrap;
   word-break: break-word;

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
@@ -1,6 +1,8 @@
 :host {
   display: block;
   min-width: 0;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .panel {
@@ -11,6 +13,7 @@
   overflow: hidden;
   background: var(--p-surface-100);
   height: 100%;
+  max-height: 100%;
   transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 
   &:hover {
@@ -70,6 +73,7 @@
 
 .body {
   flex: 1;
+  min-height: 0;
   padding: 1rem 1.125rem;
   overflow-y: auto;
   font-size: var(--text-md);

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
@@ -39,7 +39,7 @@
   flex-shrink: 0;
 }
 
-.mt {
+.header-label {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
@@ -56,13 +56,13 @@
   background: var(--p-surface-400);
   transition: all 0.25s;
 
-  &.live {
+  &.streaming {
     background: var(--p-teal-400);
     box-shadow: 0 0 8px rgb(52 212 180 / 30%);
     animation: bd 1.2s ease-in-out infinite;
   }
 
-  &.done {
+  &.complete {
     background: var(--p-teal-400);
     box-shadow: 0 0 6px rgb(52 212 180 / 20%);
   }

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
@@ -154,12 +154,39 @@
 
 .content {
   clear: both;
-  white-space: pre-wrap;
   word-break: break-word;
   margin-bottom: 1rem;
 
   &:last-child {
     margin-bottom: 0;
+  }
+
+  /* stylelint-disable-next-line selector-pseudo-element-no-unknown, selector-type-no-unknown */
+  ::ng-deep markdown {
+    display: block;
+
+    p:last-child {
+      margin-bottom: 0;
+    }
+
+    code {
+      background: var(--p-surface-200);
+      padding: 0.125rem 0.375rem;
+      border-radius: 4px;
+      font-size: 0.9em;
+    }
+
+    pre {
+      background: var(--p-surface-200);
+      border-radius: 8px;
+      padding: 0.75rem 1rem;
+      overflow-x: auto;
+
+      code {
+        background: none;
+        padding: 0;
+      }
+    }
   }
 }
 

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
@@ -4,45 +4,63 @@
 }
 
 .panel {
-  background: var(--p-surface-50);
   border: 1px solid var(--p-surface-200);
-  border-radius: var(--p-rounded-xl);
+  border-radius: 16px;
   display: flex;
   flex-direction: column;
-  height: 100%;
   overflow: hidden;
-  transition: border-color 0.4s;
+  background: var(--p-surface-100);
+  height: 100%;
+  transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+
+  &:hover {
+    border-color: var(--p-surface-300);
+  }
 
   &.winner {
-    border-color: var(--p-primary-color);
-    box-shadow: 0 0 12px rgb(249 115 22 / 15%);
+    border-color: rgb(249 115 22 / 25%);
+  }
+
+  &.tie {
+    border-color: rgb(253 252 251 / 12%);
   }
 }
 
 .header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
+  justify-content: space-between;
+  padding: 0.625rem 1rem;
   border-bottom: 1px solid var(--p-surface-200);
-  font-size: 0.8125rem;
-  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.mt {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: var(--text-xs);
+  font-weight: 560;
+  color: var(--p-surface-500);
+  letter-spacing: -0.01em;
 }
 
 .dot {
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
-  background: var(--p-surface-300);
-  flex-shrink: 0;
+  background: var(--p-surface-400);
+  transition: all 0.25s;
 
   &.live {
-    background: #22c55e;
-    animation: pulse 1.5s ease-in-out infinite;
+    background: var(--p-teal-400);
+    box-shadow: 0 0 8px rgb(52 212 180 / 30%);
+    animation: bd 1.2s ease-in-out infinite;
   }
 
   &.done {
-    background: #22c55e;
+    background: var(--p-teal-400);
+    box-shadow: 0 0 6px rgb(52 212 180 / 20%);
   }
 
   &.error {
@@ -50,42 +68,40 @@
   }
 }
 
-.label {
-  color: var(--p-text-color);
-}
-
-.status {
-  margin-left: auto;
-  font-weight: 400;
-  color: var(--p-text-muted-color);
-  font-size: 0.75rem;
-}
-
 .body {
   flex: 1;
-  padding: 1rem;
+  padding: 1rem 1.125rem;
   overflow-y: auto;
-  min-height: 200px;
-  max-height: 400px;
+  font-size: var(--text-md);
+  line-height: 1.7;
+  scroll-behavior: smooth;
+  color: var(--p-surface-700);
+
+  &::-webkit-scrollbar {
+    width: 3px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--p-surface-200);
+    border-radius: 2px;
+  }
 }
 
 .content {
   white-space: pre-wrap;
   word-break: break-word;
-  line-height: 1.6;
-  font-size: 0.9375rem;
-  color: var(--p-text-color);
 }
 
 .error-message {
   color: #ef4444;
-  font-size: 0.875rem;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+  font-size: var(--text-md);
 
   &::before {
-    content: '\26A0';
+    content: '\26A0 ';
   }
 }
 
@@ -109,22 +125,20 @@
 .footer {
   padding: 0.5rem 1rem;
   border-top: 1px solid var(--p-surface-200);
-  font-size: 0.75rem;
-  color: var(--p-text-muted-color);
+  font-size: var(--text-sm);
+  font-weight: 620;
+  letter-spacing: -0.01em;
+  text-align: center;
 }
 
-.model-name {
-  font-weight: 600;
-}
-
-@keyframes pulse {
+@keyframes bd {
   0%,
   100% {
     opacity: 1;
   }
 
   50% {
-    opacity: 0.4;
+    opacity: 0.3;
   }
 }
 

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
@@ -1,0 +1,140 @@
+:host {
+  display: block;
+  min-width: 0;
+}
+
+.panel {
+  background: var(--p-surface-50);
+  border: 1px solid var(--p-surface-200);
+  border-radius: var(--p-rounded-xl);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  transition: border-color 0.4s;
+
+  &.winner {
+    border-color: var(--p-primary-color);
+    box-shadow: 0 0 12px rgb(249 115 22 / 15%);
+  }
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--p-surface-200);
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--p-surface-300);
+  flex-shrink: 0;
+
+  &.live {
+    background: #22c55e;
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+
+  &.done {
+    background: #22c55e;
+  }
+
+  &.error {
+    background: #ef4444;
+  }
+}
+
+.label {
+  color: var(--p-text-color);
+}
+
+.status {
+  margin-left: auto;
+  font-weight: 400;
+  color: var(--p-text-muted-color);
+  font-size: 0.75rem;
+}
+
+.body {
+  flex: 1;
+  padding: 1rem;
+  overflow-y: auto;
+  min-height: 200px;
+  max-height: 400px;
+}
+
+.content {
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.6;
+  font-size: 0.9375rem;
+  color: var(--p-text-color);
+}
+
+.error-message {
+  color: #ef4444;
+  font-size: 0.875rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  &::before {
+    content: '\26A0';
+  }
+}
+
+.skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.skeleton-line {
+  height: 14px;
+  border-radius: 4px;
+  background: var(--p-surface-200);
+  animation: shimmer 1.5s ease-in-out infinite;
+
+  &.short {
+    width: 60%;
+  }
+}
+
+.footer {
+  padding: 0.5rem 1rem;
+  border-top: 1px solid var(--p-surface-200);
+  font-size: 0.75rem;
+  color: var(--p-text-muted-color);
+}
+
+.model-name {
+  font-weight: 600;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.4;
+  }
+}
+
+@keyframes shimmer {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+
+  50% {
+    opacity: 0.8;
+  }
+}

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
@@ -68,7 +68,7 @@
   }
 
   &.error {
-    background: #ef4444;
+    background: var(--p-red-400);
   }
 }
 
@@ -228,23 +228,6 @@
   }
 }
 
-.skeleton {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.skeleton-line {
-  height: 14px;
-  border-radius: 4px;
-  background: var(--p-surface-200);
-  animation: shimmer 1.5s ease-in-out infinite;
-
-  &.short {
-    width: 60%;
-  }
-}
-
 .footer {
   padding: 0.5rem 1rem;
   border-top: 1px solid var(--p-surface-200);
@@ -262,16 +245,5 @@
 
   50% {
     opacity: 0.3;
-  }
-}
-
-@keyframes shimmer {
-  0%,
-  100% {
-    opacity: 0.4;
-  }
-
-  50% {
-    opacity: 0.8;
   }
 }

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.spec.ts
@@ -13,7 +13,6 @@ describe('ModelPanelComponent', () => {
 
     fixture = TestBed.createComponent(ModelPanelComponent);
     component = fixture.componentInstance;
-    fixture.componentRef.setInput('anonymousName', 'Model A');
     fixture.componentRef.setInput('modelId', 'model1');
     fixture.componentRef.setInput('streamState', INITIAL_STREAM_STATE);
     fixture.detectChanges();

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.spec.ts
@@ -14,6 +14,7 @@ describe('ModelPanelComponent', () => {
     fixture = TestBed.createComponent(ModelPanelComponent);
     component = fixture.componentInstance;
     fixture.componentRef.setInput('label', 'Model A');
+    fixture.componentRef.setInput('modelId', 'model1');
     fixture.componentRef.setInput('streamState', INITIAL_STREAM_STATE);
     fixture.detectChanges();
   });

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.spec.ts
@@ -1,0 +1,54 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ModelPanelComponent } from './model-panel.component';
+import { INITIAL_STREAM_STATE } from '../battle.types';
+
+describe('ModelPanelComponent', () => {
+  let component: ModelPanelComponent;
+  let fixture: ComponentFixture<ModelPanelComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ModelPanelComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ModelPanelComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('label', 'Model A');
+    fixture.componentRef.setInput('streamState', INITIAL_STREAM_STATE);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should show cursor during streaming', () => {
+    fixture.componentRef.setInput('streamState', {
+      ...INITIAL_STREAM_STATE,
+      text: 'Hello',
+      status: 'streaming',
+    });
+    expect(component.displayText()).toBe('Hello\u258C');
+  });
+
+  it('should not show cursor when complete', () => {
+    fixture.componentRef.setInput('streamState', {
+      ...INITIAL_STREAM_STATE,
+      text: 'Hello world',
+      status: 'complete',
+    });
+    expect(component.displayText()).toBe('Hello world');
+  });
+
+  it('should show label when no revealed name', () => {
+    expect(component.revealedName()).toBeNull();
+  });
+
+  it('should return correct status class', () => {
+    fixture.componentRef.setInput('streamState', {
+      ...INITIAL_STREAM_STATE,
+      status: 'streaming',
+    });
+    expect(component.statusClass()).toBe('live');
+  });
+});

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.spec.ts
@@ -13,7 +13,7 @@ describe('ModelPanelComponent', () => {
 
     fixture = TestBed.createComponent(ModelPanelComponent);
     component = fixture.componentInstance;
-    fixture.componentRef.setInput('label', 'Model A');
+    fixture.componentRef.setInput('anonymousName', 'Model A');
     fixture.componentRef.setInput('modelId', 'model1');
     fixture.componentRef.setInput('streamState', INITIAL_STREAM_STATE);
     fixture.detectChanges();
@@ -41,15 +41,15 @@ describe('ModelPanelComponent', () => {
     expect(component.displayText()).toBe('Hello world');
   });
 
-  it('should show label when no revealed name', () => {
-    expect(component.revealedName()).toBeNull();
+  it('should have no model name by default', () => {
+    expect(component.modelName()).toBeNull();
   });
 
-  it('should return correct status class', () => {
+  it('should return streaming status from stream state', () => {
     fixture.componentRef.setInput('streamState', {
       ...INITIAL_STREAM_STATE,
       status: 'streaming',
     });
-    expect(component.statusClass()).toBe('live');
+    expect(component.streamState().status).toBe('streaming');
   });
 });

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
@@ -5,6 +5,7 @@ import {
   ElementRef,
   inject,
   input,
+  output,
   PLATFORM_ID,
   viewChild,
 } from '@angular/core';
@@ -29,6 +30,7 @@ export class ModelPanelComponent {
   readonly modelName = input<string | null>(null);
   readonly selectedOutcome = input<BattleEvaluationOutcome | null>(null);
   readonly hoveredModel = input<BattleEvaluationOutcome | null>(null);
+  readonly retry = output<void>();
 
   readonly isSelected = computed(() => {
     const o = this.selectedOutcome();

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
@@ -23,12 +23,12 @@ import { STREAM_CURSOR } from '../battle.constants';
 export class ModelPanelComponent {
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
-  readonly label = input.required<string>();
+  readonly anonymousName = input.required<string>();
   readonly modelId = input.required<'model1' | 'model2'>();
   readonly streamState = input.required<ModelStreamState>();
-  readonly revealedName = input<string | null>(null);
+  readonly modelName = input<string | null>(null);
   readonly selectedOutcome = input<BattleEvaluationOutcome | null>(null);
-  readonly hoveredModel = input<'model1' | 'model2' | 'tie' | null>(null);
+  readonly hoveredModel = input<BattleEvaluationOutcome | null>(null);
 
   readonly isSelected = computed(() => {
     const o = this.selectedOutcome();
@@ -48,8 +48,8 @@ export class ModelPanelComponent {
   });
 
   readonly bodyEl = viewChild<ElementRef<HTMLDivElement>>('body');
-  private userScrolled = false;
-  private programmaticScroll = false;
+  private isUserScrolled = false;
+  private isAutoScroll = false;
 
   readonly displayText = computed(() => {
     const state = this.streamState();
@@ -59,30 +59,12 @@ export class ModelPanelComponent {
     return state.text;
   });
 
-  readonly statusClass = computed(() => {
-    const status = this.streamState().status;
-    if (status === 'streaming') return 'live';
-    if (status === 'complete') return 'done';
-    if (status === 'error') return 'error';
-    return '';
-  });
-
-  readonly statusLabel = computed(() => {
-    const state = this.streamState();
-    if (state.status === 'waiting') return 'Connecting...';
-    if (state.status === 'streaming' && state.isSlowHint) return 'Taking longer than expected...';
-    if (state.status === 'streaming') return 'Generating...';
-    if (state.status === 'complete') return 'Complete';
-    if (state.status === 'error') return 'Error';
-    return '';
-  });
-
   constructor() {
     if (this.isBrowser) {
       // Auto-scroll to bottom on every stream state change, unless user has scrolled up
       effect(() => {
         this.streamState(); // Read to register signal dependency
-        if (!this.userScrolled) {
+        if (!this.isUserScrolled) {
           requestAnimationFrame(() => this.scrollToBottom());
         }
       });
@@ -91,19 +73,19 @@ export class ModelPanelComponent {
 
   // Detect manual scroll: if user scrolls away from bottom, stop auto-scrolling
   onScroll(event: Event): void {
-    if (this.programmaticScroll) return;
+    if (this.isAutoScroll) return;
     const el = event.target as HTMLDivElement;
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
-    this.userScrolled = !atBottom;
+    this.isUserScrolled = !atBottom;
   }
 
   private scrollToBottom(): void {
     const el = this.bodyEl()?.nativeElement;
     if (el) {
       // Flag prevents onScroll from treating our scrollTo as a user-initiated scroll
-      this.programmaticScroll = true;
+      this.isAutoScroll = true;
       el.scrollTop = el.scrollHeight;
-      requestAnimationFrame(() => (this.programmaticScroll = false));
+      requestAnimationFrame(() => (this.isAutoScroll = false));
     }
   }
 }

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
@@ -1,0 +1,66 @@
+import { Component, computed, effect, ElementRef, input, signal, viewChild } from '@angular/core';
+import { ModelStreamState } from '../battle.types';
+import { STREAM_CURSOR } from '../battle.constants';
+
+@Component({
+  selector: 'bixarena-model-panel',
+  templateUrl: './model-panel.component.html',
+  styleUrl: './model-panel.component.scss',
+})
+export class ModelPanelComponent {
+  readonly label = input.required<string>();
+  readonly streamState = input.required<ModelStreamState>();
+  readonly revealedName = input<string | null>(null);
+  readonly isWinner = input(false);
+
+  readonly bodyEl = viewChild<ElementRef<HTMLDivElement>>('body');
+  private userScrolled = false;
+
+  readonly displayText = computed(() => {
+    const state = this.streamState();
+    if (state.status === 'streaming') {
+      return state.text + STREAM_CURSOR;
+    }
+    return state.text;
+  });
+
+  readonly statusClass = computed(() => {
+    const status = this.streamState().status;
+    if (status === 'streaming') return 'live';
+    if (status === 'complete') return 'done';
+    if (status === 'error') return 'error';
+    return '';
+  });
+
+  readonly statusLabel = computed(() => {
+    const state = this.streamState();
+    if (state.status === 'waiting') return 'Connecting...';
+    if (state.status === 'streaming' && state.isSlowHint) return 'Taking longer than expected...';
+    if (state.status === 'streaming') return 'Generating...';
+    if (state.status === 'complete') return 'Complete';
+    if (state.status === 'error') return 'Error';
+    return '';
+  });
+
+  constructor() {
+    effect(() => {
+      this.displayText();
+      if (!this.userScrolled) {
+        requestAnimationFrame(() => this.scrollToBottom());
+      }
+    });
+  }
+
+  onScroll(event: Event): void {
+    const el = event.target as HTMLDivElement;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+    this.userScrolled = !atBottom;
+  }
+
+  private scrollToBottom(): void {
+    const el = this.bodyEl()?.nativeElement;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }
+}

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
@@ -1,5 +1,16 @@
-import { Component, computed, effect, ElementRef, input, viewChild } from '@angular/core';
+import {
+  Component,
+  computed,
+  effect,
+  ElementRef,
+  inject,
+  input,
+  PLATFORM_ID,
+  viewChild,
+} from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { MarkdownComponent } from 'ngx-markdown';
+import { BattleEvaluationOutcome } from '@sagebionetworks/bixarena/api-client';
 import { ModelStreamState } from '../battle.types';
 import { STREAM_CURSOR } from '../battle.constants';
 
@@ -10,12 +21,14 @@ import { STREAM_CURSOR } from '../battle.constants';
   styleUrl: './model-panel.component.scss',
 })
 export class ModelPanelComponent {
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+
   readonly label = input.required<string>();
   readonly modelId = input.required<'model1' | 'model2'>();
   readonly streamState = input.required<ModelStreamState>();
   readonly revealedName = input<string | null>(null);
-  readonly selectedOutcome = input<string | null>(null);
-  readonly hoveredModel = input<string | null>(null);
+  readonly selectedOutcome = input<BattleEvaluationOutcome | null>(null);
+  readonly hoveredModel = input<'model1' | 'model2' | 'tie' | null>(null);
 
   readonly isSelected = computed(() => {
     const o = this.selectedOutcome();
@@ -65,12 +78,14 @@ export class ModelPanelComponent {
   });
 
   constructor() {
-    effect(() => {
-      this.streamState();
-      if (!this.userScrolled) {
-        requestAnimationFrame(() => this.scrollToBottom());
-      }
-    });
+    if (this.isBrowser) {
+      effect(() => {
+        this.streamState(); // Register dependency to trigger on every chunk
+        if (!this.userScrolled) {
+          requestAnimationFrame(() => this.scrollToBottom());
+        }
+      });
+    }
   }
 
   onScroll(event: Event): void {

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
@@ -79,8 +79,9 @@ export class ModelPanelComponent {
 
   constructor() {
     if (this.isBrowser) {
+      // Auto-scroll to bottom on every stream state change, unless user has scrolled up
       effect(() => {
-        this.streamState(); // Register dependency to trigger on every chunk
+        this.streamState(); // Read to register signal dependency
         if (!this.userScrolled) {
           requestAnimationFrame(() => this.scrollToBottom());
         }
@@ -88,6 +89,7 @@ export class ModelPanelComponent {
     }
   }
 
+  // Detect manual scroll: if user scrolls away from bottom, stop auto-scrolling
   onScroll(event: Event): void {
     if (this.programmaticScroll) return;
     const el = event.target as HTMLDivElement;
@@ -98,9 +100,9 @@ export class ModelPanelComponent {
   private scrollToBottom(): void {
     const el = this.bodyEl()?.nativeElement;
     if (el) {
+      // Flag prevents onScroll from treating our scrollTo as a user-initiated scroll
       this.programmaticScroll = true;
       el.scrollTop = el.scrollHeight;
-      // Reset after smooth scroll completes
       requestAnimationFrame(() => (this.programmaticScroll = false));
     }
   }

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
@@ -1,9 +1,11 @@
 import { Component, computed, effect, ElementRef, input, viewChild } from '@angular/core';
+import { MarkdownComponent } from 'ngx-markdown';
 import { ModelStreamState } from '../battle.types';
 import { STREAM_CURSOR } from '../battle.constants';
 
 @Component({
   selector: 'bixarena-model-panel',
+  imports: [MarkdownComponent],
   templateUrl: './model-panel.component.html',
   styleUrl: './model-panel.component.scss',
 })

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
@@ -9,9 +9,28 @@ import { STREAM_CURSOR } from '../battle.constants';
 })
 export class ModelPanelComponent {
   readonly label = input.required<string>();
+  readonly modelId = input.required<'model1' | 'model2'>();
   readonly streamState = input.required<ModelStreamState>();
   readonly revealedName = input<string | null>(null);
-  readonly isWinner = input(false);
+  readonly selectedOutcome = input<string | null>(null);
+  readonly hoveredModel = input<string | null>(null);
+
+  readonly isSelected = computed(() => {
+    const o = this.selectedOutcome();
+    if (!o) return false;
+    return o === this.modelId() || o === 'tie';
+  });
+
+  readonly isUnselected = computed(() => {
+    const o = this.selectedOutcome();
+    if (!o) return false;
+    return o !== this.modelId() && o !== 'tie';
+  });
+
+  readonly isHovered = computed(() => {
+    const h = this.hoveredModel();
+    return h === this.modelId() || h === 'tie';
+  });
 
   readonly bodyEl = viewChild<ElementRef<HTMLDivElement>>('body');
   private userScrolled = false;

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
@@ -23,8 +23,8 @@ import { STREAM_CURSOR } from '../battle.constants';
 export class ModelPanelComponent {
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
-  readonly anonymousName = input.required<string>();
   readonly modelId = input.required<'model1' | 'model2'>();
+  readonly anonymousName = computed(() => (this.modelId() === 'model1' ? 'Model A' : 'Model B'));
   readonly streamState = input.required<ModelStreamState>();
   readonly modelName = input<string | null>(null);
   readonly selectedOutcome = input<BattleEvaluationOutcome | null>(null);

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, effect, ElementRef, input, signal, viewChild } from '@angular/core';
+import { Component, computed, effect, ElementRef, input, viewChild } from '@angular/core';
 import { ModelStreamState } from '../battle.types';
 import { STREAM_CURSOR } from '../battle.constants';
 

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
@@ -34,6 +34,7 @@ export class ModelPanelComponent {
 
   readonly bodyEl = viewChild<ElementRef<HTMLDivElement>>('body');
   private userScrolled = false;
+  private programmaticScroll = false;
 
   readonly displayText = computed(() => {
     const state = this.streamState();
@@ -63,7 +64,7 @@ export class ModelPanelComponent {
 
   constructor() {
     effect(() => {
-      this.displayText();
+      this.streamState();
       if (!this.userScrolled) {
         requestAnimationFrame(() => this.scrollToBottom());
       }
@@ -71,6 +72,7 @@ export class ModelPanelComponent {
   }
 
   onScroll(event: Event): void {
+    if (this.programmaticScroll) return;
     const el = event.target as HTMLDivElement;
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
     this.userScrolled = !atBottom;
@@ -79,7 +81,10 @@ export class ModelPanelComponent {
   private scrollToBottom(): void {
     const el = this.bodyEl()?.nativeElement;
     if (el) {
+      this.programmaticScroll = true;
       el.scrollTop = el.scrollHeight;
+      // Reset after smooth scroll completes
+      requestAnimationFrame(() => (this.programmaticScroll = false));
     }
   }
 }

--- a/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.html
+++ b/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.html
@@ -1,0 +1,33 @@
+<div class="comp-card">
+  <textarea
+    #textarea
+    class="input"
+    [placeholder]="placeholder()"
+    [disabled]="disabled()"
+    [attr.maxlength]="maxLength()"
+    rows="1"
+    (input)="onInput($event)"
+    (keydown)="onKeydown($event)"
+  ></textarea>
+  <div class="bar">
+    <span class="char-count">{{ text().length }} / {{ maxLength() }}</span>
+    <button
+      class="send"
+      [class.hot]="isHot"
+      [disabled]="!isHot"
+      (click)="submit()"
+      aria-label="Send prompt"
+    >
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M5 12h14M12 5l7 7-7 7" />
+      </svg>
+    </button>
+  </div>
+</div>

--- a/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.html
+++ b/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.html
@@ -13,8 +13,8 @@
     <span class="char-count">{{ text().length }} / {{ maxLength() }}</span>
     <button
       class="send"
-      [class.hot]="isHot"
-      [disabled]="!isHot"
+      [class.hot]="isHot()"
+      [disabled]="!isHot()"
       (click)="submit()"
       aria-label="Send prompt"
     >

--- a/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.html
+++ b/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.html
@@ -9,7 +9,7 @@
     (input)="onInput($event)"
     (keydown)="onKeydown($event)"
   ></textarea>
-  <div class="bar">
+  <div class="toolbar">
     <span class="char-count">{{ text().length }} / {{ maxLength() }}</span>
     <button
       class="send"

--- a/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.scss
+++ b/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.scss
@@ -1,0 +1,86 @@
+:host {
+  display: block;
+  width: 100%;
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.comp-card {
+  background: var(--p-surface-50);
+  border: 1px solid var(--p-surface-200);
+  border-radius: var(--p-rounded-xl);
+  overflow: hidden;
+  transition: all 0.25s;
+
+  &:focus-within {
+    border-color: var(--p-surface-300);
+    box-shadow:
+      0 4px 32px rgb(0 0 0 / 10%),
+      0 0 0 3px rgb(249 115 22 / 4%);
+  }
+}
+
+.input {
+  width: 100%;
+  min-height: 56px;
+  max-height: 140px;
+  padding: 1rem;
+  border: none;
+  outline: none;
+  resize: none;
+  font: inherit;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  background: transparent;
+  color: var(--p-text-color);
+
+  &::placeholder {
+    color: var(--p-text-muted-color);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+}
+
+.char-count {
+  font-size: 0.75rem;
+  color: var(--p-text-muted-color);
+}
+
+.send {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  background: transparent;
+  color: var(--p-text-muted-color);
+  transition: all 0.2s;
+  opacity: 0.5;
+
+  &.hot {
+    background: var(--p-text-color);
+    color: var(--p-surface-0);
+    opacity: 1;
+  }
+
+  &.hot:hover {
+    transform: scale(1.06);
+  }
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+}

--- a/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.scss
+++ b/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.scss
@@ -1,35 +1,35 @@
 :host {
   display: block;
   width: 100%;
-  max-width: 640px;
+  max-width: 40rem;
   margin: 0 auto;
 }
 
 .comp-card {
-  background: var(--p-surface-50);
+  background: var(--p-surface-100);
   border: 1px solid var(--p-surface-200);
-  border-radius: var(--p-rounded-xl);
+  border-radius: 16px;
   overflow: hidden;
   transition: all 0.25s;
 
   &:focus-within {
     border-color: var(--p-surface-300);
     box-shadow:
-      0 4px 32px rgb(0 0 0 / 10%),
+      0 4px 32px rgb(0 0 0 / 20%),
       0 0 0 3px rgb(249 115 22 / 4%);
   }
 }
 
 .input {
   width: 100%;
-  min-height: 56px;
-  max-height: 140px;
-  padding: 1rem;
+  min-height: 3.5rem;
+  max-height: 8.75rem;
+  padding: 1rem 1.125rem 0.5rem;
   border: none;
   outline: none;
   resize: none;
   font: inherit;
-  font-size: 0.9375rem;
+  font-size: var(--text-md);
   line-height: 1.5;
   background: transparent;
   color: var(--p-text-color);
@@ -48,12 +48,18 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5rem 1rem;
+  padding: 6px 12px 10px;
 }
 
 .char-count {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--p-text-muted-color);
+  opacity: 0;
+  transition: opacity 0.2s;
+
+  .comp-card:focus-within & {
+    opacity: 1;
+  }
 }
 
 .send {
@@ -62,10 +68,11 @@
   border-radius: 6px;
   border: none;
   cursor: pointer;
-  display: grid;
-  place-items: center;
-  background: transparent;
-  color: var(--p-text-muted-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--p-surface-500);
+  color: var(--p-text-color);
   transition: all 0.2s;
   opacity: 0.5;
 

--- a/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.scss
+++ b/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.scss
@@ -44,7 +44,7 @@
   }
 }
 
-.bar {
+.toolbar {
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.spec.ts
@@ -1,0 +1,63 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PromptComposerComponent } from './prompt-composer.component';
+
+describe('PromptComposerComponent', () => {
+  let component: PromptComposerComponent;
+  let fixture: ComponentFixture<PromptComposerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PromptComposerComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PromptComposerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit promptSubmit on submit with text', () => {
+    const spy = jest.fn();
+    component.promptSubmit.subscribe(spy);
+    component.text.set('test prompt');
+    component.submit();
+    expect(spy).toHaveBeenCalledWith('test prompt');
+  });
+
+  it('should not emit when text is empty', () => {
+    const spy = jest.fn();
+    component.promptSubmit.subscribe(spy);
+    component.text.set('   ');
+    component.submit();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should not emit when disabled', () => {
+    const spy = jest.fn();
+    component.promptSubmit.subscribe(spy);
+    fixture.componentRef.setInput('disabled', true);
+    component.text.set('test');
+    component.submit();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should clear text after submit', () => {
+    component.text.set('test');
+    component.submit();
+    expect(component.text()).toBe('');
+  });
+
+  it('isHot should be true when text is non-empty and not disabled', () => {
+    component.text.set('hello');
+    expect(component.isHot).toBe(true);
+  });
+
+  it('isHot should be false when disabled', () => {
+    fixture.componentRef.setInput('disabled', true);
+    component.text.set('hello');
+    expect(component.isHot).toBe(false);
+  });
+});

--- a/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.spec.ts
@@ -12,6 +12,7 @@ describe('PromptComposerComponent', () => {
 
     fixture = TestBed.createComponent(PromptComposerComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('maxLength', 5000);
     fixture.detectChanges();
   });
 

--- a/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.spec.ts
@@ -52,12 +52,12 @@ describe('PromptComposerComponent', () => {
 
   it('isHot should be true when text is non-empty and not disabled', () => {
     component.text.set('hello');
-    expect(component.isHot).toBe(true);
+    expect(component.isHot()).toBe(true);
   });
 
   it('isHot should be false when disabled', () => {
     fixture.componentRef.setInput('disabled', true);
     component.text.set('hello');
-    expect(component.isHot).toBe(false);
+    expect(component.isHot()).toBe(false);
   });
 });

--- a/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.ts
+++ b/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.ts
@@ -8,7 +8,7 @@ import { Component, computed, ElementRef, input, output, signal, viewChild } fro
 export class PromptComposerComponent {
   readonly placeholder = input('Ask anything biomedical...');
   readonly disabled = input(false);
-  readonly maxLength = input(5000);
+  readonly maxLength = input.required<number>();
 
   readonly promptSubmit = output<string>();
 

--- a/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.ts
+++ b/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, input, output, signal, viewChild } from '@angular/core';
+import { Component, computed, ElementRef, input, output, signal, viewChild } from '@angular/core';
 
 @Component({
   selector: 'bixarena-prompt-composer',
@@ -15,9 +15,7 @@ export class PromptComposerComponent {
   readonly text = signal('');
   readonly textareaEl = viewChild<ElementRef<HTMLTextAreaElement>>('textarea');
 
-  get isHot(): boolean {
-    return this.text().trim().length > 0 && !this.disabled();
-  }
+  readonly isHot = computed(() => this.text().trim().length > 0 && !this.disabled());
 
   onInput(event: Event): void {
     const el = event.target as HTMLTextAreaElement;

--- a/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.ts
+++ b/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.ts
@@ -1,0 +1,47 @@
+import { Component, ElementRef, input, output, signal, viewChild } from '@angular/core';
+
+@Component({
+  selector: 'bixarena-prompt-composer',
+  templateUrl: './prompt-composer.component.html',
+  styleUrl: './prompt-composer.component.scss',
+})
+export class PromptComposerComponent {
+  readonly placeholder = input('Ask anything biomedical...');
+  readonly disabled = input(false);
+  readonly maxLength = input(5000);
+
+  readonly promptSubmit = output<string>();
+
+  readonly text = signal('');
+  readonly textareaEl = viewChild<ElementRef<HTMLTextAreaElement>>('textarea');
+
+  get isHot(): boolean {
+    return this.text().trim().length > 0 && !this.disabled();
+  }
+
+  onInput(event: Event): void {
+    const el = event.target as HTMLTextAreaElement;
+    this.text.set(el.value);
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      this.submit();
+    }
+  }
+
+  submit(): void {
+    const value = this.text().trim();
+    if (!value || this.disabled()) return;
+    this.promptSubmit.emit(value);
+    this.text.set('');
+    const el = this.textareaEl()?.nativeElement;
+    if (el) {
+      el.value = '';
+      el.style.height = 'auto';
+    }
+  }
+}

--- a/libs/bixarena/battle/src/lib/services/battle-stream.service.spec.ts
+++ b/libs/bixarena/battle/src/lib/services/battle-stream.service.spec.ts
@@ -1,0 +1,92 @@
+import { TestBed } from '@angular/core/testing';
+import { BASE_PATH, ModelChatCompletionChunk } from '@sagebionetworks/bixarena/api-client';
+import { BattleStreamService } from './battle-stream.service';
+import { firstValueFrom, toArray } from 'rxjs';
+
+function createMockReader(chunks: ModelChatCompletionChunk[]) {
+  const sseText = chunks.map((c) => `data: ${JSON.stringify(c)}\n\n`).join('');
+  const encoded = new TextEncoder().encode(sseText);
+  let read = false;
+  return {
+    read: jest.fn().mockImplementation(() => {
+      if (!read) {
+        read = true;
+        return Promise.resolve({ done: false, value: encoded });
+      }
+      return Promise.resolve({ done: true, value: undefined });
+    }),
+    cancel: jest.fn(),
+  };
+}
+
+describe('BattleStreamService', () => {
+  let service: BattleStreamService;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = jest.fn();
+    TestBed.configureTestingModule({
+      providers: [BattleStreamService, { provide: BASE_PATH, useValue: 'http://test/api/v1' }],
+    });
+    service = TestBed.inject(BattleStreamService);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const mockFetch = () => globalThis.fetch as jest.Mock;
+
+  it('should create', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should parse SSE chunks and emit ModelChatCompletionChunk', async () => {
+    const chunks: ModelChatCompletionChunk[] = [
+      { content: 'Hello', status: 'streaming' },
+      { content: 'Hello world', status: 'streaming' },
+      { status: 'complete', finishReason: 'stop' },
+    ];
+    const reader = createMockReader(chunks);
+    mockFetch().mockResolvedValue({ ok: true, body: { getReader: () => reader } });
+
+    const received = await firstValueFrom(
+      service.streamCompletion('battle-1', 'round-1', 'model-1').pipe(toArray()),
+    );
+
+    expect(received).toHaveLength(3);
+    expect(received[0].content).toBe('Hello');
+    expect(received[2].status).toBe('complete');
+    expect(reader.cancel).toHaveBeenCalled();
+  });
+
+  it('should error on non-ok response', async () => {
+    mockFetch().mockResolvedValue({ ok: false, status: 500 });
+
+    await expect(
+      firstValueFrom(service.streamCompletion('battle-1', 'round-1', 'model-1')),
+    ).rejects.toThrow('500');
+  });
+
+  it('should construct correct URL with BASE_PATH', () => {
+    const reader = createMockReader([]);
+    mockFetch().mockResolvedValue({ ok: true, body: { getReader: () => reader } });
+    service.streamCompletion('b-id', 'r-id', 'm-id').subscribe();
+
+    expect(mockFetch()).toHaveBeenCalledWith(
+      'http://test/api/v1/battles/b-id/rounds/r-id/stream?modelId=m-id',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+      }),
+    );
+  });
+
+  it('should abort on unsubscribe', () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    mockFetch().mockReturnValue(new Promise(() => {}));
+    const sub = service.streamCompletion('b-id', 'r-id', 'm-id').subscribe();
+    sub.unsubscribe();
+    expect(mockFetch()).toHaveBeenCalled();
+  });
+});

--- a/libs/bixarena/battle/src/lib/services/battle-stream.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle-stream.service.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { BASE_PATH, ModelChatCompletionChunk } from '@sagebionetworks/bixarena/api-client';
+import { StreamHttpError } from '../battle-errors';
 
 @Injectable()
 export class BattleStreamService {
@@ -23,7 +24,7 @@ export class BattleStreamService {
       })
         .then(async (response) => {
           if (!response.ok) {
-            subscriber.error(new Error(`Stream request failed: ${response.status}`));
+            subscriber.error(new StreamHttpError(response.status));
             return;
           }
 

--- a/libs/bixarena/battle/src/lib/services/battle-stream.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle-stream.service.ts
@@ -1,0 +1,73 @@
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { BASE_PATH, ModelChatCompletionChunk } from '@sagebionetworks/bixarena/api-client';
+
+@Injectable()
+export class BattleStreamService {
+  private readonly basePath = inject(BASE_PATH);
+
+  streamCompletion(
+    battleId: string,
+    roundId: string,
+    modelId: string,
+  ): Observable<ModelChatCompletionChunk> {
+    return new Observable((subscriber) => {
+      const controller = new AbortController();
+      const url = `${this.basePath}/battles/${battleId}/rounds/${roundId}/stream?modelId=${modelId}`;
+
+      fetch(url, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { Accept: 'text/event-stream' },
+        signal: controller.signal,
+      })
+        .then(async (response) => {
+          if (!response.ok) {
+            subscriber.error(new Error(`Stream request failed: ${response.status}`));
+            return;
+          }
+
+          if (!response.body) {
+            subscriber.error(new Error('Response body is null'));
+            return;
+          }
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = '';
+
+          try {
+            // eslint-disable-next-line no-constant-condition
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+
+              buffer += decoder.decode(value, { stream: true });
+
+              const events = buffer.split('\n\n');
+              buffer = events.pop() ?? '';
+
+              for (const event of events) {
+                for (const line of event.split('\n')) {
+                  if (line.startsWith('data: ')) {
+                    const chunk = JSON.parse(line.slice(6)) as ModelChatCompletionChunk;
+                    subscriber.next(chunk);
+                  }
+                }
+              }
+            }
+          } finally {
+            reader.cancel();
+          }
+
+          subscriber.complete();
+        })
+        .catch((err) => {
+          if (err.name !== 'AbortError') {
+            subscriber.error(err);
+          }
+        });
+
+      return () => controller.abort();
+    });
+  }
+}

--- a/libs/bixarena/battle/src/lib/services/battle-stream.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle-stream.service.ts
@@ -49,8 +49,12 @@ export class BattleStreamService {
               for (const event of events) {
                 for (const line of event.split('\n')) {
                   if (line.startsWith('data: ')) {
-                    const chunk = JSON.parse(line.slice(6)) as ModelChatCompletionChunk;
-                    subscriber.next(chunk);
+                    try {
+                      const chunk = JSON.parse(line.slice(6)) as ModelChatCompletionChunk;
+                      subscriber.next(chunk);
+                    } catch {
+                      // Skip malformed SSE chunk
+                    }
                   }
                 }
               }

--- a/libs/bixarena/battle/src/lib/services/battle-stream.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle-stream.service.ts
@@ -43,6 +43,7 @@ export class BattleStreamService {
 
               buffer += decoder.decode(value, { stream: true });
 
+              // SSE frames are double-newline delimited; last element is a partial frame kept in buffer
               const events = buffer.split('\n\n');
               buffer = events.pop() ?? '';
 
@@ -66,11 +67,13 @@ export class BattleStreamService {
           subscriber.complete();
         })
         .catch((err) => {
+          // AbortError is expected when the Observable is unsubscribed
           if (err.name !== 'AbortError') {
             subscriber.error(err);
           }
         });
 
+      // Teardown: abort fetch when the Observable is unsubscribed
       return () => controller.abort();
     });
   }

--- a/libs/bixarena/battle/src/lib/services/battle.service.spec.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.spec.ts
@@ -180,9 +180,9 @@ describe('BattleStateService', () => {
       expect(service.bothComplete()).toBe(false);
     });
 
-    it('model display names should show labels until reveal', () => {
-      expect(service.model1DisplayName()).toBe('Model A');
-      expect(service.model2DisplayName()).toBe('Model B');
+    it('should expose promptLengthLimit and promptUseDots from config', () => {
+      expect(service.promptLengthLimit).toBeGreaterThan(0);
+      expect(service.promptUseDots.length).toBe(service.promptUseLimit);
     });
   });
 

--- a/libs/bixarena/battle/src/lib/services/battle.service.spec.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.spec.ts
@@ -71,7 +71,6 @@ describe('BattleStateService', () => {
       await service.submitPrompt('test prompt');
       expect(service.phase()).not.toBe('landing');
       expect(service.battleId()).toBe('battle-1');
-      expect(service.roundNumber()).toBe(1);
     });
 
     it('should create battle and round via API', async () => {

--- a/libs/bixarena/battle/src/lib/services/battle.service.spec.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.spec.ts
@@ -112,6 +112,7 @@ describe('BattleStateService', () => {
         finishReason: 'stop',
         errorMessage: null,
         isSlowHint: false,
+        retryable: false,
       });
       service.model2Stream.set({
         messages: [],
@@ -120,6 +121,7 @@ describe('BattleStateService', () => {
         finishReason: 'stop',
         errorMessage: null,
         isSlowHint: false,
+        retryable: false,
       });
     });
 
@@ -148,6 +150,7 @@ describe('BattleStateService', () => {
         finishReason: 'stop',
         errorMessage: null,
         isSlowHint: false,
+        retryable: false,
       });
       service.model2Stream.set({
         messages: [],
@@ -156,6 +159,7 @@ describe('BattleStateService', () => {
         finishReason: null,
         errorMessage: 'err',
         isSlowHint: false,
+        retryable: false,
       });
       expect(service.bothComplete()).toBe(true);
     });
@@ -168,6 +172,7 @@ describe('BattleStateService', () => {
         finishReason: 'stop',
         errorMessage: null,
         isSlowHint: false,
+        retryable: false,
       });
       service.model2Stream.set({
         messages: [],
@@ -176,6 +181,7 @@ describe('BattleStateService', () => {
         finishReason: null,
         errorMessage: null,
         isSlowHint: false,
+        retryable: false,
       });
       expect(service.bothComplete()).toBe(false);
     });

--- a/libs/bixarena/battle/src/lib/services/battle.service.spec.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.spec.ts
@@ -1,0 +1,192 @@
+import { TestBed } from '@angular/core/testing';
+import { PLATFORM_ID } from '@angular/core';
+import { of, EMPTY, throwError } from 'rxjs';
+import {
+  BattleService as BattleApiService,
+  BattleEvaluationOutcome,
+} from '@sagebionetworks/bixarena/api-client';
+import { ConfigService } from '@sagebionetworks/bixarena/config';
+import { BattleStateService } from './battle.service';
+import { BattleStreamService } from './battle-stream.service';
+
+const mockConfig = {
+  config: {
+    battle: { promptLengthLimit: 5000, roundLimit: 20, promptUseLimit: 5 },
+  },
+};
+
+const mockBattleResponse = {
+  id: 'battle-1',
+  model1: { id: 'model-1', name: 'GPT-4' },
+  model2: { id: 'model-2', name: 'Claude' },
+};
+
+const mockRoundResponse = {
+  id: 'round-1',
+  battleId: 'battle-1',
+  roundNumber: 1,
+};
+
+describe('BattleStateService', () => {
+  let service: BattleStateService;
+  let battleApi: {
+    createBattle: jest.Mock;
+    createBattleRound: jest.Mock;
+    createBattleEvaluation: jest.Mock;
+    updateBattle: jest.Mock;
+  };
+  let streamService: { streamCompletion: jest.Mock };
+
+  beforeEach(() => {
+    battleApi = {
+      createBattle: jest.fn().mockReturnValue(of(mockBattleResponse)),
+      createBattleRound: jest.fn().mockReturnValue(of(mockRoundResponse)),
+      createBattleEvaluation: jest.fn().mockReturnValue(of({})),
+      updateBattle: jest.fn().mockReturnValue(of({})),
+    };
+
+    streamService = {
+      streamCompletion: jest.fn().mockReturnValue(EMPTY),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        BattleStateService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: BattleApiService, useValue: battleApi },
+        { provide: BattleStreamService, useValue: streamService },
+        { provide: ConfigService, useValue: mockConfig },
+      ],
+    });
+    service = TestBed.inject(BattleStateService);
+  });
+
+  it('should create with landing phase', () => {
+    expect(service).toBeTruthy();
+    expect(service.phase()).toBe('landing');
+  });
+
+  describe('submitPrompt', () => {
+    it('should transition to streaming phase', async () => {
+      await service.submitPrompt('test prompt');
+      expect(service.phase()).not.toBe('landing');
+      expect(service.battleId()).toBe('battle-1');
+      expect(service.roundNumber()).toBe(1);
+    });
+
+    it('should create battle and round via API', async () => {
+      await service.submitPrompt('test prompt');
+      expect(battleApi.createBattle).toHaveBeenCalledWith({ title: 'test prompt' });
+      expect(battleApi.createBattleRound).toHaveBeenCalledWith('battle-1', {
+        promptMessage: { role: 'user', content: 'test prompt' },
+      });
+    });
+
+    it('should set prompt use limit for new prompts', async () => {
+      await service.submitPrompt('new prompt');
+      expect(service.promptUsesRemaining()).toBe(5);
+      expect(service.lastPrompt()).toBe('new prompt');
+    });
+
+    it('should transition to error on API failure', async () => {
+      battleApi.createBattle.mockReturnValue(throwError(() => new Error('fail')));
+      await service.submitPrompt('test');
+      expect(service.phase()).toBe('error');
+    });
+
+    it('should start two parallel streams', async () => {
+      await service.submitPrompt('test');
+      expect(streamService.streamCompletion).toHaveBeenCalledTimes(2);
+      expect(streamService.streamCompletion).toHaveBeenCalledWith('battle-1', 'round-1', 'model-1');
+      expect(streamService.streamCompletion).toHaveBeenCalledWith('battle-1', 'round-1', 'model-2');
+    });
+  });
+
+  describe('submitVote', () => {
+    beforeEach(async () => {
+      await service.submitPrompt('test');
+      service.model1Stream.set({
+        text: 'done',
+        status: 'complete',
+        finishReason: 'stop',
+        errorMessage: null,
+        isSlowHint: false,
+      });
+      service.model2Stream.set({
+        text: 'done',
+        status: 'complete',
+        finishReason: 'stop',
+        errorMessage: null,
+        isSlowHint: false,
+      });
+    });
+
+    it('should submit evaluation and transition to reveal', async () => {
+      await service.submitVote(BattleEvaluationOutcome.Model1);
+      expect(battleApi.createBattleEvaluation).toHaveBeenCalledWith('battle-1', {
+        outcome: 'model1',
+      });
+      expect(service.phase()).toBe('reveal');
+      expect(service.selectedOutcome()).toBe('model1');
+    });
+
+    it('should decrement prompt uses remaining', async () => {
+      const before = service.promptUsesRemaining();
+      await service.submitVote(BattleEvaluationOutcome.Tie);
+      expect(service.promptUsesRemaining()).toBe(before - 1);
+    });
+  });
+
+  describe('computed signals', () => {
+    it('bothComplete should be true when both streams are done', () => {
+      service.model1Stream.set({
+        text: '',
+        status: 'complete',
+        finishReason: 'stop',
+        errorMessage: null,
+        isSlowHint: false,
+      });
+      service.model2Stream.set({
+        text: '',
+        status: 'error',
+        finishReason: null,
+        errorMessage: 'err',
+        isSlowHint: false,
+      });
+      expect(service.bothComplete()).toBe(true);
+    });
+
+    it('bothComplete should be false when one stream is still going', () => {
+      service.model1Stream.set({
+        text: '',
+        status: 'complete',
+        finishReason: 'stop',
+        errorMessage: null,
+        isSlowHint: false,
+      });
+      service.model2Stream.set({
+        text: '',
+        status: 'streaming',
+        finishReason: null,
+        errorMessage: null,
+        isSlowHint: false,
+      });
+      expect(service.bothComplete()).toBe(false);
+    });
+
+    it('model display names should show labels until reveal', () => {
+      expect(service.model1DisplayName()).toBe('Model A');
+      expect(service.model2DisplayName()).toBe('Model B');
+    });
+  });
+
+  describe('reset', () => {
+    it('should return to landing phase', async () => {
+      await service.submitPrompt('test');
+      service.reset();
+      expect(service.phase()).toBe('landing');
+      expect(service.battleId()).toBeNull();
+      expect(service.model1()).toBeNull();
+    });
+  });
+});

--- a/libs/bixarena/battle/src/lib/services/battle.service.spec.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.spec.ts
@@ -106,6 +106,7 @@ describe('BattleStateService', () => {
     beforeEach(async () => {
       await service.submitPrompt('test');
       service.model1Stream.set({
+        messages: [],
         text: 'done',
         status: 'complete',
         finishReason: 'stop',
@@ -113,6 +114,7 @@ describe('BattleStateService', () => {
         isSlowHint: false,
       });
       service.model2Stream.set({
+        messages: [],
         text: 'done',
         status: 'complete',
         finishReason: 'stop',
@@ -140,6 +142,7 @@ describe('BattleStateService', () => {
   describe('computed signals', () => {
     it('bothComplete should be true when both streams are done', () => {
       service.model1Stream.set({
+        messages: [],
         text: '',
         status: 'complete',
         finishReason: 'stop',
@@ -147,6 +150,7 @@ describe('BattleStateService', () => {
         isSlowHint: false,
       });
       service.model2Stream.set({
+        messages: [],
         text: '',
         status: 'error',
         finishReason: null,
@@ -158,6 +162,7 @@ describe('BattleStateService', () => {
 
     it('bothComplete should be false when one stream is still going', () => {
       service.model1Stream.set({
+        messages: [],
         text: '',
         status: 'complete',
         finishReason: 'stop',
@@ -165,6 +170,7 @@ describe('BattleStateService', () => {
         isSlowHint: false,
       });
       service.model2Stream.set({
+        messages: [],
         text: '',
         status: 'streaming',
         finishReason: null,

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -210,7 +210,7 @@ export class BattleStateService {
     if (this.bothComplete()) {
       const s1 = this.model1Stream().status;
       const s2 = this.model2Stream().status;
-      if (s1 === 'error' && s2 === 'error') {
+      if (s1 === 'error' || s2 === 'error') {
         this.phase.set('error');
       } else {
         this.phase.set('voting');

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -100,7 +100,8 @@ export class BattleStateService {
       this.prepareStreams(prompt);
       try {
         await this.createRoundAndStream(existingBattle, model1.id, model2.id, prompt);
-      } catch {
+      } catch (err) {
+        console.error('Failed to create follow-up round', err);
         this.setStreamError('Something went wrong', true);
       }
       return;
@@ -112,7 +113,8 @@ export class BattleStateService {
     try {
       battle = await firstValueFrom(this.battleApi.createBattle({ title: prompt.slice(0, 50) }));
       if (!battle) throw new Error('Failed to create battle');
-    } catch {
+    } catch (err) {
+      console.error('Failed to create battle', err);
       this.setStreamError('Something went wrong. Try a new battle', false);
       return;
     }
@@ -121,7 +123,8 @@ export class BattleStateService {
     this.model2.set(battle.model2);
     try {
       await this.createRoundAndStream(battle.id, battle.model1.id, battle.model2.id, prompt);
-    } catch {
+    } catch (err) {
+      console.error('Failed to start streaming', err);
       this.setStreamError('Something went wrong', true);
     }
   }
@@ -137,7 +140,8 @@ export class BattleStateService {
     this.prepareStreams(prompt);
     try {
       await this.createRoundAndStream(battleId, model1.id, model2.id, prompt);
-    } catch {
+    } catch (err) {
+      console.error('Failed to retry round', err);
       this.setStreamError('Something went wrong', true);
     }
   }

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -9,32 +9,9 @@ import {
 import { ConfigService } from '@sagebionetworks/bixarena/config';
 import { BattlePhase, INITIAL_STREAM_STATE, ModelStreamState } from '../battle.types';
 import { SLOW_MODEL_THRESHOLD_MS, MODEL_TIMEOUT_MS } from '../battle.constants';
+import { StreamHttpError, mapStreamHttpError } from '../battle-errors';
 import { BattleStreamService } from './battle-stream.service';
 
-/**
- * BattleStateService — orchestrates the battle lifecycle.
- *
- * Phase state machine:
- *   landing  --[submitPrompt]--> creating
- *   creating --[API success]---> streaming
- *   creating --[API error]-----> error
- *   streaming -[both complete]-> voting   (no model errored)
- *   streaming -[both complete]-> error    (any model errored)
- *   voting   --[submitVote]----> reveal
- *   reveal   --[newBattle]-----> creating ("same question new matchup")
- *   reveal   --[reset]---------> landing  ("new battle")
- *   error    --[newBattle]-----> creating
- *   error    --[reset]---------> landing
- *
- * Dot rail (same-question matchup tracking):
- *   promptUsesRemaining decrements on each vote. Budget resets only
- *   when the user types a genuinely new prompt. Errors don't decrement.
- *
- * Timeouts (two-tier):
- *   SLOW_MODEL_THRESHOLD_MS - soft UI hint ("Taking longer than expected")
- *   MODEL_TIMEOUT_MS        - hard cutoff (forces error status)
- *   Both clear on first received chunk.
- */
 @Injectable()
 export class BattleStateService {
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
@@ -43,131 +20,112 @@ export class BattleStateService {
   private readonly config = inject(ConfigService).config;
 
   constructor() {
+    // Cancel active streams when the service is destroyed
     inject(DestroyRef).onDestroy(() => this.cleanupStreams());
   }
 
+  // Phase state machine
   readonly phase = signal<BattlePhase>('landing');
+
+  // Battle and round identifiers
   readonly battleId = signal<string | null>(null);
   readonly roundId = signal<string | null>(null);
   readonly roundNumber = signal(0);
+
+  // Competing models
   readonly model1 = signal<Model | null>(null);
   readonly model2 = signal<Model | null>(null);
+
+  // Per-model stream state
   readonly model1Stream = signal<ModelStreamState>({ ...INITIAL_STREAM_STATE });
   readonly model2Stream = signal<ModelStreamState>({ ...INITIAL_STREAM_STATE });
+
+  // Prompt reuse tracking
   readonly lastPrompt = signal<string | null>(null);
   readonly promptUsesRemaining = signal(0);
-  readonly selectedOutcome = signal<BattleEvaluationOutcome | null>(null);
-
   readonly promptUseLimit = this.config.battle.promptUseLimit;
   readonly promptLengthLimit = this.config.battle.promptLengthLimit;
   readonly promptUseDots = Array.from({ length: this.promptUseLimit }, (_, i) => i + 1);
+  readonly canReuse = computed(() => this.lastPrompt() !== null && this.promptUsesRemaining() > 0);
+  readonly completedMatches = computed(
+    () => this.config.battle.promptUseLimit - this.promptUsesRemaining(),
+  );
+  readonly currentMatch = computed(() => {
+    const completed = this.completedMatches();
+    return this.phase() === 'reveal' ? completed : completed + 1;
+  });
+  readonly allMatchesComplete = computed(
+    () => this.completedMatches() >= this.config.battle.promptUseLimit,
+  );
 
-  // Gates transition to voting/error phase
+  // Voting state — current selection and stream completion gates
+  readonly selectedOutcome = signal<BattleEvaluationOutcome | null>(null);
   readonly bothComplete = computed(() => {
     const s1 = this.model1Stream().status;
     const s2 = this.model2Stream().status;
     return (s1 === 'complete' || s1 === 'error') && (s2 === 'complete' || s2 === 'error');
   });
-
-  // Voting allowed when at least one model succeeded (both-error goes to error phase instead)
   readonly canVote = computed(
     () =>
       this.phase() === 'voting' &&
       (this.model1Stream().status !== 'error' || this.model2Stream().status !== 'error'),
   );
 
-  readonly canReuse = computed(() => this.lastPrompt() !== null && this.promptUsesRemaining() > 0);
-
-  readonly completedMatches = computed(
-    () => this.config.battle.promptUseLimit - this.promptUsesRemaining(),
-  );
-
-  // On reveal, promptUsesRemaining already decremented so completedMatches is accurate.
-  // During active phases, add 1 to show the in-progress match number.
-  readonly currentMatch = computed(() => {
-    const completed = this.completedMatches();
-    return this.phase() === 'reveal' ? completed : completed + 1;
-  });
-
-  readonly allMatchesComplete = computed(
-    () => this.completedMatches() >= this.config.battle.promptUseLimit,
-  );
-
+  // Active stream subscriptions, timer handles, and submission guards
   private model1Sub?: Subscription;
   private model2Sub?: Subscription;
   private model1Timeout?: ReturnType<typeof setTimeout>;
   private model2Timeout?: ReturnType<typeof setTimeout>;
   private model1SlowTimeout?: ReturnType<typeof setTimeout>;
   private model2SlowTimeout?: ReturnType<typeof setTimeout>;
+  private isVoting = false;
 
   async submitPrompt(prompt: string): Promise<void> {
     if (!this.isBrowser) return;
 
-    // First use of a prompt gets full reuse budget; same prompt does not reset it
+    // Reset reuse budget for a new prompt; preserve remaining uses for the same prompt
     const isNewPrompt = prompt !== this.lastPrompt();
     if (isNewPrompt) {
       this.promptUsesRemaining.set(this.config.battle.promptUseLimit);
     }
     this.lastPrompt.set(prompt);
-
-    this.phase.set('creating');
     this.selectedOutcome.set(null);
 
-    // Carry forward chat history so follow-up rounds show prior messages
-    const userMsg = { role: 'user' as const, content: prompt };
-    const prev1 = this.model1Stream().messages;
-    const prev2 = this.model2Stream().messages;
-    this.model1Stream.set({
-      ...INITIAL_STREAM_STATE,
-      messages: [...prev1, userMsg],
-      status: 'waiting',
-    });
-    this.model2Stream.set({
-      ...INITIAL_STREAM_STATE,
-      messages: [...prev2, userMsg],
-      status: 'waiting',
-    });
-
+    // Create a new battle (new match, new model pair)
+    this.prepareStreams(prompt);
+    let battle;
     try {
-      const battle = await firstValueFrom(
-        this.battleApi.createBattle({ title: prompt.slice(0, 50) }),
-      );
-
+      battle = await firstValueFrom(this.battleApi.createBattle({ title: prompt.slice(0, 50) }));
       if (!battle) throw new Error('Failed to create battle');
-
-      this.battleId.set(battle.id);
-      this.model1.set(battle.model1);
-      this.model2.set(battle.model2);
-
-      const round = await firstValueFrom(
-        this.battleApi.createBattleRound(battle.id, {
-          promptMessage: { role: 'user', content: prompt },
-        }),
-      );
-
-      if (!round) throw new Error('Failed to create round');
-
-      this.roundId.set(round.id);
-      this.roundNumber.set(round.roundNumber);
-
-      this.startStreaming(battle.id, round.id, battle.model1.id, battle.model2.id);
     } catch {
-      // Reset streams so panels don't show stale "Connecting..." status
-      this.model1Stream.set({
-        ...INITIAL_STREAM_STATE,
-        status: 'error',
-        errorMessage: 'Failed to start battle',
-      });
-      this.model2Stream.set({
-        ...INITIAL_STREAM_STATE,
-        status: 'error',
-        errorMessage: 'Failed to start battle',
-      });
-      this.phase.set('error');
+      this.setStreamError('Something went wrong. Try a new battle', false);
+      return;
+    }
+    this.battleId.set(battle.id);
+    this.model1.set(battle.model1);
+    this.model2.set(battle.model2);
+    try {
+      await this.createRoundAndStream(battle.id, battle.model1.id, battle.model2.id, prompt);
+    } catch {
+      this.setStreamError('Something went wrong', true);
     }
   }
 
-  private isVoting = false;
+  // Retry after error — creates a new round in the same battle with the same models
+  async retry(): Promise<void> {
+    const prompt = this.lastPrompt();
+    const battleId = this.battleId();
+    const model1 = this.model1();
+    const model2 = this.model2();
+    if (!prompt || !battleId || !model1 || !model2) return;
+
+    this.prepareStreams(prompt);
+    try {
+      await this.createRoundAndStream(battleId, model1.id, model2.id, prompt);
+    } catch {
+      this.setStreamError('Something went wrong', true);
+    }
+  }
 
   async submitVote(outcome: BattleEvaluationOutcome): Promise<void> {
     const battleId = this.battleId();
@@ -177,27 +135,31 @@ export class BattleStateService {
     try {
       await firstValueFrom(this.battleApi.createBattleEvaluation(battleId, { outcome }));
     } catch {
+      // On failure, stay in voting phase so the user can retry
       this.isVoting = false;
-      return; // Evaluation failed — stay in voting phase
+      return;
     }
 
+    // Record outcome, decrement budget, advance to reveal
     this.selectedOutcome.set(outcome);
     this.promptUsesRemaining.update((n) => Math.max(0, n - 1));
     this.phase.set('reveal');
     this.isVoting = false;
 
-    // Best-effort: record battle end time (backend validation may update the battle concurrently)
+    // Best-effort: record battle end time (non-critical, ignore failures)
     firstValueFrom(this.battleApi.updateBattle(battleId, { endedAt: new Date().toISOString() }))
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       .catch(() => {});
   }
 
-  // "Same question new matchup": reset streams but keep lastPrompt so reuse budget continues
   async newBattle(prompt?: string): Promise<void> {
+    // Cancel active streams and reset stream state, preserving the prompt reuse budget
     this.cleanupStreams();
     this.model1Stream.set({ ...INITIAL_STREAM_STATE });
     this.model2Stream.set({ ...INITIAL_STREAM_STATE });
     this.selectedOutcome.set(null);
+
+    // Re-submit with the provided prompt or fall back to the last prompt
     const text = prompt ?? this.lastPrompt();
     if (text) {
       await this.submitPrompt(text);
@@ -205,6 +167,7 @@ export class BattleStateService {
   }
 
   reset(): void {
+    // Full teardown — cancel streams and return to landing state
     this.cleanupStreams();
     this.phase.set('landing');
     this.battleId.set(null);
@@ -217,6 +180,46 @@ export class BattleStateService {
     this.lastPrompt.set(null);
     this.promptUsesRemaining.set(0);
     this.selectedOutcome.set(null);
+  }
+
+  // Shared setup — reset streams with user message and transition to creating
+  private prepareStreams(prompt: string): void {
+    this.cleanupStreams();
+    this.phase.set('creating');
+    const userMsg = { role: 'user' as const, content: prompt };
+    this.model1Stream.set({ ...INITIAL_STREAM_STATE, messages: [userMsg], status: 'waiting' });
+    this.model2Stream.set({ ...INITIAL_STREAM_STATE, messages: [userMsg], status: 'waiting' });
+  }
+
+  // Shared round creation + streaming kickoff
+  private async createRoundAndStream(
+    battleId: string,
+    model1Id: string,
+    model2Id: string,
+    prompt: string,
+  ): Promise<void> {
+    const round = await firstValueFrom(
+      this.battleApi.createBattleRound(battleId, {
+        promptMessage: { role: 'user', content: prompt },
+      }),
+    );
+    if (!round) throw new Error('Failed to create round');
+    this.roundId.set(round.id);
+    this.roundNumber.set(round.roundNumber);
+    this.startStreaming(battleId, round.id, model1Id, model2Id);
+  }
+
+  // Shared error setter for both stream panels
+  private setStreamError(message: string, retryable: boolean): void {
+    const errorState = {
+      ...INITIAL_STREAM_STATE,
+      status: 'error' as const,
+      errorMessage: message,
+      retryable,
+    };
+    this.model1Stream.set({ ...errorState, messages: this.model1Stream().messages });
+    this.model2Stream.set({ ...errorState, messages: this.model2Stream().messages });
+    this.phase.set('error');
   }
 
   private startStreaming(
@@ -241,14 +244,16 @@ export class BattleStateService {
     modelId: string,
     streamSignal: ReturnType<typeof signal<ModelStreamState>>,
   ): Subscription {
+    // Per-model accumulator that builds the full response text across chunks
     let accumulatedText = '';
 
     return this.streamService.streamCompletion(battleId, roundId, modelId).subscribe({
       next: (chunk) => {
-        // First chunk arrived — cancel slow/timeout timers
+        // Cancel slow and hard timeouts on first received chunk
         this.clearTimeouts(streamSignal === this.model1Stream ? 'model1' : 'model2');
 
         if (chunk.status === 'streaming' && chunk.content) {
+          // Append incoming content and update the live text display
           accumulatedText += chunk.content;
           streamSignal.set({
             ...streamSignal(),
@@ -257,7 +262,7 @@ export class BattleStateService {
             isSlowHint: false,
           });
         } else if (chunk.status === 'complete') {
-          // Move accumulated text into messages array and clear streaming text
+          // Move accumulated text into message history and clear the streaming buffer
           const current = streamSignal();
           streamSignal.set({
             ...current,
@@ -272,20 +277,28 @@ export class BattleStateService {
           });
           this.checkBothComplete();
         } else if (chunk.status === 'error') {
+          // Handle stream-level error reported by the backend (details already logged to DB)
           streamSignal.set({
             ...streamSignal(),
             status: 'error',
-            errorMessage: chunk.errorMessage ?? 'An error occurred',
+            errorMessage: 'Something went wrong',
+            retryable: true,
             isSlowHint: false,
           });
           this.checkBothComplete();
         }
       },
-      error: () => {
+      error: (err: unknown) => {
+        // Map HTTP status errors; fall back to generic connection message for transport failures
+        const mapped =
+          err instanceof StreamHttpError
+            ? mapStreamHttpError(err.status)
+            : { message: 'Connection lost', retryable: true };
         streamSignal.set({
           ...streamSignal(),
           status: 'error',
-          errorMessage: 'Connection lost',
+          errorMessage: mapped.message,
+          retryable: mapped.retryable,
           isSlowHint: false,
         });
         this.checkBothComplete();
@@ -294,6 +307,7 @@ export class BattleStateService {
   }
 
   private checkBothComplete(): void {
+    // Advance phase once both models reach a terminal state
     if (this.bothComplete()) {
       const s1 = this.model1Stream().status;
       const s2 = this.model2Stream().status;
@@ -309,24 +323,28 @@ export class BattleStateService {
     streamSignal: ReturnType<typeof signal<ModelStreamState>>,
     key: 'model1' | 'model2',
   ): void {
+    // Soft hint — show "taking longer than expected" after threshold
     const slowTimeout = setTimeout(() => {
       if (streamSignal().status === 'waiting' || streamSignal().status === 'streaming') {
         streamSignal.set({ ...streamSignal(), isSlowHint: true });
       }
     }, SLOW_MODEL_THRESHOLD_MS);
 
+    // Hard cutoff — force error if the model never responds in time
     const hardTimeout = setTimeout(() => {
       if (streamSignal().status === 'waiting' || streamSignal().status === 'streaming') {
         streamSignal.set({
           ...streamSignal(),
           status: 'error',
           errorMessage: 'Model took too long to respond',
+          retryable: true,
           isSlowHint: false,
         });
         this.checkBothComplete();
       }
     }, MODEL_TIMEOUT_MS);
 
+    // Store handles by key so they can be cleared when the first chunk arrives
     if (key === 'model1') {
       this.model1SlowTimeout = slowTimeout;
       this.model1Timeout = hardTimeout;
@@ -347,6 +365,7 @@ export class BattleStateService {
   }
 
   private cleanupStreams(): void {
+    // Cancel subscriptions and clear all timers for both models
     this.model1Sub?.unsubscribe();
     this.model2Sub?.unsubscribe();
     this.clearTimeouts('model1');

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -1,6 +1,6 @@
-import { computed, inject, Injectable, PLATFORM_ID, signal } from '@angular/core';
+import { computed, DestroyRef, inject, Injectable, PLATFORM_ID, signal } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
-import { Subscription } from 'rxjs';
+import { firstValueFrom, Subscription } from 'rxjs';
 import {
   BattleService as BattleApiService,
   BattleEvaluationOutcome,
@@ -17,6 +17,10 @@ export class BattleStateService {
   private readonly battleApi = inject(BattleApiService);
   private readonly streamService = inject(BattleStreamService);
   private readonly config = inject(ConfigService).config;
+
+  constructor() {
+    inject(DestroyRef).onDestroy(() => this.cleanupStreams());
+  }
 
   readonly phase = signal<BattlePhase>('landing');
   readonly battleId = signal<string | null>(null);
@@ -86,7 +90,9 @@ export class BattleStateService {
     });
 
     try {
-      const battle = await this.battleApi.createBattle({ title: prompt.slice(0, 50) }).toPromise();
+      const battle = await firstValueFrom(
+        this.battleApi.createBattle({ title: prompt.slice(0, 50) }),
+      );
 
       if (!battle) throw new Error('Failed to create battle');
 
@@ -94,11 +100,11 @@ export class BattleStateService {
       this.model1.set(battle.model1);
       this.model2.set(battle.model2);
 
-      const round = await this.battleApi
-        .createBattleRound(battle.id, {
+      const round = await firstValueFrom(
+        this.battleApi.createBattleRound(battle.id, {
           promptMessage: { role: 'user', content: prompt },
-        })
-        .toPromise();
+        }),
+      );
 
       if (!round) throw new Error('Failed to create round');
 
@@ -107,6 +113,17 @@ export class BattleStateService {
 
       this.startStreaming(battle.id, round.id, battle.model1.id, battle.model2.id);
     } catch {
+      // Reset streams so panels don't show stale "Connecting..." status
+      this.model1Stream.set({
+        ...INITIAL_STREAM_STATE,
+        status: 'error',
+        errorMessage: 'Failed to start battle',
+      });
+      this.model2Stream.set({
+        ...INITIAL_STREAM_STATE,
+        status: 'error',
+        errorMessage: 'Failed to start battle',
+      });
       this.phase.set('error');
     }
   }
@@ -119,7 +136,7 @@ export class BattleStateService {
 
     this.isVoting = true;
     try {
-      await this.battleApi.createBattleEvaluation(battleId, { outcome }).toPromise();
+      await firstValueFrom(this.battleApi.createBattleEvaluation(battleId, { outcome }));
     } catch {
       this.isVoting = false;
       return; // Evaluation failed — stay in voting phase
@@ -131,9 +148,7 @@ export class BattleStateService {
     this.isVoting = false;
 
     // Best-effort: record battle end time (may race with async validation)
-    this.battleApi
-      .updateBattle(battleId, { endedAt: new Date().toISOString() })
-      .toPromise()
+    firstValueFrom(this.battleApi.updateBattle(battleId, { endedAt: new Date().toISOString() }))
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       .catch(() => {});
   }

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -1,0 +1,268 @@
+import { computed, inject, Injectable, PLATFORM_ID, signal } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Subscription } from 'rxjs';
+import {
+  BattleService as BattleApiService,
+  BattleEvaluationOutcome,
+  Model,
+} from '@sagebionetworks/bixarena/api-client';
+import { ConfigService } from '@sagebionetworks/bixarena/config';
+import { BattlePhase, INITIAL_STREAM_STATE, ModelStreamState } from '../battle.types';
+import { SLOW_MODEL_THRESHOLD_MS, MODEL_TIMEOUT_MS } from '../battle.constants';
+import { BattleStreamService } from './battle-stream.service';
+
+@Injectable()
+export class BattleStateService {
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+  private readonly battleApi = inject(BattleApiService);
+  private readonly streamService = inject(BattleStreamService);
+  private readonly config = inject(ConfigService).config;
+
+  readonly phase = signal<BattlePhase>('landing');
+  readonly battleId = signal<string | null>(null);
+  readonly roundId = signal<string | null>(null);
+  readonly roundNumber = signal(0);
+  readonly model1 = signal<Model | null>(null);
+  readonly model2 = signal<Model | null>(null);
+  readonly model1Stream = signal<ModelStreamState>({ ...INITIAL_STREAM_STATE });
+  readonly model2Stream = signal<ModelStreamState>({ ...INITIAL_STREAM_STATE });
+  readonly lastPrompt = signal<string | null>(null);
+  readonly promptUsesRemaining = signal(0);
+  readonly selectedOutcome = signal<BattleEvaluationOutcome | null>(null);
+
+  readonly bothComplete = computed(() => {
+    const s1 = this.model1Stream().status;
+    const s2 = this.model2Stream().status;
+    return (s1 === 'complete' || s1 === 'error') && (s2 === 'complete' || s2 === 'error');
+  });
+
+  readonly canVote = computed(
+    () =>
+      this.phase() === 'voting' &&
+      (this.model1Stream().status !== 'error' || this.model2Stream().status !== 'error'),
+  );
+
+  readonly canReuse = computed(() => this.lastPrompt() !== null && this.promptUsesRemaining() > 0);
+
+  readonly model1DisplayName = computed(() =>
+    this.phase() === 'reveal' ? (this.model1()?.name ?? 'Model A') : 'Model A',
+  );
+
+  readonly model2DisplayName = computed(() =>
+    this.phase() === 'reveal' ? (this.model2()?.name ?? 'Model B') : 'Model B',
+  );
+
+  private model1Sub?: Subscription;
+  private model2Sub?: Subscription;
+  private model1Timeout?: ReturnType<typeof setTimeout>;
+  private model2Timeout?: ReturnType<typeof setTimeout>;
+  private model1SlowTimeout?: ReturnType<typeof setTimeout>;
+  private model2SlowTimeout?: ReturnType<typeof setTimeout>;
+
+  async submitPrompt(prompt: string): Promise<void> {
+    if (!this.isBrowser) return;
+
+    const isNewPrompt = prompt !== this.lastPrompt();
+    if (isNewPrompt) {
+      this.promptUsesRemaining.set(this.config.battle.promptUseLimit);
+    }
+    this.lastPrompt.set(prompt);
+
+    this.phase.set('creating');
+    this.selectedOutcome.set(null);
+    this.model1Stream.set({ ...INITIAL_STREAM_STATE, status: 'waiting' });
+    this.model2Stream.set({ ...INITIAL_STREAM_STATE, status: 'waiting' });
+
+    try {
+      const battle = await this.battleApi.createBattle({ title: prompt.slice(0, 50) }).toPromise();
+
+      if (!battle) throw new Error('Failed to create battle');
+
+      this.battleId.set(battle.id);
+      this.model1.set(battle.model1);
+      this.model2.set(battle.model2);
+
+      const round = await this.battleApi
+        .createBattleRound(battle.id, {
+          promptMessage: { role: 'user', content: prompt },
+        })
+        .toPromise();
+
+      if (!round) throw new Error('Failed to create round');
+
+      this.roundId.set(round.id);
+      this.roundNumber.set(round.roundNumber);
+
+      this.startStreaming(battle.id, round.id, battle.model1.id, battle.model2.id);
+    } catch {
+      this.phase.set('error');
+    }
+  }
+
+  async submitVote(outcome: BattleEvaluationOutcome): Promise<void> {
+    const battleId = this.battleId();
+    if (!battleId) return;
+
+    try {
+      await this.battleApi.createBattleEvaluation(battleId, { outcome }).toPromise();
+      await this.battleApi
+        .updateBattle(battleId, { endedAt: new Date().toISOString() })
+        .toPromise();
+      this.selectedOutcome.set(outcome);
+      this.promptUsesRemaining.update((n) => Math.max(0, n - 1));
+      this.phase.set('reveal');
+    } catch {
+      // Vote failed — stay in voting phase, user can retry
+    }
+  }
+
+  async newBattle(prompt?: string): Promise<void> {
+    this.cleanupStreams();
+    const text = prompt ?? this.lastPrompt();
+    if (text) {
+      await this.submitPrompt(text);
+    }
+  }
+
+  reset(): void {
+    this.cleanupStreams();
+    this.phase.set('landing');
+    this.battleId.set(null);
+    this.roundId.set(null);
+    this.roundNumber.set(0);
+    this.model1.set(null);
+    this.model2.set(null);
+    this.model1Stream.set({ ...INITIAL_STREAM_STATE });
+    this.model2Stream.set({ ...INITIAL_STREAM_STATE });
+    this.lastPrompt.set(null);
+    this.promptUsesRemaining.set(0);
+    this.selectedOutcome.set(null);
+  }
+
+  private startStreaming(
+    battleId: string,
+    roundId: string,
+    model1Id: string,
+    model2Id: string,
+  ): void {
+    this.phase.set('streaming');
+    this.cleanupStreams();
+
+    this.model1Sub = this.subscribeToStream(battleId, roundId, model1Id, this.model1Stream);
+    this.model2Sub = this.subscribeToStream(battleId, roundId, model2Id, this.model2Stream);
+
+    this.startTimeouts(this.model1Stream, 'model1');
+    this.startTimeouts(this.model2Stream, 'model2');
+  }
+
+  private subscribeToStream(
+    battleId: string,
+    roundId: string,
+    modelId: string,
+    streamSignal: ReturnType<typeof signal<ModelStreamState>>,
+  ): Subscription {
+    let accumulatedText = '';
+
+    return this.streamService.streamCompletion(battleId, roundId, modelId).subscribe({
+      next: (chunk) => {
+        this.clearTimeouts(streamSignal === this.model1Stream ? 'model1' : 'model2');
+
+        if (chunk.status === 'streaming' && chunk.content) {
+          accumulatedText += chunk.content;
+          streamSignal.set({
+            ...streamSignal(),
+            text: accumulatedText,
+            status: 'streaming',
+            isSlowHint: false,
+          });
+        } else if (chunk.status === 'complete') {
+          streamSignal.set({
+            ...streamSignal(),
+            text: accumulatedText,
+            status: 'complete',
+            finishReason: chunk.finishReason ?? null,
+            isSlowHint: false,
+          });
+          this.checkBothComplete();
+        } else if (chunk.status === 'error') {
+          streamSignal.set({
+            ...streamSignal(),
+            status: 'error',
+            errorMessage: chunk.errorMessage ?? 'An error occurred',
+            isSlowHint: false,
+          });
+          this.checkBothComplete();
+        }
+      },
+      error: () => {
+        streamSignal.set({
+          ...streamSignal(),
+          status: 'error',
+          errorMessage: 'Connection lost',
+          isSlowHint: false,
+        });
+        this.checkBothComplete();
+      },
+    });
+  }
+
+  private checkBothComplete(): void {
+    if (this.bothComplete()) {
+      const s1 = this.model1Stream().status;
+      const s2 = this.model2Stream().status;
+      if (s1 === 'error' && s2 === 'error') {
+        this.phase.set('error');
+      } else {
+        this.phase.set('voting');
+      }
+    }
+  }
+
+  private startTimeouts(
+    streamSignal: ReturnType<typeof signal<ModelStreamState>>,
+    key: 'model1' | 'model2',
+  ): void {
+    const slowTimeout = setTimeout(() => {
+      if (streamSignal().status === 'waiting' || streamSignal().status === 'streaming') {
+        streamSignal.set({ ...streamSignal(), isSlowHint: true });
+      }
+    }, SLOW_MODEL_THRESHOLD_MS);
+
+    const hardTimeout = setTimeout(() => {
+      if (streamSignal().status === 'waiting' || streamSignal().status === 'streaming') {
+        streamSignal.set({
+          ...streamSignal(),
+          status: 'error',
+          errorMessage: 'Model took too long to respond',
+          isSlowHint: false,
+        });
+        this.checkBothComplete();
+      }
+    }, MODEL_TIMEOUT_MS);
+
+    if (key === 'model1') {
+      this.model1SlowTimeout = slowTimeout;
+      this.model1Timeout = hardTimeout;
+    } else {
+      this.model2SlowTimeout = slowTimeout;
+      this.model2Timeout = hardTimeout;
+    }
+  }
+
+  private clearTimeouts(key: 'model1' | 'model2'): void {
+    if (key === 'model1') {
+      clearTimeout(this.model1SlowTimeout);
+      clearTimeout(this.model1Timeout);
+    } else {
+      clearTimeout(this.model2SlowTimeout);
+      clearTimeout(this.model2Timeout);
+    }
+  }
+
+  private cleanupStreams(): void {
+    this.model1Sub?.unsubscribe();
+    this.model2Sub?.unsubscribe();
+    this.clearTimeouts('model1');
+    this.clearTimeouts('model2');
+  }
+}

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -58,6 +58,9 @@ export class BattleStateService {
   readonly promptUsesRemaining = signal(0);
   readonly selectedOutcome = signal<BattleEvaluationOutcome | null>(null);
 
+  readonly promptUseLimit = this.config.battle.promptUseLimit;
+  readonly promptUseDots = Array.from({ length: this.promptUseLimit }, (_, i) => i + 1);
+
   // Gates transition to voting/error phase
   readonly bothComplete = computed(() => {
     const s1 = this.model1Stream().status;
@@ -74,12 +77,19 @@ export class BattleStateService {
 
   readonly canReuse = computed(() => this.lastPrompt() !== null && this.promptUsesRemaining() > 0);
 
-  readonly model1DisplayName = computed(() =>
-    this.phase() === 'reveal' ? (this.model1()?.name ?? 'Model A') : 'Model A',
+  readonly completedMatches = computed(
+    () => this.config.battle.promptUseLimit - this.promptUsesRemaining(),
   );
 
-  readonly model2DisplayName = computed(() =>
-    this.phase() === 'reveal' ? (this.model2()?.name ?? 'Model B') : 'Model B',
+  // On reveal, promptUsesRemaining already decremented so completedMatches is accurate.
+  // During active phases, add 1 to show the in-progress match number.
+  readonly currentMatch = computed(() => {
+    const completed = this.completedMatches();
+    return this.phase() === 'reveal' ? completed : completed + 1;
+  });
+
+  readonly allMatchesComplete = computed(
+    () => this.completedMatches() >= this.config.battle.promptUseLimit,
   );
 
   private model1Sub?: Subscription;

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -40,14 +40,18 @@ export class BattleStateService {
   readonly model1Stream = signal<ModelStreamState>({ ...INITIAL_STREAM_STATE });
   readonly model2Stream = signal<ModelStreamState>({ ...INITIAL_STREAM_STATE });
 
-  // Prompt reuse tracking
+  // Prompt reuse tracking — initialPrompt is the first question (used for "Same Question New Matchup"),
+  // lastPrompt is the most recent submission (may be a follow-up).
+  readonly initialPrompt = signal<string | null>(null);
   readonly lastPrompt = signal<string | null>(null);
   readonly promptUsesRemaining = signal(0);
   readonly promptUseLimit = this.config.battle.promptUseLimit;
   readonly promptLengthLimit = this.config.battle.promptLengthLimit;
   private readonly roundLimit = this.config.battle.roundLimit;
   readonly promptUseDots = Array.from({ length: this.promptUseLimit }, (_, i) => i + 1);
-  readonly canReuse = computed(() => this.lastPrompt() !== null && this.promptUsesRemaining() > 0);
+  readonly canReuse = computed(
+    () => this.initialPrompt() !== null && this.promptUsesRemaining() > 0,
+  );
   readonly completedMatches = computed(
     () => this.config.battle.promptUseLimit - this.promptUsesRemaining(),
   );
@@ -83,32 +87,14 @@ export class BattleStateService {
 
   async submitPrompt(prompt: string): Promise<void> {
     if (!this.isBrowser) return;
-
-    // Reset reuse budget for a new prompt; preserve remaining uses for the same prompt
-    const isNewPrompt = prompt !== this.lastPrompt();
-    if (isNewPrompt) {
-      this.promptUsesRemaining.set(this.config.battle.promptUseLimit);
-    }
+    this.initialPrompt.set(prompt);
     this.lastPrompt.set(prompt);
+    this.promptUsesRemaining.set(this.config.battle.promptUseLimit);
     this.selectedOutcome.set(null);
 
-    // If a battle already exists, add a new round (follow-up question, same LLMs)
-    const existingBattle = this.battleId();
-    const model1 = this.model1();
-    const model2 = this.model2();
-    if (existingBattle && model1 && model2) {
-      this.prepareStreams(prompt);
-      try {
-        await this.createRoundAndStream(existingBattle, model1.id, model2.id, prompt);
-      } catch (err) {
-        console.error('Failed to create follow-up round', err);
-        this.setStreamError('Something went wrong', true);
-      }
-      return;
-    }
+    const userMsg = { role: 'user' as const, content: prompt };
+    this.resetStreams([userMsg], [userMsg]);
 
-    // No existing battle — create a new one (new match, new LLM pair)
-    this.prepareStreams(prompt);
     let battle;
     try {
       battle = await firstValueFrom(this.battleApi.createBattle({ title: prompt.slice(0, 50) }));
@@ -129,7 +115,63 @@ export class BattleStateService {
     }
   }
 
-  // Retry after error — creates a new round in the same battle with the same models
+  async submitFollowUp(prompt: string): Promise<void> {
+    const battleId = this.battleId();
+    const model1 = this.model1();
+    const model2 = this.model2();
+    if (!battleId || !model1 || !model2) return;
+
+    this.lastPrompt.set(prompt);
+    this.selectedOutcome.set(null);
+
+    const userMsg = { role: 'user' as const, content: prompt };
+    this.resetStreams(
+      [...this.model1Stream().messages, userMsg],
+      [...this.model2Stream().messages, userMsg],
+    );
+    try {
+      await this.createRoundAndStream(battleId, model1.id, model2.id, prompt);
+    } catch (err) {
+      console.error('Failed to create follow-up round', err);
+      this.setStreamError('Something went wrong', true);
+    }
+  }
+
+  async newMatchup(): Promise<void> {
+    const prompt = this.initialPrompt();
+    if (!prompt || this.promptUsesRemaining() <= 0) return;
+
+    this.battleId.set(null);
+    this.roundId.set(null);
+    this.model1.set(null);
+    this.model2.set(null);
+    this.completedRounds = 0;
+    this.lastPrompt.set(prompt);
+    this.selectedOutcome.set(null);
+
+    const userMsg = { role: 'user' as const, content: prompt };
+    this.resetStreams([userMsg], [userMsg]);
+
+    let battle;
+    try {
+      battle = await firstValueFrom(this.battleApi.createBattle({ title: prompt.slice(0, 50) }));
+      if (!battle) throw new Error('Failed to create battle');
+    } catch (err) {
+      console.error('Failed to create matchup', err);
+      this.setStreamError('Something went wrong. Try a new battle', false);
+      return;
+    }
+    this.battleId.set(battle.id);
+    this.model1.set(battle.model1);
+    this.model2.set(battle.model2);
+    try {
+      await this.createRoundAndStream(battle.id, battle.model1.id, battle.model2.id, prompt);
+    } catch (err) {
+      console.error('Failed to start streaming', err);
+      this.setStreamError('Something went wrong', true);
+    }
+  }
+
   async retry(): Promise<void> {
     const prompt = this.lastPrompt();
     const battleId = this.battleId();
@@ -137,7 +179,7 @@ export class BattleStateService {
     const model2 = this.model2();
     if (!prompt || !battleId || !model1 || !model2) return;
 
-    this.prepareStreams(prompt);
+    this.resetStreams(this.model1Stream().messages, this.model2Stream().messages);
     try {
       await this.createRoundAndStream(battleId, model1.id, model2.id, prompt);
     } catch (err) {
@@ -154,40 +196,21 @@ export class BattleStateService {
     try {
       await firstValueFrom(this.battleApi.createBattleEvaluation(battleId, { outcome }));
     } catch {
-      // On failure, stay in voting phase so the user can retry
       this.isVoting = false;
       return;
     }
 
-    // Record outcome, decrement budget, advance to reveal
     this.selectedOutcome.set(outcome);
     this.promptUsesRemaining.update((n) => Math.max(0, n - 1));
     this.phase.set('reveal');
     this.isVoting = false;
 
-    // Best-effort: record battle end time (non-critical, ignore failures)
     firstValueFrom(this.battleApi.updateBattle(battleId, { endedAt: new Date().toISOString() }))
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       .catch(() => {});
   }
 
-  async newBattle(prompt?: string): Promise<void> {
-    // Cancel active streams and reset stream state, preserving the prompt reuse budget
-    this.cleanupStreams();
-    this.completedRounds = 0;
-    this.model1Stream.set({ ...INITIAL_STREAM_STATE });
-    this.model2Stream.set({ ...INITIAL_STREAM_STATE });
-    this.selectedOutcome.set(null);
-
-    // Re-submit with the provided prompt or fall back to the last prompt
-    const text = prompt ?? this.lastPrompt();
-    if (text) {
-      await this.submitPrompt(text);
-    }
-  }
-
   reset(): void {
-    // Full teardown — cancel streams and return to landing state
     this.cleanupStreams();
     this.completedRounds = 0;
     this.phase.set('landing');
@@ -197,18 +220,20 @@ export class BattleStateService {
     this.model2.set(null);
     this.model1Stream.set({ ...INITIAL_STREAM_STATE });
     this.model2Stream.set({ ...INITIAL_STREAM_STATE });
+    this.initialPrompt.set(null);
     this.lastPrompt.set(null);
     this.promptUsesRemaining.set(0);
     this.selectedOutcome.set(null);
   }
 
-  // Shared setup — reset streams with user message and transition to creating
-  private prepareStreams(prompt: string): void {
+  private resetStreams(
+    m1Messages: { role: 'user' | 'assistant'; content: string }[],
+    m2Messages: { role: 'user' | 'assistant'; content: string }[],
+  ): void {
     this.cleanupStreams();
     this.phase.set('creating');
-    const userMsg = { role: 'user' as const, content: prompt };
-    this.model1Stream.set({ ...INITIAL_STREAM_STATE, messages: [userMsg], status: 'waiting' });
-    this.model2Stream.set({ ...INITIAL_STREAM_STATE, messages: [userMsg], status: 'waiting' });
+    this.model1Stream.set({ ...INITIAL_STREAM_STATE, messages: m1Messages, status: 'waiting' });
+    this.model2Stream.set({ ...INITIAL_STREAM_STATE, messages: m2Messages, status: 'waiting' });
   }
 
   // Shared round creation + streaming kickoff

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -30,7 +30,7 @@ export class BattleStateService {
   // Battle and round identifiers
   readonly battleId = signal<string | null>(null);
   readonly roundId = signal<string | null>(null);
-  readonly roundNumber = signal(0);
+  private completedRounds = 0;
 
   // Competing models
   readonly model1 = signal<Model | null>(null);
@@ -45,6 +45,7 @@ export class BattleStateService {
   readonly promptUsesRemaining = signal(0);
   readonly promptUseLimit = this.config.battle.promptUseLimit;
   readonly promptLengthLimit = this.config.battle.promptLengthLimit;
+  private readonly roundLimit = this.config.battle.roundLimit;
   readonly promptUseDots = Array.from({ length: this.promptUseLimit }, (_, i) => i + 1);
   readonly canReuse = computed(() => this.lastPrompt() !== null && this.promptUsesRemaining() > 0);
   readonly completedMatches = computed(
@@ -91,7 +92,21 @@ export class BattleStateService {
     this.lastPrompt.set(prompt);
     this.selectedOutcome.set(null);
 
-    // Create a new battle (new match, new model pair)
+    // If a battle already exists, add a new round (follow-up question, same LLMs)
+    const existingBattle = this.battleId();
+    const model1 = this.model1();
+    const model2 = this.model2();
+    if (existingBattle && model1 && model2) {
+      this.prepareStreams(prompt);
+      try {
+        await this.createRoundAndStream(existingBattle, model1.id, model2.id, prompt);
+      } catch {
+        this.setStreamError('Something went wrong', true);
+      }
+      return;
+    }
+
+    // No existing battle — create a new one (new match, new LLM pair)
     this.prepareStreams(prompt);
     let battle;
     try {
@@ -155,6 +170,7 @@ export class BattleStateService {
   async newBattle(prompt?: string): Promise<void> {
     // Cancel active streams and reset stream state, preserving the prompt reuse budget
     this.cleanupStreams();
+    this.completedRounds = 0;
     this.model1Stream.set({ ...INITIAL_STREAM_STATE });
     this.model2Stream.set({ ...INITIAL_STREAM_STATE });
     this.selectedOutcome.set(null);
@@ -169,10 +185,10 @@ export class BattleStateService {
   reset(): void {
     // Full teardown — cancel streams and return to landing state
     this.cleanupStreams();
+    this.completedRounds = 0;
     this.phase.set('landing');
     this.battleId.set(null);
     this.roundId.set(null);
-    this.roundNumber.set(0);
     this.model1.set(null);
     this.model2.set(null);
     this.model1Stream.set({ ...INITIAL_STREAM_STATE });
@@ -198,6 +214,13 @@ export class BattleStateService {
     model2Id: string,
     prompt: string,
   ): Promise<void> {
+    if (this.completedRounds >= this.roundLimit) {
+      this.setStreamError(
+        "You've reached the limit for this battle. Vote or start a new battle",
+        false,
+      );
+      return;
+    }
     const round = await firstValueFrom(
       this.battleApi.createBattleRound(battleId, {
         promptMessage: { role: 'user', content: prompt },
@@ -205,7 +228,6 @@ export class BattleStateService {
     );
     if (!round) throw new Error('Failed to create round');
     this.roundId.set(round.id);
-    this.roundNumber.set(round.roundNumber);
     this.startStreaming(battleId, round.id, model1Id, model2Id);
   }
 
@@ -314,6 +336,7 @@ export class BattleStateService {
       if (s1 === 'error' || s2 === 'error') {
         this.phase.set('error');
       } else {
+        this.completedRounds++;
         this.phase.set('voting');
       }
     }

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -70,8 +70,20 @@ export class BattleStateService {
 
     this.phase.set('creating');
     this.selectedOutcome.set(null);
-    this.model1Stream.set({ ...INITIAL_STREAM_STATE, status: 'waiting' });
-    this.model2Stream.set({ ...INITIAL_STREAM_STATE, status: 'waiting' });
+
+    const userMsg = { role: 'user' as const, content: prompt };
+    const prev1 = this.model1Stream().messages;
+    const prev2 = this.model2Stream().messages;
+    this.model1Stream.set({
+      ...INITIAL_STREAM_STATE,
+      messages: [...prev1, userMsg],
+      status: 'waiting',
+    });
+    this.model2Stream.set({
+      ...INITIAL_STREAM_STATE,
+      messages: [...prev2, userMsg],
+      status: 'waiting',
+    });
 
     try {
       const battle = await this.battleApi.createBattle({ title: prompt.slice(0, 50) }).toPromise();
@@ -176,9 +188,14 @@ export class BattleStateService {
             isSlowHint: false,
           });
         } else if (chunk.status === 'complete') {
+          const current = streamSignal();
           streamSignal.set({
-            ...streamSignal(),
-            text: accumulatedText,
+            ...current,
+            messages: [
+              ...current.messages,
+              { role: 'assistant' as const, content: accumulatedText },
+            ],
+            text: '',
             status: 'complete',
             finishReason: chunk.finishReason ?? null,
             isSlowHint: false,

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -59,6 +59,7 @@ export class BattleStateService {
   readonly selectedOutcome = signal<BattleEvaluationOutcome | null>(null);
 
   readonly promptUseLimit = this.config.battle.promptUseLimit;
+  readonly promptLengthLimit = this.config.battle.promptLengthLimit;
   readonly promptUseDots = Array.from({ length: this.promptUseLimit }, (_, i) => i + 1);
 
   // Gates transition to voting/error phase

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -11,6 +11,30 @@ import { BattlePhase, INITIAL_STREAM_STATE, ModelStreamState } from '../battle.t
 import { SLOW_MODEL_THRESHOLD_MS, MODEL_TIMEOUT_MS } from '../battle.constants';
 import { BattleStreamService } from './battle-stream.service';
 
+/**
+ * BattleStateService — orchestrates the battle lifecycle.
+ *
+ * Phase state machine:
+ *   landing  --[submitPrompt]--> creating
+ *   creating --[API success]---> streaming
+ *   creating --[API error]-----> error
+ *   streaming -[both complete]-> voting   (no model errored)
+ *   streaming -[both complete]-> error    (any model errored)
+ *   voting   --[submitVote]----> reveal
+ *   reveal   --[newBattle]-----> creating ("same question new matchup")
+ *   reveal   --[reset]---------> landing  ("new battle")
+ *   error    --[newBattle]-----> creating
+ *   error    --[reset]---------> landing
+ *
+ * Dot rail (same-question matchup tracking):
+ *   promptUsesRemaining decrements on each vote. Budget resets only
+ *   when the user types a genuinely new prompt. Errors don't decrement.
+ *
+ * Timeouts (two-tier):
+ *   SLOW_MODEL_THRESHOLD_MS - soft UI hint ("Taking longer than expected")
+ *   MODEL_TIMEOUT_MS        - hard cutoff (forces error status)
+ *   Both clear on first received chunk.
+ */
 @Injectable()
 export class BattleStateService {
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
@@ -34,12 +58,14 @@ export class BattleStateService {
   readonly promptUsesRemaining = signal(0);
   readonly selectedOutcome = signal<BattleEvaluationOutcome | null>(null);
 
+  // Gates transition to voting/error phase
   readonly bothComplete = computed(() => {
     const s1 = this.model1Stream().status;
     const s2 = this.model2Stream().status;
     return (s1 === 'complete' || s1 === 'error') && (s2 === 'complete' || s2 === 'error');
   });
 
+  // Voting allowed when at least one model succeeded (both-error goes to error phase instead)
   readonly canVote = computed(
     () =>
       this.phase() === 'voting' &&
@@ -66,6 +92,7 @@ export class BattleStateService {
   async submitPrompt(prompt: string): Promise<void> {
     if (!this.isBrowser) return;
 
+    // First use of a prompt gets full reuse budget; same prompt does not reset it
     const isNewPrompt = prompt !== this.lastPrompt();
     if (isNewPrompt) {
       this.promptUsesRemaining.set(this.config.battle.promptUseLimit);
@@ -75,6 +102,7 @@ export class BattleStateService {
     this.phase.set('creating');
     this.selectedOutcome.set(null);
 
+    // Carry forward chat history so follow-up rounds show prior messages
     const userMsg = { role: 'user' as const, content: prompt };
     const prev1 = this.model1Stream().messages;
     const prev2 = this.model2Stream().messages;
@@ -147,12 +175,13 @@ export class BattleStateService {
     this.phase.set('reveal');
     this.isVoting = false;
 
-    // Best-effort: record battle end time (may race with async validation)
+    // Best-effort: record battle end time (backend validation may update the battle concurrently)
     firstValueFrom(this.battleApi.updateBattle(battleId, { endedAt: new Date().toISOString() }))
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       .catch(() => {});
   }
 
+  // "Same question new matchup": reset streams but keep lastPrompt so reuse budget continues
   async newBattle(prompt?: string): Promise<void> {
     this.cleanupStreams();
     this.model1Stream.set({ ...INITIAL_STREAM_STATE });
@@ -205,6 +234,7 @@ export class BattleStateService {
 
     return this.streamService.streamCompletion(battleId, roundId, modelId).subscribe({
       next: (chunk) => {
+        // First chunk arrived — cancel slow/timeout timers
         this.clearTimeouts(streamSignal === this.model1Stream ? 'model1' : 'model2');
 
         if (chunk.status === 'streaming' && chunk.content) {
@@ -216,6 +246,7 @@ export class BattleStateService {
             isSlowHint: false,
           });
         } else if (chunk.status === 'complete') {
+          // Move accumulated text into messages array and clear streaming text
           const current = streamSignal();
           streamSignal.set({
             ...current,

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -111,25 +111,38 @@ export class BattleStateService {
     }
   }
 
+  private isVoting = false;
+
   async submitVote(outcome: BattleEvaluationOutcome): Promise<void> {
     const battleId = this.battleId();
-    if (!battleId) return;
+    if (!battleId || this.isVoting) return;
 
+    this.isVoting = true;
     try {
       await this.battleApi.createBattleEvaluation(battleId, { outcome }).toPromise();
-      await this.battleApi
-        .updateBattle(battleId, { endedAt: new Date().toISOString() })
-        .toPromise();
-      this.selectedOutcome.set(outcome);
-      this.promptUsesRemaining.update((n) => Math.max(0, n - 1));
-      this.phase.set('reveal');
     } catch {
-      // Vote failed — stay in voting phase, user can retry
+      this.isVoting = false;
+      return; // Evaluation failed — stay in voting phase
     }
+
+    this.selectedOutcome.set(outcome);
+    this.promptUsesRemaining.update((n) => Math.max(0, n - 1));
+    this.phase.set('reveal');
+    this.isVoting = false;
+
+    // Best-effort: record battle end time (may race with async validation)
+    this.battleApi
+      .updateBattle(battleId, { endedAt: new Date().toISOString() })
+      .toPromise()
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      .catch(() => {});
   }
 
   async newBattle(prompt?: string): Promise<void> {
     this.cleanupStreams();
+    this.model1Stream.set({ ...INITIAL_STREAM_STATE });
+    this.model2Stream.set({ ...INITIAL_STREAM_STATE });
+    this.selectedOutcome.set(null);
     const text = prompt ?? this.lastPrompt();
     if (text) {
       await this.submitPrompt(text);

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
@@ -78,9 +78,7 @@
   @if (phase() === 'reveal' || phase() === 'error') {
     <div class="nudge">
       @if (canReuse()) {
-        <button class="nb go" (click)="samePrompt.emit()">
-          Same Prompt ({{ promptUsesRemaining() }} remaining) &rarr;
-        </button>
+        <button class="nb go" (click)="samePrompt.emit()">Same Question New Matchup</button>
       }
       <button class="nb sec" (click)="newBattle.emit()">New Battle</button>
     </div>

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
@@ -5,20 +5,72 @@
         class="vb left"
         [disabled]="!canVote()"
         (click)="voteModel1()"
+        (mouseenter)="hoverSide.emit('model1')"
+        (mouseleave)="hoverSide.emit(null)"
         aria-label="Vote Model A as better"
       >
-        Left is Better 👈
+        <svg
+          class="vb-icon flip"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="m11 19-6-6" />
+          <path d="m5 21-2-2" />
+          <path d="m8 16-4 4" />
+          <path d="M9.5 17.5 21 6V3h-3L6.5 14.5" />
+        </svg>
+        A is Better
       </button>
-      <button class="vb" [disabled]="!canVote()" (click)="voteTie()" aria-label="Vote tie">
-        🤝 Tie
+      <button
+        class="vb tie"
+        [disabled]="!canVote()"
+        (click)="voteTie()"
+        (mouseenter)="hoverSide.emit('tie')"
+        (mouseleave)="hoverSide.emit(null)"
+        aria-label="Vote tie"
+      >
+        <svg
+          class="vb-icon"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path
+            d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+          />
+        </svg>
+        Tie
       </button>
       <button
         class="vb right"
         [disabled]="!canVote()"
         (click)="voteModel2()"
+        (mouseenter)="hoverSide.emit('model2')"
+        (mouseleave)="hoverSide.emit(null)"
         aria-label="Vote Model B as better"
       >
-        👉 Right is Better
+        B is Better
+        <svg
+          class="vb-icon"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="m11 19-6-6" />
+          <path d="m5 21-2-2" />
+          <path d="m8 16-4 4" />
+          <path d="M9.5 17.5 21 6V3h-3L6.5 14.5" />
+        </svg>
       </button>
     </div>
   }

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
@@ -1,0 +1,48 @@
+<div class="voting-bar">
+  @if (phase() === 'voting') {
+    <div class="vote-buttons">
+      <p-button
+        label="Left is Better"
+        icon="pi pi-arrow-left"
+        [disabled]="!canVote()"
+        (onClick)="voteModel1()"
+        aria-label="Vote Model A as better"
+        severity="secondary"
+        [outlined]="true"
+      />
+      <p-button
+        label="Tie"
+        icon="pi pi-thumbs-up"
+        [disabled]="!canVote()"
+        (onClick)="voteTie()"
+        aria-label="Vote tie"
+        severity="secondary"
+        [outlined]="true"
+      />
+      <p-button
+        label="Right is Better"
+        icon="pi pi-arrow-right"
+        iconPos="right"
+        [disabled]="!canVote()"
+        (onClick)="voteModel2()"
+        aria-label="Vote Model B as better"
+        severity="secondary"
+        [outlined]="true"
+      />
+    </div>
+  }
+
+  @if (phase() === 'reveal' || phase() === 'error') {
+    <div class="nudge-buttons">
+      @if (canReuse()) {
+        <p-button
+          [label]="'Same Prompt (' + promptUsesRemaining() + ' remaining)'"
+          (onClick)="samePrompt.emit()"
+          severity="secondary"
+          [outlined]="true"
+        />
+      }
+      <p-button label="New Battle" (onClick)="newBattle.emit()" />
+    </div>
+  }
+</div>

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
@@ -1,48 +1,36 @@
-<div class="voting-bar">
+<div class="abar">
   @if (phase() === 'voting') {
-    <div class="vote-buttons">
-      <p-button
-        label="Left is Better"
-        icon="pi pi-arrow-left"
+    <div class="votes">
+      <button
+        class="vb left"
         [disabled]="!canVote()"
-        (onClick)="voteModel1()"
+        (click)="voteModel1()"
         aria-label="Vote Model A as better"
-        severity="secondary"
-        [outlined]="true"
-      />
-      <p-button
-        label="Tie"
-        icon="pi pi-thumbs-up"
+      >
+        Left is Better 👈
+      </button>
+      <button class="vb" [disabled]="!canVote()" (click)="voteTie()" aria-label="Vote tie">
+        🤝 Tie
+      </button>
+      <button
+        class="vb right"
         [disabled]="!canVote()"
-        (onClick)="voteTie()"
-        aria-label="Vote tie"
-        severity="secondary"
-        [outlined]="true"
-      />
-      <p-button
-        label="Right is Better"
-        icon="pi pi-arrow-right"
-        iconPos="right"
-        [disabled]="!canVote()"
-        (onClick)="voteModel2()"
+        (click)="voteModel2()"
         aria-label="Vote Model B as better"
-        severity="secondary"
-        [outlined]="true"
-      />
+      >
+        👉 Right is Better
+      </button>
     </div>
   }
 
   @if (phase() === 'reveal' || phase() === 'error') {
-    <div class="nudge-buttons">
+    <div class="nudge">
       @if (canReuse()) {
-        <p-button
-          [label]="'Same Prompt (' + promptUsesRemaining() + ' remaining)'"
-          (onClick)="samePrompt.emit()"
-          severity="secondary"
-          [outlined]="true"
-        />
+        <button class="nb go" (click)="samePrompt.emit()">
+          Same Prompt ({{ promptUsesRemaining() }} remaining) &rarr;
+        </button>
       }
-      <p-button label="New Battle" (onClick)="newBattle.emit()" />
+      <button class="nb sec" (click)="newBattle.emit()">New Battle</button>
     </div>
   }
 </div>

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
@@ -78,9 +78,9 @@
   @if (phase() === 'reveal' || phase() === 'error') {
     <div class="nudge">
       @if (canReuse()) {
-        <button class="nb go" (click)="samePrompt.emit()">Same Question New Matchup</button>
+        <p-button label="Same Question New Matchup" (onClick)="samePrompt.emit()" />
       }
-      <button class="nb sec" (click)="newBattle.emit()">New Battle</button>
+      <p-button label="New Battle" severity="secondary" (onClick)="newBattle.emit()" />
     </div>
   }
 </div>

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
@@ -1,21 +1,103 @@
 :host {
   display: block;
+  flex-shrink: 0;
 }
 
-.voting-bar {
-  padding: 1rem 0;
-}
-
-.vote-buttons {
+.abar {
   display: flex;
+  flex-direction: column;
+  align-items: center;
   justify-content: center;
-  gap: 0.75rem;
-  flex-wrap: wrap;
+  min-height: 52px;
+  padding: 0.25rem 0;
+  gap: 0.5rem;
 }
 
-.nudge-buttons {
+.votes {
   display: flex;
-  justify-content: center;
-  gap: 0.75rem;
+  gap: 0.5rem;
   flex-wrap: wrap;
+  justify-content: center;
+}
+
+.vb {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 1.25rem;
+  border: 1px solid var(--p-surface-200);
+  border-radius: 100px;
+  background: var(--p-surface-100);
+  color: var(--p-surface-600);
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 520;
+  cursor: pointer;
+  transition: all 0.2s;
+  letter-spacing: -0.01em;
+
+  &:hover {
+    background: var(--p-surface-200);
+    border-color: var(--p-surface-300);
+    color: var(--p-text-color);
+    transform: translateY(-1px);
+  }
+
+  &.left:hover {
+    border-color: rgb(108 180 252 / 20%);
+    color: var(--p-blue-400);
+  }
+
+  &.right:hover {
+    border-color: rgb(180 156 250 / 20%);
+    color: var(--p-violet-400);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+}
+
+.nudge {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.nb {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 1.25rem;
+  border: 1px solid var(--p-surface-200);
+  border-radius: 100px;
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 520;
+  cursor: pointer;
+  transition: all 0.2s;
+  letter-spacing: -0.01em;
+
+  &.sec {
+    background: var(--p-surface-100);
+    color: var(--p-surface-600);
+
+    &:hover {
+      background: var(--p-surface-200);
+      color: var(--p-text-color);
+    }
+  }
+
+  &.go {
+    background: var(--p-primary-color);
+    border-color: var(--p-primary-color);
+    color: #fff;
+
+    &:hover {
+      background: var(--p-primary-500);
+      border-color: var(--p-primary-500);
+    }
+  }
 }

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
@@ -65,39 +65,3 @@
   flex-wrap: wrap;
   justify-content: center;
 }
-
-.nb {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-  padding: 0.5rem 1.25rem;
-  border: 1px solid var(--p-surface-200);
-  border-radius: 100px;
-  font: inherit;
-  font-size: var(--text-sm);
-  font-weight: 520;
-  cursor: pointer;
-  transition: all 0.2s;
-  letter-spacing: -0.01em;
-
-  &.sec {
-    background: var(--p-surface-100);
-    color: var(--p-surface-600);
-
-    &:hover {
-      background: var(--p-surface-200);
-      color: var(--p-text-color);
-    }
-  }
-
-  &.go {
-    background: var(--p-primary-color);
-    border-color: var(--p-primary-color);
-    color: #fff;
-
-    &:hover {
-      background: var(--p-primary-500);
-      border-color: var(--p-primary-500);
-    }
-  }
-}

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
@@ -43,19 +43,19 @@
     transform: translateY(-1px);
   }
 
-  &.left:hover {
-    border-color: rgb(108 180 252 / 20%);
-    color: var(--p-blue-400);
-  }
-
-  &.right:hover {
-    border-color: rgb(180 156 250 / 20%);
-    color: var(--p-violet-400);
-  }
-
   &:disabled {
     opacity: 0.5;
     pointer-events: none;
+  }
+}
+
+.vb-icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+
+  &.flip {
+    transform: scaleX(-1);
   }
 }
 

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
@@ -1,0 +1,21 @@
+:host {
+  display: block;
+}
+
+.voting-bar {
+  padding: 1rem 0;
+}
+
+.vote-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.nudge-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.spec.ts
@@ -1,0 +1,43 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { VotingBarComponent } from './voting-bar.component';
+
+describe('VotingBarComponent', () => {
+  let component: VotingBarComponent;
+  let fixture: ComponentFixture<VotingBarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [VotingBarComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(VotingBarComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('phase', 'voting');
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit model1 vote', () => {
+    const spy = jest.fn();
+    component.vote.subscribe(spy);
+    component.voteModel1();
+    expect(spy).toHaveBeenCalledWith('model1');
+  });
+
+  it('should emit tie vote', () => {
+    const spy = jest.fn();
+    component.vote.subscribe(spy);
+    component.voteTie();
+    expect(spy).toHaveBeenCalledWith('tie');
+  });
+
+  it('should emit model2 vote', () => {
+    const spy = jest.fn();
+    component.vote.subscribe(spy);
+    component.voteModel2();
+    expect(spy).toHaveBeenCalledWith('model2');
+  });
+});

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.ts
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.ts
@@ -1,10 +1,8 @@
 import { Component, input, output } from '@angular/core';
-import { ButtonModule } from 'primeng/button';
 import { BattleEvaluationOutcome } from '@sagebionetworks/bixarena/api-client';
 
 @Component({
   selector: 'bixarena-voting-bar',
-  imports: [ButtonModule],
   templateUrl: './voting-bar.component.html',
   styleUrl: './voting-bar.component.scss',
 })

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.ts
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.ts
@@ -1,16 +1,17 @@
 import { Component, input, output } from '@angular/core';
+import { ButtonModule } from 'primeng/button';
 import { BattleEvaluationOutcome } from '@sagebionetworks/bixarena/api-client';
 import { BattlePhase } from '../battle.types';
 
 @Component({
   selector: 'bixarena-voting-bar',
+  imports: [ButtonModule],
   templateUrl: './voting-bar.component.html',
   styleUrl: './voting-bar.component.scss',
 })
 export class VotingBarComponent {
   readonly canVote = input(false);
   readonly canReuse = input(false);
-  readonly promptUsesRemaining = input(0);
   readonly phase = input.required<BattlePhase>();
 
   readonly vote = output<BattleEvaluationOutcome>();

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.ts
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.ts
@@ -14,7 +14,7 @@ export class VotingBarComponent {
   readonly phase = input.required<BattlePhase>();
 
   readonly vote = output<BattleEvaluationOutcome>();
-  readonly hoverSide = output<'model1' | 'model2' | 'tie' | null>();
+  readonly hoverSide = output<BattleEvaluationOutcome | null>();
   readonly newBattle = output<void>();
   readonly samePrompt = output<void>();
 

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.ts
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.ts
@@ -1,5 +1,6 @@
 import { Component, input, output } from '@angular/core';
 import { BattleEvaluationOutcome } from '@sagebionetworks/bixarena/api-client';
+import { BattlePhase } from '../battle.types';
 
 @Component({
   selector: 'bixarena-voting-bar',
@@ -10,7 +11,7 @@ export class VotingBarComponent {
   readonly canVote = input(false);
   readonly canReuse = input(false);
   readonly promptUsesRemaining = input(0);
-  readonly phase = input.required<string>();
+  readonly phase = input.required<BattlePhase>();
 
   readonly vote = output<BattleEvaluationOutcome>();
   readonly hoverSide = output<'model1' | 'model2' | 'tie' | null>();

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.ts
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.ts
@@ -13,6 +13,7 @@ export class VotingBarComponent {
   readonly phase = input.required<string>();
 
   readonly vote = output<BattleEvaluationOutcome>();
+  readonly hoverSide = output<'model1' | 'model2' | 'tie' | null>();
   readonly newBattle = output<void>();
   readonly samePrompt = output<void>();
 

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.ts
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.ts
@@ -1,0 +1,32 @@
+import { Component, input, output } from '@angular/core';
+import { ButtonModule } from 'primeng/button';
+import { BattleEvaluationOutcome } from '@sagebionetworks/bixarena/api-client';
+
+@Component({
+  selector: 'bixarena-voting-bar',
+  imports: [ButtonModule],
+  templateUrl: './voting-bar.component.html',
+  styleUrl: './voting-bar.component.scss',
+})
+export class VotingBarComponent {
+  readonly canVote = input(false);
+  readonly canReuse = input(false);
+  readonly promptUsesRemaining = input(0);
+  readonly phase = input.required<string>();
+
+  readonly vote = output<BattleEvaluationOutcome>();
+  readonly newBattle = output<void>();
+  readonly samePrompt = output<void>();
+
+  voteModel1(): void {
+    this.vote.emit(BattleEvaluationOutcome.Model1);
+  }
+
+  voteTie(): void {
+    this.vote.emit(BattleEvaluationOutcome.Tie);
+  }
+
+  voteModel2(): void {
+    this.vote.emit(BattleEvaluationOutcome.Model2);
+  }
+}

--- a/libs/bixarena/config/src/lib/config.schema.ts
+++ b/libs/bixarena/config/src/lib/config.schema.ts
@@ -43,7 +43,7 @@ export const AppConfigSchema = BaseConfigSchema.extend({
 export type AppConfig = z.infer<typeof AppConfigSchema>;
 
 export interface RuntimeServerConfig extends AppConfig {
-  isPlatformServer: true;
+  isPlatformServer: boolean;
 }
 
 export function validateConfig(config: unknown): AppConfig {

--- a/libs/bixarena/config/src/lib/config.schema.ts
+++ b/libs/bixarena/config/src/lib/config.schema.ts
@@ -26,6 +26,12 @@ export const AppConfigSchema = BaseConfigSchema.extend({
     }),
   }),
 
+  battle: z.object({
+    promptLengthLimit: z.number().int().positive(),
+    roundLimit: z.number().int().positive(),
+    promptUseLimit: z.number().int().positive(),
+  }),
+
   analytics: z.object({
     googleTagManager: z.object({
       enabled: z.boolean(),

--- a/libs/bixarena/config/src/lib/config.service.ts
+++ b/libs/bixarena/config/src/lib/config.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
 import { ConfigLoaderService } from '@sagebionetworks/platform/config/angular';
 import { RuntimeServerConfig, validateConfig, AppConfig } from './config.schema';
 
@@ -18,7 +19,7 @@ export class ConfigService extends ConfigLoaderService<RuntimeServerConfig, AppC
     const loaded = await super.loadConfig(basePath);
     this.config = {
       ...(loaded as AppConfig),
-      isPlatformServer: true,
+      isPlatformServer: isPlatformServer(this.platformId),
     } as RuntimeServerConfig;
     return this.config;
   }

--- a/libs/bixarena/styles/src/lib/_general.scss
+++ b/libs/bixarena/styles/src/lib/_general.scss
@@ -19,6 +19,12 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+// Routed components inserted by router-outlet need to participate in flex layout.
+// Angular host elements default to display: inline, breaking the flex chain.
+main > * {
+  display: contents;
+}
+
 body::after {
   content: '';
   position: fixed;

--- a/libs/bixarena/styles/src/lib/_general.scss
+++ b/libs/bixarena/styles/src/lib/_general.scss
@@ -9,6 +9,10 @@
   box-sizing: border-box;
 }
 
+:focus {
+  outline: none;
+}
+
 body {
   margin: 0;
   background: var(--p-surface-0);
@@ -17,11 +21,6 @@ body {
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-:focus-visible {
-  outline: 2px solid var(--p-primary-color);
-  outline-offset: 2px;
 }
 
 // Routed components inserted by router-outlet need to participate in flex layout.

--- a/libs/bixarena/styles/src/lib/_general.scss
+++ b/libs/bixarena/styles/src/lib/_general.scss
@@ -19,6 +19,11 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+:focus-visible {
+  outline: 2px solid var(--p-primary-color);
+  outline-offset: 2px;
+}
+
 // Routed components inserted by router-outlet need to participate in flex layout.
 // Angular host elements default to display: inline, breaking the flex chain.
 main > * {

--- a/libs/bixarena/styles/src/lib/_overrides.scss
+++ b/libs/bixarena/styles/src/lib/_overrides.scss
@@ -1,13 +1,13 @@
 // PrimeNG component style overrides.
 @layer app {
   bixarena-nav .p-button {
-    padding: 0 0.875rem;
-    font-size: 0.75rem;
+    padding: 0 1rem;
+    font-size: var(--text-sm);
     font-family: inherit;
     font-variation-settings: 'wght' 540;
     letter-spacing: -0.01em;
     border-radius: var(--p-border-radius-md);
-    height: 1.875rem;
-    line-height: 1.875rem;
+    height: 2rem;
+    line-height: 2rem;
   }
 }

--- a/libs/bixarena/styles/src/lib/_overrides.scss
+++ b/libs/bixarena/styles/src/lib/_overrides.scss
@@ -10,4 +10,15 @@
     height: 2rem;
     line-height: 2rem;
   }
+
+  bixarena-voting-bar .nudge .p-button {
+    padding: 0.5rem 1.25rem;
+    font-size: var(--text-sm);
+    font-family: inherit;
+    font-variation-settings: 'wght' 520;
+    letter-spacing: -0.01em;
+    border-radius: 100px;
+    height: auto;
+    line-height: inherit;
+  }
 }

--- a/libs/bixarena/styles/src/lib/_utilities.scss
+++ b/libs/bixarena/styles/src/lib/_utilities.scss
@@ -4,4 +4,5 @@
   max-width: var(--max-width);
   margin-inline: auto;
   padding-inline: 2rem;
+  padding-bottom: 2rem;
 }

--- a/libs/bixarena/styles/src/lib/_variables.scss
+++ b/libs/bixarena/styles/src/lib/_variables.scss
@@ -1,17 +1,26 @@
 // rem: font sizes, padding, margins, max-widths
 // px: borders, box-shadows, border-radius
 :root {
-  --nav-height: 3.5rem;
+  --nav-height: 3.75rem;
   --max-width: 80rem;
   --font-serif: 'Playfair Display Variable', 'Playfair Display', 'Georgia', serif;
+
+  // Font size scale
+  --text-xs: 0.75rem;
+  --text-sm: 0.8125rem;
+  --text-md: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
 }
 
 html:not(.dark) {
   --nav-bg: rgb(253 252 251 / 80%);
+  --hover-bg: rgb(0 0 0 / 4%);
   --grain-opacity: 0.08;
 }
 
 html.dark {
   --nav-bg: rgb(27 24 24 / 80%);
+  --hover-bg: rgb(253 252 251 / 4%);
   --grain-opacity: 0.15;
 }

--- a/libs/bixarena/styles/src/lib/base-preset.ts
+++ b/libs/bixarena/styles/src/lib/base-preset.ts
@@ -18,17 +18,17 @@ export const BixArenaPreset = definePreset(Lara, {
   },
   semantic: {
     primary: {
-      50: '#fff7ed',
-      100: '#ffedd5',
-      200: '#ffddb3',
-      300: '#fdba74',
-      400: '#fb923c',
-      500: '#f97316',
-      600: '#ea580c',
-      700: '#c2410c',
-      800: '#9a3412',
-      900: '#7c2d12',
-      950: '#6c2e12',
+      50: '#ffedd5',
+      100: '#ffddb3',
+      200: '#fdba74',
+      300: '#fb923c',
+      400: '#f97316',
+      500: '#ea580c',
+      600: '#c2410c',
+      700: '#9a3412',
+      800: '#7c2d12',
+      900: '#6c2e12',
+      950: '#431407',
     },
     colorScheme: {
       light: {

--- a/libs/bixarena/ui/src/lib/footer/footer.component.scss
+++ b/libs/bixarena/ui/src/lib/footer/footer.component.scss
@@ -1,19 +1,19 @@
 @use 'shared/typescript/styles/src/shared-styles/variables' as shared;
 
 footer {
-  border-top: 1px solid var(--p-surface-100);
+  border-top: 1px solid var(--p-surface-200);
   padding: 1rem 2rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 0.75rem;
+  font-size: var(--text-sm);
   color: var(--p-text-muted-color);
   position: relative;
   z-index: 2;
 }
 
 a {
-  color: var(--p-surface-400);
+  color: var(--p-surface-500);
   text-decoration: none;
   transition: color 0.12s;
 

--- a/libs/bixarena/ui/src/lib/nav/nav.component.scss
+++ b/libs/bixarena/ui/src/lib/nav/nav.component.scss
@@ -3,9 +3,9 @@
   align-items: center;
   gap: 0;
   padding: 0 2rem;
-  height: 56px;
+  height: var(--nav-height);
   color: var(--p-text-color);
-  border-bottom: 1px solid var(--p-surface-100);
+  border-bottom: 1px solid var(--p-surface-200);
 }
 
 .brand {
@@ -14,7 +14,7 @@
   gap: 0.5rem;
   text-decoration: none;
   color: var(--p-text-color);
-  font-size: 0.9375rem;
+  font-size: var(--text-base);
   font-variation-settings: 'wght' 650;
   letter-spacing: -0.02em;
   margin-right: 2.5rem;
@@ -30,20 +30,20 @@
   a {
     display: inline-flex;
     align-items: center;
-    padding: 0.3125rem 0.75rem;
+    padding: 0.5rem 0.875rem;
     text-decoration: none;
     color: var(--p-surface-500);
-    font-size: 0.875rem;
+    font-size: var(--text-base);
     font-variation-settings: 'wght' 440;
     letter-spacing: -0.01em;
-    border-radius: 6px;
+    border-radius: var(--p-border-radius-md);
     transition:
       color 0.12s,
       background 0.12s;
 
     &:hover {
       color: var(--p-text-color);
-      background: var(--p-surface-100);
+      background: var(--hover-bg);
     }
 
     &.active {
@@ -62,22 +62,22 @@
 .divider {
   display: block;
   width: 1px;
-  height: 20px;
+  height: 1.1875rem;
   background: var(--p-surface-200);
   margin: 0 0.75rem;
   flex-shrink: 0;
 }
 
 .avatar {
-  width: 1.875rem;
-  height: 1.875rem;
+  width: 2rem;
+  height: 2rem;
   border-radius: 50%;
   background: var(--p-primary-500);
   color: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.6875rem;
+  font-size: var(--text-xs);
   font-weight: 600;
   letter-spacing: 0.02em;
   border: none;
@@ -107,10 +107,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: 2.125rem;
+  height: 2.125rem;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--p-border-radius-md);
   background: transparent;
   color: var(--p-surface-400);
   cursor: pointer;
@@ -120,6 +120,6 @@
 
   &:hover {
     color: var(--p-text-color);
-    background: var(--p-surface-100);
+    background: var(--hover-bg);
   }
 }


### PR DESCRIPTION
## Description

Implements the full battle page for Angular app — two anonymous LLMs respond to a user's biomedical question in real time, and the user votes on which response they trust more. Model identities are revealed after voting. Users can reuse the same prompt across multiple matchups (different LLM pairs) to stress-test a question.

## Changelog

- Add signal-based `BattleStateService` with phase transitions: `landing → creating → streaming → voting → reveal → error`
- Add `BattleStreamService` using native `fetch()` + `ReadableStream` for SSE streaming (Angular `HttpClient` buffers full responses, can't deliver tokens incrementally)
- Parallel streaming with independent per-model signal updates, rAF-batched for ~60fps rendering
- `isVoting` guard prevents double-vote submissions; separated try blocks isolate vote recording from non-critical `updateBattle` calls
- `completedRounds` counter enforces battle round limit from config; errored rounds are excluded from the count
- HTTP error mapping with `StreamHttpError` class with actionable user-facing hints and selective retryable button
- **Battle shell** — orchestrates landing vs active battle views, dot rail progress indicator (`Match N / 5`) and prompt composers
- **Model panel** — markdown rendering via `ngx-markdown`, auto-scroll with user-scroll detection (`isAutoScroll` / `isUserScrolled` flags prevent smooth-scroll false stops), streaming cursor (`▌`), thinking spinner, error display with retry
- **Voting bar** — sword/shield SVG icons, panel hover preview (mouseenter → emit hover side → both panels respond), PrimeNG `<p-button>` for nudge actions (consistent with nav Login button)
- **Prompt composer** — auto-growing textarea, `maxLength` from config, `isHot` computed for send button glow, Enter to submit / Shift+Enter for newline
- **Example prompts** — DNA helix SVG animation with specialty category nodes, click-to-load random prompts
- Add `battle` section to config schema: `promptLengthLimit`, `roundLimit`, `promptUseLimit`
- Shift primary color scale warmer, scale up font sizes to 16px base
- Global `:focus-visible` outline for keyboard navigation accessibility
- Global PrimeNG button overrides in `_overrides.scss` (nav + voting bar)
- `withEventReplay()` on `provideClientHydration()` — preserves user input during SSR→CSR hydration gap

## Battle States

1. **Landing** — user types a biomedical question or picks an example prompt
2. **Creating** — backend pairs two random anonymous LLMs
3. **Streaming** — both models stream responses side-by-side in real time
4. **Voting** — user votes A is Better / Tie / B is Better
   - If one model errors: user can retry it or vote or new battle depending on error
5. **Reveal** — model identities shown, then:
   - **Same Question New Matchup** — reuse the prompt with a fresh LLM pair
   - **New Battle** — reset to landing

## Follow-up work

- **Example prompts are static** — not yet wired to the backend - need to categorize the example prompt data first 
- **Auth UX** — unauthenticated users can currently type and hit submit (getting a 401). A login modal popup will be added in a future PR to intercept before submission
- **LaTeX rendering** — not yet supported; requires `katex` package + `[katex]` attribute on `<markdown>` tags
- **Battle Validation Animation** — display some animation during the battle validation process

## Preview

```bash
# Start full stack
bixarena-build-images && nx serve-detach bixarena-apex

# Remove Gradio app container
docker rm -f bixarena-app

# Start Angular app in dev mode
nx serve bixarena-app-angular
```

Access at http://127.0.0.1:8111/battle

### Example Prompt 

https://github.com/user-attachments/assets/775073c6-ac97-466d-9fa5-efa8aa3b8438


### Battle Flow

https://github.com/user-attachments/assets/27f28802-ebc1-4eb6-8737-b385677ace2b

