### PR TITLE
fix(bixarena): regenerate API clients and add missing APP_HOST

### DIFF
--- a/apps/bixarena/api-gateway/src/main/resources/routes.yml
+++ b/apps/bixarena/api-gateway/src/main/resources/routes.yml
@@ -1,0 +1,248 @@
+app:
+  routes:
+    - method: 'DELETE'
+      path: '/api/v1/battles/{battleId}'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30
+    - method: 'DELETE'
+      path: '/api/v1/example-prompts/{examplePromptId}'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 60
+    - method: 'DELETE'
+      path: '/api/v1/quests/{questId}'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30
+    - method: 'DELETE'
+      path: '/api/v1/quests/{questId}/posts/{postIndex}'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30
+    - method: 'GET'
+      path: '/.well-known/jwks.json'
+      audience: 'urn:bixarena:auth'
+      anonymousAccess: true
+      rateLimitRequestsPerMinute: 100
+    - method: 'GET'
+      path: '/api/v1/admin/quests/{questId}'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 60
+    - method: 'GET'
+      path: '/api/v1/admin/stats'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 60
+    - method: 'GET'
+      path: '/api/v1/battles'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 300
+    - method: 'GET'
+      path: '/api/v1/battles/{battleId}'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 300
+    - method: 'GET'
+      path: '/api/v1/battles/{battleId}/categorizations'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 60
+    - method: 'GET'
+      path: '/api/v1/battles/{battleId}/validations'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 60
+    - method: 'GET'
+      path: '/api/v1/example-prompts'
+      audience: 'urn:bixarena:api'
+      anonymousAccess: true
+      rateLimitRequestsPerMinute: 100
+    - method: 'GET'
+      path: '/api/v1/example-prompts/{examplePromptId}'
+      audience: 'urn:bixarena:api'
+      anonymousAccess: true
+      rateLimitRequestsPerMinute: 100
+    - method: 'GET'
+      path: '/api/v1/example-prompts/{examplePromptId}/categorizations'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 60
+    - method: 'GET'
+      path: '/api/v1/health-check'
+      audience: 'urn:bixarena:ai'
+      anonymousAccess: true
+    - method: 'GET'
+      path: '/api/v1/leaderboards'
+      audience: 'urn:bixarena:api'
+      anonymousAccess: true
+      rateLimitRequestsPerMinute: 100
+    - method: 'GET'
+      path: '/api/v1/leaderboards/{leaderboardId}'
+      audience: 'urn:bixarena:api'
+      anonymousAccess: true
+      rateLimitRequestsPerMinute: 100
+    - method: 'GET'
+      path: '/api/v1/leaderboards/{leaderboardId}/history/{modelId}'
+      audience: 'urn:bixarena:api'
+      anonymousAccess: true
+      rateLimitRequestsPerMinute: 100
+    - method: 'GET'
+      path: '/api/v1/leaderboards/{leaderboardId}/snapshots'
+      audience: 'urn:bixarena:api'
+      anonymousAccess: true
+      rateLimitRequestsPerMinute: 100
+    - method: 'GET'
+      path: '/api/v1/models'
+      audience: 'urn:bixarena:api'
+      anonymousAccess: true
+      rateLimitRequestsPerMinute: 100
+    - method: 'GET'
+      path: '/api/v1/quests/{questId}'
+      audience: 'urn:bixarena:api'
+      anonymousAccess: true
+      rateLimitRequestsPerMinute: 100
+    - method: 'GET'
+      path: '/api/v1/quests/{questId}/contributors'
+      audience: 'urn:bixarena:api'
+      anonymousAccess: true
+      rateLimitRequestsPerMinute: 100
+    - method: 'GET'
+      path: '/api/v1/stats'
+      audience: 'urn:bixarena:api'
+      anonymousAccess: true
+      rateLimitRequestsPerMinute: 100
+    - method: 'GET'
+      path: '/api/v1/users/me/stats'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 300
+    - method: 'GET'
+      path: '/auth/callback'
+      audience: 'urn:bixarena:auth'
+      anonymousAccess: true
+      rateLimitRequestsPerMinute: 20
+    - method: 'GET'
+      path: '/auth/login'
+      audience: 'urn:bixarena:auth'
+      anonymousAccess: true
+      rateLimitRequestsPerMinute: 20
+    - method: 'GET'
+      path: '/userinfo'
+      audience: 'urn:bixarena:auth'
+      rateLimitRequestsPerMinute: 60
+    - method: 'PATCH'
+      path: '/api/v1/battles/{battleId}'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30
+    - method: 'PATCH'
+      path: '/api/v1/battles/{battleId}/categorizations/effective'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30
+    - method: 'PATCH'
+      path: '/api/v1/battles/{battleId}/rounds/{roundId}'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30
+    - method: 'PATCH'
+      path: '/api/v1/battles/{battleId}/validations/effective'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30
+    - method: 'PATCH'
+      path: '/api/v1/example-prompts/{examplePromptId}'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30
+    - method: 'PATCH'
+      path: '/api/v1/example-prompts/{examplePromptId}/categorizations/effective'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30
+    - method: 'POST'
+      path: '/api/v1/battles'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30
+    - method: 'POST'
+      path: '/api/v1/battles/{battleId}/categorizations'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 60
+    - method: 'POST'
+      path: '/api/v1/battles/{battleId}/categorizations/run'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30
+    - method: 'POST'
+      path: '/api/v1/battles/{battleId}/evaluations'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 60
+    - method: 'POST'
+      path: '/api/v1/battles/{battleId}/rounds'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 60
+    - method: 'POST'
+      path: '/api/v1/battles/{battleId}/rounds/{roundId}/stream'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 60
+    - method: 'POST'
+      path: '/api/v1/battles/{battleId}/validations'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 60
+    - method: 'POST'
+      path: '/api/v1/battles/{battleId}/validations/run'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30
+    - method: 'POST'
+      path: '/api/v1/categorize-battle'
+      audience: 'urn:bixarena:ai'
+      rateLimitRequestsPerMinute: 60
+    - method: 'POST'
+      path: '/api/v1/categorize-prompt'
+      audience: 'urn:bixarena:ai'
+      rateLimitRequestsPerMinute: 60
+    - method: 'POST'
+      path: '/api/v1/chat/completions'
+      audience: 'urn:bixarena:ai'
+      rateLimitRequestsPerMinute: 60
+    - method: 'POST'
+      path: '/api/v1/example-prompts'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 60
+    - method: 'POST'
+      path: '/api/v1/example-prompts/{examplePromptId}/categorizations'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 60
+    - method: 'POST'
+      path: '/api/v1/example-prompts/{examplePromptId}/categorizations/run'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30
+    - method: 'POST'
+      path: '/api/v1/models/{modelId}/errors'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 60
+    - method: 'POST'
+      path: '/api/v1/quests'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30
+    - method: 'POST'
+      path: '/api/v1/quests/{questId}/posts'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30
+    - method: 'POST'
+      path: '/api/v1/validate-battle'
+      audience: 'urn:bixarena:ai'
+      rateLimitRequestsPerMinute: 60
+    - method: 'POST'
+      path: '/api/v1/validate-prompt'
+      audience: 'urn:bixarena:ai'
+      rateLimitRequestsPerMinute: 60
+    - method: 'POST'
+      path: '/auth/logout'
+      audience: 'urn:bixarena:auth'
+      rateLimitRequestsPerMinute: 60
+    - method: 'POST'
+      path: '/oauth2/service-token'
+      audience: 'urn:bixarena:auth'
+      rateLimitRequestsPerMinute: 30
+    - method: 'POST'
+      path: '/oauth2/token'
+      audience: 'urn:bixarena:auth'
+      anonymousAccess: true
+      rateLimitRequestsPerMinute: 60
+    - method: 'PUT'
+      path: '/api/v1/quests/{questId}'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30
+    - method: 'PUT'
+      path: '/api/v1/quests/{questId}/posts/reorder'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30
+    - method: 'PUT'
+      path: '/api/v1/quests/{questId}/posts/{postIndex}'
+      audience: 'urn:bixarena:api'
+      rateLimitRequestsPerMinute: 30

--- a/apps/bixarena/app/.env.example
+++ b/apps/bixarena/app/.env.example
@@ -1,4 +1,5 @@
 API_BASE_URL=http://bixarena-api-gateway:8113/api/v1
+APP_HOST=0.0.0.0
 APP_PORT=8100
 AUTH_BASE_URL_CSR=http://127.0.0.1:8113
 AUTH_BASE_URL_SSR=http://bixarena-api-gateway:8113


### PR DESCRIPTION
## Descritpion
PR #3991 merged with an empty routes.yml and a missing APP_HOST in the Gradio app's .env.example, causing the bixarena-api-gateway to crash-loop and the Gradio container to fail startup in local stacks. This PR regenerates all BixArena API client artifacts from the OpenAPI specs so the gateway's route table is populated, and adds the missing env var.

## Related Issue
N/A

## Changelog
- Regenerate all clients (fixes empty routes.yml)
- Add APP_HOST=0.0.0.0 to the Gradio app's `.env.example`