### PR TITLE
refactor(explorers): restructure logger lib to GTM-style token+providers pattern

### DIFF
--- a/apps/agora/app/src/app/app.config.ts
+++ b/apps/agora/app/src/app/app.config.ts
@@ -18,7 +18,7 @@ import {
 import { BASE_PATH as API_CLIENT_BASE_PATH } from '@sagebionetworks/agora/api-client';
 import { configFactory, ConfigService } from '@sagebionetworks/agora/config';
 import { LoggerService, provideExplorersConfig } from '@sagebionetworks/explorers/services';
-import { LOGGER } from '@sagebionetworks/web-shared/angular/logger';
+import { provideLogger } from '@sagebionetworks/web-shared/angular/logger';
 import { httpErrorInterceptor } from '@sagebionetworks/explorers/util';
 import { BASE_PATH as SYNAPSE_API_CLIENT_BASE_PATH } from '@sagebionetworks/synapse/api-client';
 import * as Sentry from '@sentry/angular';
@@ -89,7 +89,7 @@ export const appConfig: ApplicationConfig = {
       }),
     ),
     { provide: UrlSerializer, useClass: CustomUrlSerializer },
-    { provide: LOGGER, useExisting: LoggerService },
+    provideLogger(LoggerService),
     MessageService,
     {
       provide: ErrorHandler,

--- a/apps/model-ad/app/src/app/app.config.ts
+++ b/apps/model-ad/app/src/app/app.config.ts
@@ -19,7 +19,7 @@ import { LoggerService, provideExplorersConfig } from '@sagebionetworks/explorer
 import { httpErrorInterceptor } from '@sagebionetworks/explorers/util';
 import { BASE_PATH as API_CLIENT_BASE_PATH } from '@sagebionetworks/model-ad/api-client';
 import { configFactory, ConfigService } from '@sagebionetworks/model-ad/config';
-import { LOGGER } from '@sagebionetworks/web-shared/angular/logger';
+import { provideLogger } from '@sagebionetworks/web-shared/angular/logger';
 import { provideGtmConfig, provideGtmId } from '@sagebionetworks/web-shared/angular/analytics/gtm';
 import { provideMarkdown } from 'ngx-markdown';
 import { MessageService } from 'primeng/api';
@@ -83,7 +83,7 @@ export const appConfig: ApplicationConfig = {
       }),
     ),
     { provide: UrlSerializer, useClass: CustomUrlSerializer },
-    { provide: LOGGER, useExisting: LoggerService },
+    provideLogger(LoggerService),
     MessageService,
     {
       provide: ErrorHandler,

--- a/libs/web-shared/angular/logger/src/index.ts
+++ b/libs/web-shared/angular/logger/src/index.ts
@@ -1,1 +1,2 @@
-export { Logger, LOGGER } from './lib/logger';
+export * from './lib/logger.token';
+export * from './lib/logger.providers';

--- a/libs/web-shared/angular/logger/src/lib/logger.providers.ts
+++ b/libs/web-shared/angular/logger/src/lib/logger.providers.ts
@@ -1,16 +1,6 @@
 import { Provider, Type } from '@angular/core';
 import { Logger, LOGGER } from './logger.token';
 
-export function provideLogger(implementation?: Type<Logger>): Provider {
-  if (implementation) {
-    return { provide: LOGGER, useExisting: implementation };
-  }
-  return {
-    provide: LOGGER,
-    useValue: {
-      log: (msg: string, data?: Record<string, unknown>) => console.log(msg, data),
-      warn: (msg: string, data?: Record<string, unknown>) => console.warn(msg, data),
-      error: (msg: string, err?: unknown) => console.error(msg, err),
-    },
-  };
+export function provideLogger(implementation: Type<Logger>): Provider {
+  return { provide: LOGGER, useExisting: implementation };
 }

--- a/libs/web-shared/angular/logger/src/lib/logger.providers.ts
+++ b/libs/web-shared/angular/logger/src/lib/logger.providers.ts
@@ -1,0 +1,16 @@
+import { Provider, Type } from '@angular/core';
+import { Logger, LOGGER } from './logger.token';
+
+export function provideLogger(implementation?: Type<Logger>): Provider {
+  if (implementation) {
+    return { provide: LOGGER, useExisting: implementation };
+  }
+  return {
+    provide: LOGGER,
+    useValue: {
+      log: (msg: string, data?: Record<string, unknown>) => console.log(msg, data),
+      warn: (msg: string, data?: Record<string, unknown>) => console.warn(msg, data),
+      error: (msg: string, err?: unknown) => console.error(msg, err),
+    },
+  };
+}

--- a/libs/web-shared/angular/logger/src/lib/logger.token.ts
+++ b/libs/web-shared/angular/logger/src/lib/logger.token.ts
@@ -1,10 +1,10 @@
 import { InjectionToken } from '@angular/core';
 
-export interface Logger {
+export type Logger = {
   log(message: string, data?: Record<string, unknown>): void;
   warn(message: string, data?: Record<string, unknown>): void;
   error(message: string, error?: unknown): void;
-}
+};
 
 export const LOGGER = new InjectionToken<Logger>('Logger', {
   providedIn: 'root',


### PR DESCRIPTION
## Description

Currently, `LocalStorageService` cannot be used in apps (like bixarena) using esbuild  `isolatedModules: true` with a build error, because the logger lib's `index.ts` re-exported Logger as `export { Logger }`, and an isolated compiler cannot tell whether Logger is a type or a runtime value, causing a hard build failure.

This PR refactors the logger lib to mirror the GTM lib's pattern - splitting the single `logger.ts` into `logger.token.ts` and `logger.providers.ts`. Declaring Logger as export type directly in the source file makes it unambiguous to any compiler. It also refactors to use new `provideLogger()` in agora and model-ad, so all apps wire the logger consistently.

## Related Issue

N/A

## Changelog

- Restructure logger lib into `logger.token.ts` and `logger.providers.ts` following the GTM lib pattern
- Replace `export { Logger, LOGGER }` with `export *` to fix isolatedModules: true build error
- Add `provideLogger(implementation?)` function for consistent app-level logger wiring
- Update agora and model-ad to use `provideLogger(LoggerService)` instead of raw provider objects

## Preview

1. Start the stack
```
nx serve-detach model-ad-apex
```
2. Force setItem to throw an error "quota exceeded"
```
localStorage.setItem = () => { throw new Error('quota exceeded') }
```

3. Trigger a localStorage write by changing a page size. In the browser console you should see:

<img width="1110" height="163" alt="Screenshot 2026-04-15 at 2 38 45 PM" src="https://github.com/user-attachments/assets/86c80709-33ba-4666-a64e-12071ae5b232" />

