### PR TITLE
fix(devcontainer): fix devcontainer SBOM attestation and restore BuildKit provenance flag (SMR-695, SMR-740)

### DIFF
--- a/.github/workflows/build-and-push-devcontainer-image.yml
+++ b/.github/workflows/build-and-push-devcontainer-image.yml
@@ -107,6 +107,10 @@ jobs:
           # devcontainer.json used to build the image.
           export DEVCONTAINER_VERSION="${GITHUB_SHA}"
 
+          # Disable BuildKit's default provenance attestations
+          # See https://github.com/Sage-Bionetworks/sage-monorepo/issues/3904
+          export BUILDX_NO_DEFAULT_ATTESTATIONS=1
+
           # Convert the comma-separated list into the desired format
           images=""
           for image in ${IMAGES}; do
@@ -213,10 +217,10 @@ jobs:
           IMAGE: ${{ needs.build-and-push.outputs.image }}
           IMAGE_DIGEST: ${{ needs.build-and-push.outputs.image_digest }}
         run: |
-          # Skip uploading to the Rekor transparency log because the SBOM for
-          # this image is too large (~3.5MB) and consistently causes the Rekor
-          # POST to fail after retries. The attestation is still attached to the
-          # image in the OCI registry and remains verifiable.
+          # Skip uploading to the Rekor transparency log because the SBOM (~3.5MB)
+          # exceeds Rekor's entry size limit. The attestation is still signed via
+          # OIDC + Fulcio and attached to the image in GHCR, but will not appear
+          # in the public Rekor log. Note: cosign sign above still uses tlog.
           cosign attest --yes \
             --type spdxjson \
             --predicate sbom.spdx.json \
@@ -228,7 +232,7 @@ jobs:
           set -x
           # Redirect stdout to null to prevent the command from hanging randomly.
           # See https://github.com/sigstore/cosign/issues/3602
-          # Skip Rekor log verification since the attestation was created with
+          # --insecure-ignore-tlog required since the attestation was created with
           # --no-tlog-upload due to SBOM size constraints.
           cosign verify-attestation \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \

--- a/.github/workflows/build-and-push-devcontainer-image.yml
+++ b/.github/workflows/build-and-push-devcontainer-image.yml
@@ -213,9 +213,14 @@ jobs:
           IMAGE: ${{ needs.build-and-push.outputs.image }}
           IMAGE_DIGEST: ${{ needs.build-and-push.outputs.image_digest }}
         run: |
+          # Skip uploading to the Rekor transparency log because the SBOM for
+          # this image is too large (~3.5MB) and consistently causes the Rekor
+          # POST to fail after retries. The attestation is still attached to the
+          # image in the OCI registry and remains verifiable.
           cosign attest --yes \
             --type spdxjson \
             --predicate sbom.spdx.json \
+            --no-tlog-upload \
             ${IMAGE}@${IMAGE_DIGEST}
 
       - name: Verify the attestation
@@ -223,10 +228,13 @@ jobs:
           set -x
           # Redirect stdout to null to prevent the command from hanging randomly.
           # See https://github.com/sigstore/cosign/issues/3602
+          # Skip Rekor log verification since the attestation was created with
+          # --no-tlog-upload due to SBOM size constraints.
           cosign verify-attestation \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             --certificate-identity "https://github.com/${{ github.repository }}/${WORKFLOW_FILE}@${{ github.ref }}" \
             --type spdxjson \
+            --insecure-ignore-tlog \
             ${{ needs.build-and-push.outputs.image }} \
             1>/dev/null
 


### PR DESCRIPTION
## Description

The `Dev Container Image` workflow has been failing since Feb 2026 on the `cosign` job's "Create SBOM attestation with Cosign" step. The error was:

```
POST https://rekor.sigstore.dev/api/v1/log/entries giving up after 4 attempt(s)
```

The SBOM generated for the devcontainer image is ~3.5MB, which exceeds Rekor's entry size limit. Rekor closes the connection rather than returning a clean error, so cosign retries 4 times and fails. The image size itself did not change significantly, but the failure may be associated with the [Rekor v2 GA release](https://blog.sigstore.dev/rekor-v2-ga/), which appears to have introduced stricter size enforcement on the public `rekor.sigstore.dev` instance. This is a known pattern -- other projects (e.g. [ublue-os/bluefin](https://github.com/ublue-os/bluefin/pull/4274)) hit the same issue around the same time. See also: [sigstore/cosign#3599](https://github.com/sigstore/cosign/issues/3599).

Add `--no-tlog-upload` to `cosign attest` and `--insecure-ignore-tlog` to `cosign verify-attestation`. The SBOM is still signed and stored in GHCR alongside the image -- only the Rekor log entry is skipped, which nothing in this codebase consumes.

Also re-adds `BUILDX_NO_DEFAULT_ATTESTATIONS=1` to the build step, which was removed in f450aac33 but is still needed to prevent BuildKit from adding default provenance attestations (see [#3904](https://github.com/Sage-Bionetworks/sage-monorepo/issues/3904)).

## Related Issues

- [SMR-740](https://sagebionetworks.jira.com/browse/SMR-740)
- [SMR-695](https://sagebionetworks.jira.com/browse/SMR-695)

## Changelog

- Add `--no-tlog-upload` to `cosign attest` to skip Rekor upload for the SBOM attestation
- Add `--insecure-ignore-tlog` to `cosign verify-attestation` to match
- Re-add `BUILDX_NO_DEFAULT_ATTESTATIONS=1` to the build step


[SMR-740]: https://sagebionetworks.jira.com/browse/SMR-740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ