### PR TITLE
fix(devcontainer): use correct cosign flag to skip tlog upload (SMR-740)

### DIFF
--- a/.github/workflows/build-and-push-devcontainer-image.yml
+++ b/.github/workflows/build-and-push-devcontainer-image.yml
@@ -224,7 +224,7 @@ jobs:
           cosign attest --yes \
             --type spdxjson \
             --predicate sbom.spdx.json \
-            --no-tlog-upload \
+            --tlog-upload=false \  # valid in v2.x; deprecated/broken in v3 — see sigstore/cosign#4503
             ${IMAGE}@${IMAGE_DIGEST}
 
       - name: Verify the attestation
@@ -233,7 +233,7 @@ jobs:
           # Redirect stdout to null to prevent the command from hanging randomly.
           # See https://github.com/sigstore/cosign/issues/3602
           # --insecure-ignore-tlog required since the attestation was created with
-          # --no-tlog-upload due to SBOM size constraints.
+          # --tlog-upload=false due to SBOM size constraints.
           cosign verify-attestation \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             --certificate-identity "https://github.com/${{ github.repository }}/${WORKFLOW_FILE}@${{ github.ref }}" \

--- a/.github/workflows/build-and-push-devcontainer-image.yml
+++ b/.github/workflows/build-and-push-devcontainer-image.yml
@@ -221,10 +221,11 @@ jobs:
           # exceeds Rekor's entry size limit. The attestation is still signed via
           # OIDC + Fulcio and attached to the image in GHCR, but will not appear
           # in the public Rekor log. Note: cosign sign above still uses tlog.
+          # --tlog-upload=false is valid in v2.x; deprecated/broken in v3 — see sigstore/cosign#4503
           cosign attest --yes \
             --type spdxjson \
             --predicate sbom.spdx.json \
-            --tlog-upload=false \  # valid in v2.x; deprecated/broken in v3 — see sigstore/cosign#4503
+            --tlog-upload=false \
             ${IMAGE}@${IMAGE_DIGEST}
 
       - name: Verify the attestation


### PR DESCRIPTION
## Description

Fixes an incorrect flag used in the previous SMR-740 fix (#3982 -- see failing job [here](https://github.com/Sage-Bionetworks/sage-monorepo/actions/runs/24422660849/job/71350295728)). `--no-tlog-upload` was [removed in cosign v2.0.0](https://github.com/sigstore/cosign/blob/main/CHANGELOG.md) and does not exist in v2.4.1 (the version installed by `sigstore/cosign-installer@v3.7.0`); the correct flag is [`--tlog-upload=false`](https://github.com/sigstore/cosign/blob/v2.4.1/doc/cosign_attest.md).

Note: this flag was broken and later deprecated in cosign v3 ([#4503](https://github.com/sigstore/cosign/issues/4503), [#4458](https://github.com/sigstore/cosign/pull/4458)), but works correctly in v2.4.1.

## Related Issue

- [SMR-740](https://sagebionetworks.jira.com/browse/SMR-740)

## Changelog

- Replace `--no-tlog-upload` with `--tlog-upload=false` in `cosign attest`

[SMR-740]: https://sagebionetworks.jira.com/browse/SMR-740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ