### PR TITLE
feat(model-ad): add csv download to model details boxplots selector (MG-845)

### DIFF
--- a/libs/explorers/ui/src/lib/components/base-download-dom-image/base-download-dom-image.component.ts
+++ b/libs/explorers/ui/src/lib/components/base-download-dom-image/base-download-dom-image.component.ts
@@ -13,6 +13,7 @@ import { faDownload, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { ButtonModule } from 'primeng/button';
 import { Popover, PopoverModule } from 'primeng/popover';
 import { RadioButtonModule } from 'primeng/radiobutton';
+import { FILE_TYPE_CSV, FILE_TYPE_JPEG, FILE_TYPE_PNG } from './file-types';
 
 interface Type {
   value: string;
@@ -43,11 +44,11 @@ export class BaseDownloadDomImageComponent {
     const hasImage = this.hasImageDownload();
 
     const imageTypes: Type[] = [
-      { value: '.png', label: hasCsv ? 'PNG image' : 'PNG' },
-      { value: '.jpeg', label: hasCsv ? 'JPEG image' : 'JPEG' },
+      { value: FILE_TYPE_PNG, label: hasCsv ? 'PNG image' : 'PNG' },
+      { value: FILE_TYPE_JPEG, label: hasCsv ? 'JPEG image' : 'JPEG' },
     ];
 
-    const csvType: Type = { value: '.csv', label: 'CSV data' };
+    const csvType: Type = { value: FILE_TYPE_CSV, label: 'CSV data' };
 
     if (hasImage && hasCsv) return [...imageTypes, csvType];
     if (hasImage) return imageTypes;

--- a/libs/explorers/ui/src/lib/components/base-download-dom-image/file-types.ts
+++ b/libs/explorers/ui/src/lib/components/base-download-dom-image/file-types.ts
@@ -1,0 +1,3 @@
+export const FILE_TYPE_CSV = '.csv';
+export const FILE_TYPE_PNG = '.png';
+export const FILE_TYPE_JPEG = '.jpeg';

--- a/libs/explorers/ui/src/lib/components/download-dom-image/download-dom-image.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/download-dom-image/download-dom-image.component.spec.ts
@@ -24,29 +24,4 @@ describe('DownloadDomImageComponent', () => {
     const { instance } = await setup();
     expect(instance).toBeTruthy();
   });
-
-  it('arrayToCSVString should double quote and escape values', async () => {
-    const { instance } = await setup();
-    expect(instance.arrayToCSVString(['a', 'b', 'c'])).toBe('"a","b","c"\n');
-  });
-
-  it('arrayToCSVString should handle empty array', async () => {
-    const { instance } = await setup();
-    expect(instance.arrayToCSVString([])).toBe('\n');
-  });
-
-  it('arrayToCSVString should handle embedded quotes', async () => {
-    const { instance } = await setup();
-    expect(instance.arrayToCSVString(['a"b', 'c'])).toBe('"a""b","c"\n');
-  });
-
-  it('arrayToCSVString should handle commas and newlines', async () => {
-    const { instance } = await setup();
-    expect(instance.arrayToCSVString(['a,b', 'c\nd'])).toBe('"a,b","c\nd"\n');
-  });
-
-  it('arrayToCSVString should handle empty string', async () => {
-    const { instance } = await setup();
-    expect(instance.arrayToCSVString([''])).toBe('""\n');
-  });
 });

--- a/libs/explorers/ui/src/lib/components/download-dom-image/download-dom-image.component.ts
+++ b/libs/explorers/ui/src/lib/components/download-dom-image/download-dom-image.component.ts
@@ -2,6 +2,11 @@ import { Component, input } from '@angular/core';
 import { saveAs } from 'file-saver';
 import { BaseDownloadDomImageComponent } from '../base-download-dom-image/base-download-dom-image.component';
 import { captureDomToBlob, csvDataToString } from '@sagebionetworks/explorers/util';
+import {
+  FILE_TYPE_CSV,
+  FILE_TYPE_JPEG,
+  FILE_TYPE_PNG,
+} from '../base-download-dom-image/file-types';
 
 @Component({
   selector: 'explorers-download-dom-image',
@@ -20,10 +25,10 @@ export class DownloadDomImageComponent {
   downloadImagePaddingPx = input<number>();
 
   performDownload = async (fileType: string): Promise<void> => {
-    if (fileType === '.jpeg' || fileType === '.png') {
+    if (fileType === FILE_TYPE_JPEG || fileType === FILE_TYPE_PNG) {
       await this.downloadImage(fileType);
     }
-    if (fileType === '.csv') {
+    if (fileType === FILE_TYPE_CSV) {
       await this.downloadCsvData(fileType);
     }
   };

--- a/libs/explorers/ui/src/lib/components/download-dom-image/download-dom-image.component.ts
+++ b/libs/explorers/ui/src/lib/components/download-dom-image/download-dom-image.component.ts
@@ -1,7 +1,7 @@
 import { Component, input } from '@angular/core';
 import { saveAs } from 'file-saver';
 import { BaseDownloadDomImageComponent } from '../base-download-dom-image/base-download-dom-image.component';
-import { captureDomToBlob } from '@sagebionetworks/explorers/util';
+import { captureDomToBlob, csvDataToString } from '@sagebionetworks/explorers/util';
 
 @Component({
   selector: 'explorers-download-dom-image',
@@ -45,23 +45,7 @@ export class DownloadDomImageComponent {
       return;
     }
 
-    let csv = '';
-    for (const row of data) {
-      csv += this.arrayToCSVString(row);
-    }
-
-    const blob = new Blob([csv], { type: csvType });
+    const blob = new Blob([csvDataToString(data)], { type: csvType });
     saveAs(blob, this.filename() + fileType);
   };
-
-  arrayToCSVString(values: string[]): string {
-    return (
-      values
-        .map((value) => {
-          const escaped = value.replaceAll('"', '""');
-          return `"${escaped}"`;
-        })
-        .join(',') + '\n'
-    );
-  }
 }

--- a/libs/explorers/ui/src/lib/components/download-dom-images-zip/download-dom-images-zip.component.html
+++ b/libs/explorers/ui/src/lib/components/download-dom-images-zip/download-dom-images-zip.component.html
@@ -4,4 +4,6 @@
   modalButtonLabel="Download All"
   [performDownload]="performDownload"
   buttonLabel="Download All"
+  [hasCsvDownload]="hasCsvDownload()"
+  [hasImageDownload]="hasImageDownload()"
 />

--- a/libs/explorers/ui/src/lib/components/download-dom-images-zip/download-dom-images-zip.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/download-dom-images-zip/download-dom-images-zip.component.spec.ts
@@ -1,5 +1,8 @@
 import { render } from '@testing-library/angular';
+import { saveAs } from 'file-saver';
 import { DownloadDomImagesZipComponent } from './download-dom-images-zip.component';
+
+jest.mock('file-saver', () => ({ saveAs: jest.fn() }));
 
 describe('DownloadDomImagesZipComponent', () => {
   async function setup(inputs?: Partial<DownloadDomImagesZipComponent>) {
@@ -28,5 +31,36 @@ describe('DownloadDomImagesZipComponent', () => {
   it('should create', async () => {
     const { component } = await setup();
     expect(component.fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should create a zip of CSV files when fileType is .csv', async () => {
+    const mockElement = { offsetWidth: 100, offsetHeight: 100 } as HTMLElement;
+    const { fixture } = await render(DownloadDomImagesZipComponent, {
+      componentInputs: {
+        domFiles: [{ target: mockElement, filename: 'img-1' }],
+        filename: 'test-file',
+        csvFiles: [
+          {
+            filename: 'data-1',
+            data: [
+              ['age', 'sex', 'value'],
+              ['4 months', 'Female', '42.5'],
+            ],
+          },
+          {
+            filename: 'data-2',
+            data: [
+              ['age', 'sex', 'value'],
+              ['6 months', 'Male', '55.1'],
+            ],
+          },
+        ],
+        hasCsvDownload: true,
+      },
+    });
+
+    await fixture.componentInstance.performDownload('.csv');
+
+    expect(saveAs).toHaveBeenCalledWith(expect.any(Blob), 'test-file.zip');
   });
 });

--- a/libs/explorers/ui/src/lib/components/download-dom-images-zip/download-dom-images-zip.component.ts
+++ b/libs/explorers/ui/src/lib/components/download-dom-images-zip/download-dom-images-zip.component.ts
@@ -2,11 +2,16 @@ import { Component, input } from '@angular/core';
 import { saveAs } from 'file-saver';
 import JSZip from 'jszip';
 import { BaseDownloadDomImageComponent } from '../base-download-dom-image/base-download-dom-image.component';
-import { captureDomToBlob } from '@sagebionetworks/explorers/util';
+import { captureDomToBlob, csvDataToString } from '@sagebionetworks/explorers/util';
 
 type DomFile = {
   filename: string;
   target: HTMLElement;
+};
+
+type CsvFile = {
+  filename: string;
+  data: string[][];
 };
 
 @Component({
@@ -17,17 +22,26 @@ type DomFile = {
 })
 export class DownloadDomImagesZipComponent {
   domFiles = input.required<DomFile[]>();
+  csvFiles = input<CsvFile[]>([]);
   filename = input.required();
   downloadImagePaddingPx = input<number>();
+  hasCsvDownload = input<boolean>(false);
+  hasImageDownload = input<boolean>(true);
 
   performDownload = async (fileType: string): Promise<void> => {
     const zip = new JSZip();
-    const paddingPx = this.downloadImagePaddingPx() ?? 0;
 
-    for (const domFile of this.domFiles()) {
-      const blob = await captureDomToBlob(domFile.target, paddingPx);
-      if (blob) {
-        zip.file(domFile.filename + fileType, blob);
+    if (fileType === '.csv') {
+      for (const csvFile of this.csvFiles()) {
+        zip.file(csvFile.filename + fileType, csvDataToString(csvFile.data));
+      }
+    } else {
+      const paddingPx = this.downloadImagePaddingPx() ?? 0;
+      for (const domFile of this.domFiles()) {
+        const blob = await captureDomToBlob(domFile.target, paddingPx);
+        if (blob) {
+          zip.file(domFile.filename + fileType, blob);
+        }
       }
     }
 

--- a/libs/explorers/ui/src/lib/components/download-dom-images-zip/download-dom-images-zip.component.ts
+++ b/libs/explorers/ui/src/lib/components/download-dom-images-zip/download-dom-images-zip.component.ts
@@ -3,6 +3,7 @@ import { saveAs } from 'file-saver';
 import JSZip from 'jszip';
 import { BaseDownloadDomImageComponent } from '../base-download-dom-image/base-download-dom-image.component';
 import { captureDomToBlob, csvDataToString } from '@sagebionetworks/explorers/util';
+import { FILE_TYPE_CSV } from '../base-download-dom-image/file-types';
 
 type DomFile = {
   filename: string;
@@ -31,7 +32,7 @@ export class DownloadDomImagesZipComponent {
   performDownload = async (fileType: string): Promise<void> => {
     const zip = new JSZip();
 
-    if (fileType === '.csv') {
+    if (fileType === FILE_TYPE_CSV) {
       for (const csvFile of this.csvFiles()) {
         zip.file(csvFile.filename + fileType, csvDataToString(csvFile.data));
       }

--- a/libs/explorers/util/src/index.ts
+++ b/libs/explorers/util/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/csv/csv';
 export * from './lib/dom-capture/dom-capture';
 export * from './lib/http-error-interceptor/http-error.interceptor';
 export * from './lib/loading-container/loading-container.component';

--- a/libs/explorers/util/src/lib/csv/csv.spec.ts
+++ b/libs/explorers/util/src/lib/csv/csv.spec.ts
@@ -1,0 +1,34 @@
+import { csvDataToString } from './csv';
+
+describe('csvDataToString', () => {
+  it('should return an empty string for empty input', () => {
+    expect(csvDataToString([])).toBe('');
+  });
+
+  it('should format a header row', () => {
+    expect(csvDataToString([['age', 'sex', 'value']])).toBe('"age","sex","value"\n');
+  });
+
+  it('should format multiple rows', () => {
+    const data = [
+      ['age', 'sex', 'value'],
+      ['4 months', 'Female', '42.5'],
+      ['6 months', 'Male', '55.1'],
+    ];
+    expect(csvDataToString(data)).toBe(
+      '"age","sex","value"\n"4 months","Female","42.5"\n"6 months","Male","55.1"\n',
+    );
+  });
+
+  it('should escape double quotes within values', () => {
+    expect(csvDataToString([['say "hello"', 'normal']])).toBe('"say ""hello""","normal"\n');
+  });
+
+  it('should handle values containing commas', () => {
+    expect(csvDataToString([['one, two', 'three']])).toBe('"one, two","three"\n');
+  });
+
+  it('should handle empty string values', () => {
+    expect(csvDataToString([['', 'value', '']])).toBe('"","value",""\n');
+  });
+});

--- a/libs/explorers/util/src/lib/csv/csv.spec.ts
+++ b/libs/explorers/util/src/lib/csv/csv.spec.ts
@@ -1,12 +1,8 @@
 import { csvDataToString } from './csv';
 
 describe('csvDataToString', () => {
-  it('should return an empty string for empty input', () => {
-    expect(csvDataToString([])).toBe('');
-  });
-
-  it('should format a header row', () => {
-    expect(csvDataToString([['age', 'sex', 'value']])).toBe('"age","sex","value"\n');
+  it('should double quote and escape values', () => {
+    expect(csvDataToString([['a', 'b', 'c']])).toBe('"a","b","c"\n');
   });
 
   it('should format multiple rows', () => {
@@ -20,15 +16,23 @@ describe('csvDataToString', () => {
     );
   });
 
-  it('should escape double quotes within values', () => {
-    expect(csvDataToString([['say "hello"', 'normal']])).toBe('"say ""hello""","normal"\n');
+  it('should handle empty array', () => {
+    expect(csvDataToString([])).toBe('');
   });
 
-  it('should handle values containing commas', () => {
-    expect(csvDataToString([['one, two', 'three']])).toBe('"one, two","three"\n');
+  it('should handle a row with no columns', () => {
+    expect(csvDataToString([[]])).toBe('\n');
   });
 
-  it('should handle empty string values', () => {
-    expect(csvDataToString([['', 'value', '']])).toBe('"","value",""\n');
+  it('should handle embedded quotes', () => {
+    expect(csvDataToString([['a"b', 'c']])).toBe('"a""b","c"\n');
+  });
+
+  it('should handle commas and newlines', () => {
+    expect(csvDataToString([['a,b', 'c\nd']])).toBe('"a,b","c\nd"\n');
+  });
+
+  it('should handle empty string', () => {
+    expect(csvDataToString([['']])).toBe('""\n');
   });
 });

--- a/libs/explorers/util/src/lib/csv/csv.ts
+++ b/libs/explorers/util/src/lib/csv/csv.ts
@@ -1,0 +1,9 @@
+/**
+ * Converts a 2D array of strings into a CSV-formatted string.
+ * Values are quoted and internal double-quotes are escaped.
+ */
+export function csvDataToString(data: string[][]): string {
+  return data
+    .map((row) => row.map((v) => `"${v.replaceAll('"', '""')}"`).join(',') + '\n')
+    .join('');
+}

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
@@ -44,8 +44,9 @@
       <h2>Table of Contents</h2>
       <explorers-download-dom-images-zip
         [domFiles]="domFiles()"
-        [csvFiles]="csvFiles()"
+        [csvFiles]="boxplotSections()"
         [hasCsvDownload]="true"
+        [hasImageDownload]="true"
         [filename]="
           generateBoxplotsZipFilename(
             selectedTissueOption(),
@@ -69,7 +70,8 @@
   </div>
 
   <div class="boxplots-container" #boxplotsContainer>
-    @for (evidenceType of evidenceTypes(); track evidenceType; let last = $last; let i = $index) {
+    @for (section of boxplotSections(); track section.evidenceType; let last = $last) {
+      @let evidenceType = section.evidenceType;
       <div
         class="boxplots-evidence-type"
         [id]="generateAnchorId(evidenceType)"
@@ -102,14 +104,14 @@
           <explorers-download-dom-image
             [target]="getBoxplotsGridTargetByEvidenceType(evidenceType)"
             buttonLabel="Download"
-            [filename]="csvFiles()[i].filename"
+            [filename]="section.filename"
             [downloadImagePaddingPx]="BOXPLOT_DOWNLOAD_IMAGE_PADDING_PX"
             [hasCsvDownload]="true"
-            [data]="csvFiles()[i].data"
+            [data]="section.data"
           />
         </div>
 
-        <!-- Wrapper handles full-width positioning while keeping grid in normal document flow 
+        <!-- Wrapper handles full-width positioning while keeping grid in normal document flow
          so the full grid is captured in the download image -->
         <div class="boxplots-grid-wrapper">
           <model-ad-boxplots-grid

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
@@ -69,7 +69,7 @@
   </div>
 
   <div class="boxplots-container" #boxplotsContainer>
-    @for (evidenceType of evidenceTypes(); track evidenceType; let last = $last) {
+    @for (evidenceType of evidenceTypes(); track evidenceType; let last = $last; let i = $index) {
       <div
         class="boxplots-evidence-type"
         [id]="generateAnchorId(evidenceType)"
@@ -102,17 +102,10 @@
           <explorers-download-dom-image
             [target]="getBoxplotsGridTargetByEvidenceType(evidenceType)"
             buttonLabel="Download"
-            [filename]="
-              generateBoxplotsFilename(
-                evidenceType,
-                selectedTissueOption(),
-                selectedSexOption().value,
-                modelName()
-              )
-            "
+            [filename]="csvFiles()[i].filename"
             [downloadImagePaddingPx]="BOXPLOT_DOWNLOAD_IMAGE_PADDING_PX"
             [hasCsvDownload]="true"
-            [data]="generateBoxplotsCsvData(evidenceType)"
+            [data]="csvFiles()[i].data"
           />
         </div>
 

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
@@ -44,6 +44,8 @@
       <h2>Table of Contents</h2>
       <explorers-download-dom-images-zip
         [domFiles]="domFiles()"
+        [csvFiles]="csvFiles()"
+        [hasCsvDownload]="true"
         [filename]="
           generateBoxplotsZipFilename(
             selectedTissueOption(),
@@ -109,6 +111,8 @@
               )
             "
             [downloadImagePaddingPx]="BOXPLOT_DOWNLOAD_IMAGE_PADDING_PX"
+            [hasCsvDownload]="true"
+            [data]="generateBoxplotsCsvData(evidenceType)"
           />
         </div>
 

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
@@ -181,9 +181,39 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
     );
 
     const csv = component.generateBoxplotsCsvData('NfL');
-    expect(csv[0]).toEqual(['age', 'sex', 'genotype', 'individual_id', 'value', 'units']);
-    expect(csv[1]).toEqual(['4 months', 'Female', 'TestModel', '100', '42.5', 'pg/mg']);
-    expect(csv[2]).toEqual(['4 months', 'Male', 'Control', '101', '55.1', 'pg/mg']);
+    expect(csv[0]).toEqual([
+      'name',
+      'evidence_type',
+      'tissue',
+      'age',
+      'sex',
+      'genotype',
+      'individual_id',
+      'value',
+      'units',
+    ]);
+    expect(csv[1]).toEqual([
+      'TestModel',
+      'NfL',
+      'Brain',
+      '4 months',
+      'Female',
+      'TestModel',
+      '100',
+      '42.5',
+      'pg/mg',
+    ]);
+    expect(csv[2]).toEqual([
+      'TestModel',
+      'NfL',
+      'Brain',
+      '4 months',
+      'Male',
+      'Control',
+      '101',
+      '55.1',
+      'pg/mg',
+    ]);
   });
 
   it('should generate boxplots zip filename correctly', async () => {

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
@@ -158,6 +158,36 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
     ).toBe('Abca7_V1599M_Plaque_Size_(Thio-S)_Hippocampus_Female');
   });
 
+  it('should generate CSV data for an evidence type', async () => {
+    const mockModelDataList: ModelData[] = [
+      {
+        name: 'TestModel',
+        evidence_type: 'NfL',
+        tissue: 'Brain',
+        age: '4 months',
+        units: 'pg/mg',
+        y_axis_max: 1000,
+        data: [
+          { sex: Sex.Female, individual_id: '100', value: 42.5, genotype: 'TestModel' },
+          { sex: Sex.Male, individual_id: '101', value: 55.1, genotype: 'Control' },
+        ],
+      },
+    ];
+
+    const { component } = await setup(
+      { ...modelMock, pathology: mockModelDataList },
+      mockTitle,
+      validWikiParams,
+    );
+
+    await waitFor(() => {
+      const csv = component.generateBoxplotsCsvData('NfL');
+      expect(csv[0]).toEqual(['age', 'sex', 'genotype', 'individual_id', 'value', 'units']);
+      expect(csv[1]).toEqual(['4 months', 'Female', 'TestModel', '100', '42.5', 'pg/mg']);
+      expect(csv[2]).toEqual(['4 months', 'Male', 'Control', '101', '55.1', 'pg/mg']);
+    });
+  });
+
   it('should generate boxplots zip filename correctly', async () => {
     const { component } = await setup();
     expect(

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
@@ -180,12 +180,10 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
       validWikiParams,
     );
 
-    await waitFor(() => {
-      const csv = component.generateBoxplotsCsvData('NfL');
-      expect(csv[0]).toEqual(['age', 'sex', 'genotype', 'individual_id', 'value', 'units']);
-      expect(csv[1]).toEqual(['4 months', 'Female', 'TestModel', '100', '42.5', 'pg/mg']);
-      expect(csv[2]).toEqual(['4 months', 'Male', 'Control', '101', '55.1', 'pg/mg']);
-    });
+    const csv = component.generateBoxplotsCsvData('NfL');
+    expect(csv[0]).toEqual(['age', 'sex', 'genotype', 'individual_id', 'value', 'units']);
+    expect(csv[1]).toEqual(['4 months', 'Female', 'TestModel', '100', '42.5', 'pg/mg']);
+    expect(csv[2]).toEqual(['4 months', 'Male', 'Control', '101', '55.1', 'pg/mg']);
   });
 
   it('should generate boxplots zip filename correctly', async () => {

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -213,9 +213,11 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
       'value',
       'units',
     ];
+    const sexes = this.selectedSexOption().value;
     const rows: string[][] = [header];
     for (const modelData of this.getSelectedModelDataForEvidenceType(evidenceType)) {
       for (const item of modelData.data) {
+        if (!sexes.includes(item.sex as Sex)) continue;
         rows.push([
           modelData.name,
           modelData.evidence_type,

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -163,6 +163,18 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
     return Array.from(new Set(this.selectedModelDataList().map((item) => item.evidence_type)));
   });
 
+  csvFiles = computed(() => {
+    return this.evidenceTypes().map((evidenceType: string) => ({
+      filename: this.generateBoxplotsFilename(
+        evidenceType,
+        this.selectedTissueOption(),
+        this.selectedSexOption().value,
+        this.modelName(),
+      ),
+      data: this.generateBoxplotsCsvData(evidenceType),
+    }));
+  });
+
   domFiles = computed(() => {
     if (
       this.boxplotGrids().length === 0 ||
@@ -171,17 +183,10 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
       return [];
     }
 
-    return this.evidenceTypes().map((evidenceType: string, index: number) => {
-      return {
-        target: this.boxplotGrids()[index].nativeElement,
-        filename: this.generateBoxplotsFilename(
-          evidenceType,
-          this.selectedTissueOption(),
-          this.selectedSexOption().value,
-          this.modelName(),
-        ),
-      };
-    });
+    return this.csvFiles().map((csvFile, index) => ({
+      target: this.boxplotGrids()[index].nativeElement,
+      filename: csvFile.filename,
+    }));
   });
 
   getBoxplotsGridTargetByEvidenceType(evidenceType: string) {
@@ -193,6 +198,24 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
     return this.selectedModelDataList().filter(
       (modelData) => modelData.evidence_type === evidenceType,
     );
+  }
+
+  generateBoxplotsCsvData(evidenceType: string): string[][] {
+    const header = ['age', 'sex', 'genotype', 'individual_id', 'value', 'units'];
+    const rows: string[][] = [header];
+    for (const modelData of this.getSelectedModelDataForEvidenceType(evidenceType)) {
+      for (const item of modelData.data) {
+        rows.push([
+          modelData.age,
+          item.sex,
+          item.genotype,
+          item.individual_id,
+          String(item.value),
+          modelData.units,
+        ]);
+      }
+    }
+    return rows;
   }
 
   getDefaultTissue() {

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -163,8 +163,9 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
     return Array.from(new Set(this.selectedModelDataList().map((item) => item.evidence_type)));
   });
 
-  csvFiles = computed(() => {
+  boxplotSections = computed(() => {
     return this.evidenceTypes().map((evidenceType: string) => ({
+      evidenceType,
       filename: this.generateBoxplotsFilename(
         evidenceType,
         this.selectedTissueOption(),
@@ -183,9 +184,9 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
       return [];
     }
 
-    return this.csvFiles().map((csvFile, index) => ({
+    return this.boxplotSections().map((section, index) => ({
       target: this.boxplotGrids()[index].nativeElement,
-      filename: csvFile.filename,
+      filename: section.filename,
     }));
   });
 

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -202,11 +202,24 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
   }
 
   generateBoxplotsCsvData(evidenceType: string): string[][] {
-    const header = ['age', 'sex', 'genotype', 'individual_id', 'value', 'units'];
+    const header = [
+      'name',
+      'evidence_type',
+      'tissue',
+      'age',
+      'sex',
+      'genotype',
+      'individual_id',
+      'value',
+      'units',
+    ];
     const rows: string[][] = [header];
     for (const modelData of this.getSelectedModelDataForEvidenceType(evidenceType)) {
       for (const item of modelData.data) {
         rows.push([
+          modelData.name,
+          modelData.evidence_type,
+          modelData.tissue,
           modelData.age,
           item.sex,
           item.genotype,


### PR DESCRIPTION
## Description

The model details boxplots selector previously supported only image downloads (PNG/JPEG) for individual plot grid rows and a ZIP of all images. This PR adds CSV download support to each evidence type row and to the "Download All" ZIP.

## Related Issue

- [MG-845](https://sagebionetworks.jira.com/browse/MG-845)

## Changelog

- Add `csvDataToString` utility to `explorers/util` that converts a `string[][]` to a properly quoted and escaped CSV string
- Extend `DownloadDomImagesZipComponent` to accept `csvFiles` input and produce a ZIP of CSVs when the CSV option is selected
- Add `hasCsvDownload` and `hasImageDownload` inputs to `DownloadDomImagesZipComponent` and forward them to the base download component
- Add `generateBoxplotsCsvData` method and `csvFiles` computed signal to `ModelDetailsBoxplotsSelectorComponent`
- Wire CSV download into the per-evidence-type download button and the "Download All" ZIP button in the boxplots selector template
- Refactor `domFiles` to derive filenames from `csvFiles`, eliminating duplicate filename generation

## Preview

`model-ad-build-images && model-ad-docker-start`

Download CSV for a single plot: 

https://github.com/user-attachments/assets/b5b761d4-3f81-49c1-9cc1-4ca87cf1e233

CSV: 

<img width="784" height="450" alt="image" src="https://github.com/user-attachments/assets/294804c4-bc99-4b9e-97a3-d853c78bd9be" />

Download zip of all plot CSVs: 

https://github.com/user-attachments/assets/8c22e91c-f7ca-42f2-96eb-c6bd7b9400c4


[MG-845]: https://sagebionetworks.jira.com/browse/MG-845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ