### PR TITLE
ci(sage-monorepo): audit and harden GitHub Actions workflows (SMR-747)

### DIFF
--- a/.github/actions/setup-dev-container/action.yml
+++ b/.github/actions/setup-dev-container/action.yml
@@ -13,7 +13,7 @@ runs:
   using: 'composite'
   steps:
     # - name: Set up pnpm cache
-    #   uses: actions/cache@v3
+    #   uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c #v3.5.0
     #   with:
     #     path: '/tmp/.pnpm-store'
     #     key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -21,7 +21,7 @@ runs:
     #       ${{ runner.os }}-pnpm-store-
 
     # - name: Set up Renv cache
-    #   uses: actions/cache@v3
+    #   uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c #v3.5.0
     #   with:
     #     path: '/tmp/.cache/R/renv/cache'
     #     key: ${{ runner.os }}-renv-cache-${{ hashFiles('**/renv.lock') }}
@@ -29,7 +29,7 @@ runs:
     #       ${{ runner.os }}-renv-cache-
 
     # - name: Set up venv cache
-    #   uses: actions/cache@v3
+    #   uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c #v3.5.0
     #   with:
     #     path: |
     #       /tmp/.local/share/virtualenv
@@ -37,7 +37,7 @@ runs:
     #     key: ${{ runner.os }}-venv-${{ hashFiles('**/uv.lock') }}
 
     # - name: Set up Gradle cache
-    #   uses: actions/cache@v3
+    #   uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c #v3.5.0
     #   with:
     #     path: |
     #       /tmp/.gradle/caches

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      # Batch all non-major bumps into a single PR to reduce noise.
+      # Major version bumps land as individual PRs for review.
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/build-and-push-devcontainer-image.yml
+++ b/.github/workflows/build-and-push-devcontainer-image.yml
@@ -29,7 +29,7 @@ jobs:
       DOCKERFILE: .github/.devcontainer/Dockerfile
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
@@ -59,7 +59,7 @@ jobs:
       image_digest: ${{ steps.push.outputs.image_digest }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -32,7 +32,7 @@ jobs:
       affected_storybooks: ${{ steps.check-storybook.outputs.affected_storybooks }}
       has_affected_storybooks: ${{ steps.check-storybook.outputs.has_affected_storybooks }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
 
 permissions:
-  contents: write # Required for ghp-import to push to gh-pages
+  contents: read # Deploy jobs override to `write`; PR-validation jobs stay read-only.
 
 concurrency:
   group: 'pages-${{ github.ref }}'
@@ -120,6 +120,8 @@ jobs:
       github.event_name == 'push' &&
       github.ref_name == 'main' &&
       (needs.check-affected.outputs.docs_changed == 'true' || needs.check-affected.outputs.composite_storybook_affected == 'true')
+    permissions:
+      contents: write # ghp-import pushes to gh-pages
     uses: ./.github/workflows/deploy-docs.yml
 
   # Deploy individual storybooks when parent products affected (but NOT when full site deploy is happening)
@@ -132,6 +134,8 @@ jobs:
       needs.check-affected.outputs.has_affected_storybooks == 'true' &&
       needs.check-affected.outputs.docs_changed == 'false' &&
       needs.check-affected.outputs.composite_storybook_affected == 'false'
+    permissions:
+      contents: write # ghp-import pushes to gh-pages
     uses: ./.github/workflows/deploy-storybook.yml
     with:
       storybooks: ${{ needs.check-affected.outputs.affected_storybooks }}

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: 3.x
 
@@ -21,7 +21,7 @@ jobs:
         run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
 
       - name: Restore MkDocs cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.x
 
@@ -24,7 +24,7 @@ jobs:
         run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
 
       - name: Restore MkDocs cache
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -6,6 +6,9 @@ name: Build Docs
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-22.04-4core-16GBRAM-150GBSSD
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -16,6 +16,9 @@ on:
         type: string
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   build:
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,16 @@ jobs:
         run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
 
       - name: Build and publish the images of the affected projects
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_ACTOR: ${{ github.actor }}
         run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin \
-            && nx affected --target=build-image --configuration=edge"
+          devcontainer exec --workspace-folder ../sage-monorepo \
+            --remote-env GH_TOKEN="$GH_TOKEN" \
+            --remote-env GH_ACTOR="$GH_ACTOR" \
+            bash -c '. ./dev-env.sh \
+            && echo "$GH_TOKEN" | docker login ghcr.io -u "$GH_ACTOR" --password-stdin \
+            && nx affected --target=build-image --configuration=edge'
 
       - name: Upload Sentry sourcemaps for the affected projects
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ env:
   HEAD_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
   HEAD_REPOSITORY: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
   NX_BRANCH: ${{ github.event_name == 'pull_request' && github.event.number || github.ref_name }}
-  NX_CLOUD_ENCRYPTION_KEY: ${{ secrets.NX_CLOUD_ENCRYPTION_KEY }}
 
 jobs:
   push:
@@ -23,6 +22,9 @@ jobs:
     timeout-minutes: 45
     if: ${{ github.event_name != 'pull_request' }}
     env:
+      # Scoped to this job (not workflow-level) so the secret is not exposed to the `pr`
+      # job, which executes PR-controlled code from fork checkouts.
+      NX_CLOUD_ENCRYPTION_KEY: ${{ secrets.NX_CLOUD_ENCRYPTION_KEY }}
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN_READ_WRITE }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,8 @@ jobs:
       - name: Upload Sentry sourcemaps for the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo \
-            --remote-env SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN \
-            --remote-env SENTRY_RELEASE=$SENTRY_RELEASE \
+            --remote-env SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN" \
+            --remote-env SENTRY_RELEASE="$SENTRY_RELEASE" \
             bash -c ". ./dev-env.sh \
             && nx affected --target=sentry-sourcemaps"
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN_READ_WRITE }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         name: Checkout ${{ env.HEAD_REPOSITORY }}:${{ env.HEAD_REF }}
         with:
           # We need to fetch all branches and commits so that Nx affected has a base to compare
@@ -97,7 +97,7 @@ jobs:
     # Runs for any pull_request (fork or same-repo)
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         name: Checkout merge commit
         with:
           # We need to fetch all branches and commits so that Nx affected has a base to compare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
       - synchronize
   merge_group:
 
+permissions:
+  contents: read
+
 env:
   # SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   HEAD_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
@@ -21,6 +24,9 @@ jobs:
     runs-on: ubuntu-22.04-4core-16GBRAM-150GBSSD
     timeout-minutes: 45
     if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      packages: write # push images to ghcr.io
     env:
       # Scoped to this job (not workflow-level) so the secret is not exposed to the `pr`
       # job, which executes PR-controlled code from fork checkouts.

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04-4core-16GBRAM-150GBSSD
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           persist-credentials: true

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,9 @@ name: Deploy Docs
 on:
   workflow_call:
 
+permissions:
+  contents: write # ghp-import pushes to gh-pages
+
 jobs:
   deploy:
     runs-on: ubuntu-22.04-4core-16GBRAM-150GBSSD

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -12,6 +12,9 @@ on:
         type: string
         # Examples: "agora", "explorers", "agora explorers"
 
+permissions:
+  contents: write # ghp-import pushes to gh-pages
+
 jobs:
   deploy:
     runs-on: ubuntu-22.04-4core-16GBRAM-150GBSSD

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04-4core-16GBRAM-150GBSSD
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           persist-credentials: true

--- a/.github/workflows/e2e-explorer.yaml
+++ b/.github/workflows/e2e-explorer.yaml
@@ -22,6 +22,11 @@ jobs:
     needs: validate-explorer-input
     timeout-minutes: 15
     runs-on: ubuntu-22.04-4core-16GBRAM-150GBSSD
+    # This job checks out PR HEAD and runs a composite action from the PR workspace,
+    # so it must sit behind the same environment approval used by run-explorer-e2e-tests
+    # when the PR is from a fork. See the environment comment on that job below.
+    environment: ${{ github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository && format('{0}-pr', inputs.explorer) || inputs.explorer }}
     outputs:
       explorer_affected: ${{ steps.explorer_affected.outputs.affected }}
     steps:

--- a/.github/workflows/e2e-explorer.yaml
+++ b/.github/workflows/e2e-explorer.yaml
@@ -120,6 +120,10 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
               && ${cmd}"
 
+      # SYNAPSE_AUTH_TOKEN is stored as an environment secret on the {explorer} and
+      # {explorer}-pr environments (see the environment comment on this job above), so it
+      # resolves via `secrets.*` here without the caller passing it through. This is why
+      # the caller workflow does not need `secrets: inherit` or an explicit `secrets:` block.
       - name: Write Synapse PAT for Explorer
         run: |
           env_filename="apps/${{ inputs.explorer }}/data/.env"

--- a/.github/workflows/e2e-explorer.yaml
+++ b/.github/workflows/e2e-explorer.yaml
@@ -7,6 +7,9 @@ on:
         type: string
         description: The name of the Explorer to run e2e tests for
 
+permissions:
+  contents: read
+
 jobs:
   validate-explorer-input:
     runs-on: ubuntu-22.04

--- a/.github/workflows/e2e-explorer.yaml
+++ b/.github/workflows/e2e-explorer.yaml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       explorer_affected: ${{ steps.explorer_affected.outputs.affected }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # We need to fetch all branches and commits so that Nx affected has a base to compare
           # against.
@@ -73,7 +73,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-22.04-4core-16GBRAM-150GBSSD
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # We need to fetch all branches and commits so that Nx affected has a base to compare
           # against.
@@ -143,7 +143,7 @@ jobs:
 
       - name: Upload Explorer data logs
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: 'data-logs-${{ inputs.explorer }}'
           path: data-logs.txt
@@ -161,7 +161,7 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
               && workspace-docker-stop"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ !cancelled() && steps.start-explorer.conclusion != 'failure' }}
         with:
           name: 'playwright-report-${{ inputs.explorer }}'

--- a/.github/workflows/e2e-explorers.yaml
+++ b/.github/workflows/e2e-explorers.yaml
@@ -19,4 +19,3 @@ jobs:
     uses: ./.github/workflows/e2e-explorer.yaml
     with:
       explorer: ${{ matrix.explorer }}
-    secrets: inherit

--- a/.github/workflows/e2e-explorers.yaml
+++ b/.github/workflows/e2e-explorers.yaml
@@ -7,6 +7,9 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
 
+permissions:
+  contents: read
+
 jobs:
   run-explorer-e2e:
     # Run in Sage repo on main branch and on all branches in user-owned forks

--- a/.github/workflows/lint-dockerfiles.yml
+++ b/.github/workflows/lint-dockerfiles.yml
@@ -15,7 +15,7 @@ jobs:
   hadolint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         name: Checkout
         with:
           fetch-depth: 1

--- a/.github/workflows/lint-dockerfiles.yml
+++ b/.github/workflows/lint-dockerfiles.yml
@@ -11,6 +11,9 @@ on:
       - 'sage/**'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   hadolint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,17 +63,17 @@ jobs:
             --remote-env GH_TOKEN="$GH_TOKEN" \
             --remote-env GH_ACTOR="$GH_ACTOR" \
             bash -c '. ./dev-env.sh \
-            && export VERSION=${{ env.VERSION }} \
+            && export VERSION="${{ env.VERSION }}" \
             && echo "$GH_TOKEN" | docker login ghcr.io -u "$GH_ACTOR" --password-stdin \
-            && nx run-many --target=build-image --projects=${{ env.PRODUCT }}-* --configuration=release'
+            && nx run-many --target=build-image --projects="${{ env.PRODUCT }}-*" --configuration=release'
 
       - name: Upload Sentry sourcemaps for the specified product
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo \
-            --remote-env SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN \
-            --remote-env SENTRY_RELEASE=$SENTRY_RELEASE \
-            bash -c ". ./dev-env.sh \
-            && nx run-many --target=sentry-sourcemaps --projects=${{ env.PRODUCT }}-*"
+            --remote-env SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN" \
+            --remote-env SENTRY_RELEASE="$SENTRY_RELEASE" \
+            bash -c '. ./dev-env.sh \
+            && nx run-many --target=sentry-sourcemaps --projects="${{ env.PRODUCT }}-*"'
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_RELEASE: ${{ env.VERSION }}+${{ env.SHORT_SHA }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,8 @@ on:
       - 'sage/v*'
 
 permissions:
-  packages: write
+  contents: read
+  packages: write # push images to ghcr.io
 
 env:
   PRODUCT: ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,17 @@ jobs:
             && workspace-install-affected"
 
       - name: Build the Docker images for the specified product
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_ACTOR: ${{ github.actor }}
         run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+          devcontainer exec --workspace-folder ../sage-monorepo \
+            --remote-env GH_TOKEN="$GH_TOKEN" \
+            --remote-env GH_ACTOR="$GH_ACTOR" \
+            bash -c '. ./dev-env.sh \
             && export VERSION=${{ env.VERSION }} \
-            && echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin \
-            && nx run-many --target=build-image --projects=${{ env.PRODUCT }}-* --configuration=release"
+            && echo "$GH_TOKEN" | docker login ghcr.io -u "$GH_ACTOR" --password-stdin \
+            && nx run-many --target=build-image --projects=${{ env.PRODUCT }}-* --configuration=release'
 
       - name: Upload Sentry sourcemaps for the specified product
         run: |

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -59,14 +59,14 @@ jobs:
           format: table
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
         with:
           sarif_file: trivy-results-${{ matrix.image }}-edge.sarif
           category: trivy-image-${{ matrix.image }}:edge
           wait-for-processing: true
 
       - name: Detain results for debug if needed
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: trivy-results-${{ matrix.image }}-edge.sarif
           path: trivy-results-${{ matrix.image }}-edge.sarif

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -22,7 +22,6 @@ jobs:
     env:
       TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
       TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -45,6 +44,7 @@ jobs:
 
       # Deliberately chosen master here to keep up-to-date.
       - name: Run Trivy vulnerability scanner for any major issues
+        continue-on-error: true # scan may exit non-zero when vulnerabilities are found
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ghcr.io/sage-bionetworks/${{ matrix.image }}:edge
@@ -58,6 +58,7 @@ jobs:
       # Show all detected issues.
       # Note this will show a lot more, including major un-fixed ones.
       - name: Run Trivy vulnerability scanner for local output
+        continue-on-error: true # scan may exit non-zero when vulnerabilities are found
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ghcr.io/sage-bionetworks/${{ matrix.image }}:edge

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -10,6 +10,11 @@ on:
     - cron: 29 19 * * 4
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: read # pull images from ghcr.io
+  security-events: write # upload Trivy SARIF to the Security tab
+
 jobs:
   trivy-edge:
     name: ${{ matrix.image }}

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
@@ -31,7 +31,7 @@ jobs:
           limit-severities-for-sarif: true
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
         with:
           sarif_file: 'trivy-results.sarif'
           category: 'trivy-repo'

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -9,6 +9,10 @@ on:
     - cron: 29 19 * * 4
   workflow_dispatch:
 
+permissions:
+  contents: read
+  security-events: write # upload Trivy SARIF to the Security tab
+
 jobs:
   trivy:
     name: Trivy

--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -10,8 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: update-synapse-api
@@ -42,6 +41,9 @@ jobs:
   update-synapse-api:
     runs-on: ubuntu-latest
     needs: extract-devcontainer-image
+    permissions:
+      contents: write # peter-evans/create-pull-request commits to a new branch
+      pull-requests: write # peter-evans/create-pull-request opens/updates the PR
     env:
       # By default, Corepack prompts for a confirmation before downloading and enabling
       # a package manager. We disable the prompt here to ensure non-interactive execution.

--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -33,7 +33,7 @@ jobs:
       image: ${{ steps.devcontainer.outputs.image }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - id: devcontainer
         name: Read .devcontainer/devcontainer.json
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Adjust ownership & prepare workspace (unprivileged)
         run: |


### PR DESCRIPTION
## Description

Improvements from Claude Opus 4.7 audit of GitHub Actions workflows. Pin remaining third-party actions by SHA instead of version tags. 

## Related Issue

- [SMR-747](https://sagebionetworks.jira.com/browse/SMR-747)

## Changelog

- Gate `check-explorer-affected` behind the same `{explorer}-pr` environment approval already used by `run-explorer-e2e-tests`, so fork PRs cannot execute PR-controlled code before a maintainer approves. *NOTE: this will require an approver to click through approving the job on every external PR, even when the explorer turns out not to be affected.*
- Drop `secrets: inherit` from the e2e-explorers caller since `SYNAPSE_AUTH_TOKEN` is an environment secret that resolves via the job's `environment:` binding
- Move `NX_CLOUD_ENCRYPTION_KEY` from workflow-level env to the `push` job so the `pr` job (which runs fork-controlled code) cannot access it
- Add explicit least-privilege `permissions:` blocks to all workflows and scope `contents: write` to only the jobs that deploy or create PRs
- Replace direct `${{ secrets.GITHUB_TOKEN }}` interpolation in shell commands with step-level env vars and `--remote-env` to keep the token out of inner shell argv
- Scope `continue-on-error` in `scan-images` to the Trivy scan steps only so infrastructure failures (login, SARIF upload) are no longer silently swallowed
- Pin all third-party actions to SHA, bump stale `setup-python` (v4 -> v6) and `cache` (v3 -> v5), and add `.github/dependabot.yml` for weekly grouped action-version monitoring

[SMR-747]: https://sagebionetworks.jira.com/browse/SMR-747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ