### PR TITLE
fix(devcontainer): replace actions/attest-build-provenance with actions/attest v4.1.0 to use internally SHA-pinned workflows (SMR-751)

### DIFF
--- a/.github/workflows/build-and-push-devcontainer-image.yml
+++ b/.github/workflows/build-and-push-devcontainer-image.yml
@@ -165,7 +165,7 @@ jobs:
     steps:
       - name: Attest the provenance of the Docker image build
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         id: attest
         with:
           subject-name: ${{ needs.build-and-push.outputs.image }}


### PR DESCRIPTION
## Description

Replace `actions/attest-build-provenance` (v2.2.0) with `actions/attest` (v4.1.0) in the Dev Container Image workflow to fix CI failures caused by the action internally referencing `actions/attest` by version tag instead of SHA.

## Related Issue

[SMR-751](https://sagebionetworks.jira.com/browse/SMR-751)

## Changelog

- Replace `actions/attest-build-provenance@v2.2.0` with `actions/attest@v4.1.0`, which is the upstream-recommended action that uses SHA-pinned internal references


[SMR-751]: https://sagebionetworks.jira.com/browse/SMR-751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ