### PR TITLE
feat(bixarena): enable battle example cards with DNA helix in angular app (SMR-749)

### DIFF
--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -9,15 +9,17 @@
         </p>
       </div>
       <bixarena-example-prompts (promptSelect)="onPromptSubmit($event)" />
-      <bixarena-prompt-composer
-        placeholder="Ask anything biomedical..."
-        [maxLength]="state.promptLengthLimit"
-        [disabled]="state.phase() === 'creating'"
-        (promptSubmit)="onPromptSubmit($event)"
-      />
-      <p class="disclaimer">
-        AI may make mistakes. Do not include sensitive or personal information.
-      </p>
+      <div class="composer-group">
+        <bixarena-prompt-composer
+          placeholder="Ask anything biomedical..."
+          [maxLength]="state.promptLengthLimit"
+          [disabled]="state.phase() === 'creating'"
+          (promptSubmit)="onPromptSubmit($event)"
+        />
+        <p class="disclaimer">
+          AI may make mistakes. Do not include sensitive or personal information.
+        </p>
+      </div>
     </section>
   }
 

--- a/libs/bixarena/battle/src/lib/battle.component.scss
+++ b/libs/bixarena/battle/src/lib/battle.component.scss
@@ -9,13 +9,16 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  gap: 2.5rem;
-  padding-bottom: 4rem;
+  padding: 3rem 1rem;
 }
 
 .hero {
   text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+bixarena-example-prompts {
+  margin-bottom: 2.5rem;
 }
 
 .title {
@@ -127,5 +130,5 @@
   text-align: center;
   font-size: var(--text-xs);
   color: var(--p-text-muted-color);
-  margin: 0.5rem 0 0;
+  margin: 1.5rem 0 0;
 }

--- a/libs/bixarena/battle/src/lib/battle.component.scss
+++ b/libs/bixarena/battle/src/lib/battle.component.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   min-height: calc(100dvh - var(--nav-height));
+  padding-bottom: 0;
 }
 
 .landing {
@@ -9,7 +10,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 3rem 1rem;
+  padding: 3rem 1rem 1rem;
 }
 
 .hero {
@@ -18,7 +19,19 @@
 }
 
 bixarena-example-prompts {
-  margin-bottom: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.composer-group {
+  position: sticky;
+  bottom: 1rem;
+  z-index: 5;
+  margin-top: auto;
+  width: 100%;
+  max-width: 40rem;
+  display: flex;
+  flex-direction: column;
+  align-self: center;
 }
 
 .title {
@@ -52,6 +65,7 @@ bixarena-example-prompts {
   min-height: 0;
   overflow: hidden;
   gap: 0.5rem;
+  padding-bottom: 1rem;
 }
 
 .rail {
@@ -131,4 +145,8 @@ bixarena-example-prompts {
   font-size: var(--text-xs);
   color: var(--p-text-muted-color);
   margin: 1.5rem 0 0;
+}
+
+.battle-view > .disclaimer {
+  margin-top: 1rem;
 }

--- a/libs/bixarena/battle/src/lib/example-prompts/dna-helix.ts
+++ b/libs/bixarena/battle/src/lib/example-prompts/dna-helix.ts
@@ -1,0 +1,66 @@
+// DNA helix geometry.
+// Each strand is a chain of S-cubics — one cubic per full wavelength with
+// control points on OPPOSITE sides of the midline. Y(t) peaks at
+// t = 0.5 ∓ √3/6 and reaches MID ± 0.2887·CTRL_AMP, so the visible amplitude
+// is VIS_AMP when CTRL_AMP = VIS_AMP / 0.2887.
+
+export interface RungSpec {
+  x: number;
+  y1: number;
+  y2: number;
+}
+
+export const VB_W = 900;
+export const WAVELEN = 600;
+
+const MID_Y = 90;
+const VIS_AMP = 65;
+const CTRL_AMP = VIS_AMP / 0.2887;
+// RUNG_STEP must divide WAVELEN evenly so the rung lattice is also
+// WAVELEN-periodic — otherwise rungs shift relative to the strands on spin
+// reset and flash at the viewBox edges.
+const RUNG_STEP = 20;
+const LEAD_WAVES = 1;
+const TRAIL_WAVES = 3;
+// Quarter-wavelength phase shift places midline X-crossings inside the
+// viewBox (at 150 / 450 / 750) instead of at the edges, so the leftmost
+// and rightmost ovals read symmetric with the middle one.
+const PHASE_OFFSET = WAVELEN / 4;
+
+function cubicFactor(t: number): number {
+  // 3·t·(1-t)·(1-2t) ∈ [-0.2887, +0.2887]
+  return 3 * t * (1 - t) * (1 - 2 * t);
+}
+
+export function buildStrandPath(firstUp: boolean): string {
+  const startX = -LEAD_WAVES * WAVELEN - PHASE_OFFSET;
+  const endX = VB_W + TRAIL_WAVES * WAVELEN;
+  const count = Math.ceil((endX - startX) / WAVELEN);
+  let d = `M ${startX} ${MID_Y}`;
+  for (let i = 0; i < count; i++) {
+    const x0 = startX + i * WAVELEN;
+    const x1 = x0 + WAVELEN;
+    const c1x = x0 + WAVELEN / 3;
+    const c2x = x0 + (2 * WAVELEN) / 3;
+    const c1y = firstUp ? MID_Y - CTRL_AMP : MID_Y + CTRL_AMP;
+    const c2y = firstUp ? MID_Y + CTRL_AMP : MID_Y - CTRL_AMP;
+    d += ` C ${c1x} ${c1y} ${c2x} ${c2y} ${x1} ${MID_Y}`;
+  }
+  return d;
+}
+
+export function buildRungs(): RungSpec[] {
+  const strandStartX = -LEAD_WAVES * WAVELEN - PHASE_OFFSET;
+  const rungEnd = VB_W + TRAIL_WAVES * WAVELEN;
+  const out: RungSpec[] = [];
+  for (let x = strandStartX; x <= rungEnd; x += RUNG_STEP) {
+    const offset = x - strandStartX;
+    const local = ((offset % WAVELEN) + WAVELEN) % WAVELEN;
+    const factor = cubicFactor(local / WAVELEN);
+    const yF = MID_Y - CTRL_AMP * factor;
+    const yB = MID_Y + CTRL_AMP * factor;
+    if (Math.abs(yF - yB) < 14) continue;
+    out.push({ x, y1: yF, y2: yB });
+  }
+  return out;
+}

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.html
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.html
@@ -1,44 +1,77 @@
-<div class="dna-section">
-  <div class="dna-label">Unwind a prompt</div>
-  <div class="dna-wrap">
-    <div class="helix">
-      <svg class="strand strand-back" viewBox="0 0 400 100" preserveAspectRatio="none">
-        <path d="M0,50 C50,10 100,90 150,50 C200,10 250,90 300,50 C350,10 400,90 450,50" />
-      </svg>
-      <svg class="strand strand-front" viewBox="0 0 400 100" preserveAspectRatio="none">
-        <path d="M0,50 C50,90 100,10 150,50 C200,90 250,10 300,50 C350,90 400,10 450,50" />
-      </svg>
+<div class="picker">
+  <button
+    class="unwind-label"
+    type="button"
+    (click)="tryAnother()"
+    [disabled]="loading()"
+    aria-label="Unwind another example"
+  >
+    <svg
+      class="unwind-icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12a9 9 0 1 1-3-6.7M21 4v5h-5" />
+    </svg>
+    Unwind an example
+  </button>
 
-      @for (node of nodes; track node.label) {
-        <button
-          class="helix-node"
-          [class.active]="selectedCategory() === node.label"
-          [style.left.px]="node.left"
-          [style.top.px]="node.top"
-          (click)="onNodeClick(node)"
-          role="button"
-          tabindex="0"
-          [attr.aria-label]="'Load ' + node.label + ' prompt'"
-        >
-          <svg
-            class="node-icon"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <path [attr.d]="node.icon" />
-          </svg>
-          <span class="node-label">{{ node.label }}</span>
-        </button>
+  <div class="stage">
+    <div class="helix-bg" aria-hidden="true">
+      <svg class="helix-svg" viewBox="0 0 900 180" preserveAspectRatio="none">
+        <g #flowGroup>
+          <path class="strand strand-back" [attr.d]="backPath"></path>
+          <path class="strand strand-front" [attr.d]="frontPath"></path>
+          <g class="rungs">
+            @for (r of rungs; track $index) {
+              <line
+                class="rung"
+                [attr.x1]="r.x"
+                [attr.y1]="r.y1"
+                [attr.x2]="r.x"
+                [attr.y2]="r.y2"
+              />
+            }
+          </g>
+        </g>
+      </svg>
+    </div>
+
+    <div
+      class="cards"
+      [class.swap-out]="swapClass() === 'swap-out'"
+      [class.swap-in]="swapClass() === 'swap-in'"
+    >
+      @if (loading() && prompts().length === 0) {
+        @for (_ of skeletonSlots; track $index) {
+          <div class="card card-skeleton" aria-hidden="true"></div>
+        }
+      } @else if (prompts().length > 0) {
+        @for (p of prompts(); track p.id) {
+          <button class="card" type="button" (click)="onCardClick(p)">
+            <div class="card-question">{{ p.question }}</div>
+            <div class="card-meta">
+              @if (p.categories && p.categories.length > 0) {
+                <span class="card-tag">{{ formatCategory(p.categories[0]) }}</span>
+              }
+              <span class="card-cta">Battle this &rarr;</span>
+            </div>
+          </button>
+        }
+      } @else {
+        <div class="cards-empty">
+          @if (error()) {
+            Couldn't load example prompts. Try again.
+          } @else {
+            No example prompts are available yet.
+          }
+        </div>
       }
     </div>
-  </div>
-
-  <div class="dna-reveal" [class.show]="selectedPrompt()">
-    <button class="dna-prompt" (click)="usePrompt()">{{ selectedPrompt() }}</button>
-    <div class="dna-hint">click to use this prompt</div>
   </div>
 </div>

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.html
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.html
@@ -1,10 +1,10 @@
-<div class="picker">
+<div class="prompt-picker">
   <button
     class="unwind-label"
     type="button"
-    (click)="tryAnother()"
+    (click)="refresh()"
     [disabled]="loading()"
-    aria-label="Unwind another example"
+    aria-label="Unwind an example"
   >
     <svg
       class="unwind-icon"
@@ -43,28 +43,28 @@
     </div>
 
     <div
-      class="cards"
+      class="prompt-cards"
       [class.swap-out]="swapClass() === 'swap-out'"
       [class.swap-in]="swapClass() === 'swap-in'"
     >
       @if (loading() && prompts().length === 0) {
         @for (_ of skeletonSlots; track $index) {
-          <div class="card card-skeleton" aria-hidden="true"></div>
+          <div class="prompt-card prompt-card-skeleton" aria-hidden="true"></div>
         }
       } @else if (prompts().length > 0) {
         @for (p of prompts(); track p.id) {
-          <button class="card" type="button" (click)="onCardClick(p)">
-            <div class="card-question">{{ p.question }}</div>
-            <div class="card-meta">
+          <button class="prompt-card" type="button" (click)="onCardClick(p)">
+            <div class="prompt-card-question">{{ p.question }}</div>
+            <div class="prompt-card-meta">
               @if (p.categories && p.categories.length > 0) {
-                <span class="card-tag">{{ formatCategory(p.categories[0]) }}</span>
+                <span class="prompt-card-tag">{{ formatCategory(p.categories[0]) }}</span>
               }
-              <span class="card-cta">Battle this &rarr;</span>
+              <span class="prompt-card-cta">Battle this &rarr;</span>
             </div>
           </button>
         }
       } @else {
-        <div class="cards-empty">
+        <div class="prompt-cards-empty">
           @if (error()) {
             Couldn't load example prompts. Try again.
           } @else {

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.html
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.html
@@ -49,19 +49,15 @@
     >
       @if (loading() && prompts().length === 0) {
         @for (_ of skeletonSlots; track $index) {
-          <div class="prompt-card prompt-card-skeleton" aria-hidden="true"></div>
+          <bixarena-prompt-card [question]="''" [skeleton]="true" />
         }
       } @else if (prompts().length > 0) {
         @for (p of prompts(); track p.id) {
-          <button class="prompt-card" type="button" (click)="onCardClick(p)">
-            <div class="prompt-card-question">{{ p.question }}</div>
-            <div class="prompt-card-meta">
-              @if (p.categories && p.categories.length > 0) {
-                <span class="prompt-card-tag">{{ formatCategory(p.categories[0]) }}</span>
-              }
-              <span class="prompt-card-cta">Battle this &rarr;</span>
-            </div>
-          </button>
+          <bixarena-prompt-card
+            [question]="p.question"
+            [category]="categoryLabel(p)"
+            (cardClick)="onCardClick(p)"
+          />
         }
       } @else {
         <div class="prompt-cards-empty">

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
@@ -26,7 +26,7 @@
   justify-content: center;
   gap: 0.45rem;
   width: fit-content;
-  margin: 0 auto 0.75rem;
+  margin: 0 auto;
   padding: 0.35rem 0.9rem;
   border: 1px solid var(--p-surface-200);
   border-radius: 999px;
@@ -64,7 +64,7 @@
 .stage {
   position: relative;
   width: 100%;
-  padding: 3rem 0;
+  padding: 2.8rem 0;
 }
 
 .helix-bg {

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
@@ -5,7 +5,7 @@
   margin: 0 auto;
 }
 
-.picker {
+.prompt-picker {
   width: 100%;
 }
 
@@ -104,7 +104,7 @@
   stroke-linecap: round;
 }
 
-.cards {
+.prompt-cards {
   position: relative;
   z-index: 1;
   display: grid;
@@ -112,7 +112,7 @@
   gap: 0.75rem;
 }
 
-.card-question {
+.prompt-card-question {
   font-size: var(--text-sm);
   color: var(--p-text-color);
   line-height: 1.5;
@@ -125,13 +125,13 @@
   overflow: hidden;
 }
 
-.card-meta {
+.prompt-card-meta {
   display: flex;
   align-items: center;
   gap: 0.75rem;
 }
 
-.card-tag {
+.prompt-card-tag {
   font-size: var(--text-xs);
   color: var(--p-primary-color);
   font-weight: 540;
@@ -140,14 +140,14 @@
   border-radius: 100px;
 }
 
-.card-cta {
+.prompt-card-cta {
   font-size: var(--text-xs);
   color: var(--p-text-muted-color);
   transition: color 0.15s;
   margin-left: auto;
 }
 
-.card {
+.prompt-card {
   background: var(--p-surface-100);
   border: 1px solid var(--p-surface-200);
   border-radius: var(--p-border-radius-lg);
@@ -169,13 +169,13 @@
     transform: translateY(-2px);
     box-shadow: 0 8px 32px rgb(0 0 0 / 25%);
 
-    .card-cta {
+    .prompt-card-cta {
       color: var(--p-primary-color);
     }
   }
 }
 
-.card-skeleton {
+.prompt-card-skeleton {
   cursor: default;
   position: relative;
   overflow: hidden;
@@ -185,7 +185,7 @@
     position: absolute;
     inset: 0;
     background: linear-gradient(90deg, transparent 0%, rgb(255 255 255 / 3%) 50%, transparent 100%);
-    animation: card-shimmer 1.4s ease-in-out infinite;
+    animation: prompt-card-shimmer 1.4s ease-in-out infinite;
   }
 
   &:hover {
@@ -195,7 +195,7 @@
   }
 }
 
-@keyframes card-shimmer {
+@keyframes prompt-card-shimmer {
   0% {
     transform: translateX(-100%);
   }
@@ -205,7 +205,7 @@
   }
 }
 
-.cards-empty {
+.prompt-cards-empty {
   grid-column: 1 / -1;
   text-align: center;
   color: var(--p-text-muted-color);
@@ -215,15 +215,15 @@
   border-radius: var(--p-border-radius-lg);
 }
 
-.cards.swap-out .card {
-  animation: card-swap-out 0.35s cubic-bezier(0.4, 0, 1, 1) forwards;
+.prompt-cards.swap-out .prompt-card {
+  animation: prompt-card-swap-out 0.35s cubic-bezier(0.4, 0, 1, 1) forwards;
 }
 
-.cards.swap-in .card {
-  animation: card-swap-in 0.45s cubic-bezier(0.2, 0.8, 0.3, 1);
+.prompt-cards.swap-in .prompt-card {
+  animation: prompt-card-swap-in 0.45s cubic-bezier(0.2, 0.8, 0.3, 1);
 }
 
-@keyframes card-swap-out {
+@keyframes prompt-card-swap-out {
   from {
     opacity: 1;
     transform: translateY(0);
@@ -235,7 +235,7 @@
   }
 }
 
-@keyframes card-swap-in {
+@keyframes prompt-card-swap-in {
   from {
     opacity: 0;
     transform: translateY(12px);
@@ -248,7 +248,7 @@
 }
 
 @media (width <= 720px) {
-  .cards {
+  .prompt-cards {
     grid-template-columns: 1fr;
   }
 
@@ -262,13 +262,13 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .card {
+  .prompt-card {
     transition: none;
   }
 
-  .cards.swap-out .card,
-  .cards.swap-in .card,
-  .card-skeleton::after {
+  .prompt-cards.swap-out .prompt-card,
+  .prompt-cards.swap-in .prompt-card,
+  .prompt-card-skeleton::after {
     animation: none;
   }
 }

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
@@ -1,208 +1,274 @@
 :host {
   display: block;
   width: 100%;
-  max-width: 640px;
+  max-width: 64rem;
   margin: 0 auto;
 }
 
-.dna-section {
-  position: relative;
+.picker {
+  width: 100%;
 }
 
-.dna-label {
-  text-align: center;
-  font-size: var(--text-xs);
+.unwind-icon {
+  width: 13px;
+  height: 13px;
   color: var(--p-text-muted-color);
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-  font-weight: 500;
-  margin-bottom: 0.25rem;
+  transition:
+    transform 0.9s cubic-bezier(0.5, 0, 0.5, 1),
+    color 0.2s;
 }
 
-.dna-wrap {
-  position: relative;
-  height: 130px;
+.unwind-label {
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 0.45rem;
+  width: fit-content;
+  margin: 0 auto 0.75rem;
+  padding: 0.35rem 0.9rem;
+  border: 1px solid var(--p-surface-200);
+  border-radius: 999px;
+  background: transparent;
+  font-family: inherit;
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--p-text-muted-color);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  cursor: pointer;
+  transition:
+    color 0.2s,
+    border-color 0.2s,
+    background 0.2s,
+    opacity 0.2s;
+
+  &:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  &:hover:not(:disabled) {
+    color: var(--p-teal-400);
+    border-color: rgb(52 212 180 / 45%);
+    background: rgb(52 212 180 / 6%);
+
+    .unwind-icon {
+      transform: rotate(180deg);
+      color: var(--p-teal-400);
+    }
+  }
 }
 
-.helix {
+.stage {
   position: relative;
-  width: 400px;
-  height: 100px;
+  width: 100%;
+  padding: 4rem 0;
 }
 
-.strand {
+.helix-bg {
   position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.helix-svg {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
 }
 
-.strand path {
+.helix-svg .strand {
   fill: none;
   stroke-width: 1.5;
   stroke-linecap: round;
-  opacity: 0.25;
+  opacity: 0.55;
 }
 
-.strand-front path {
+.helix-svg .strand-front {
   stroke: var(--p-teal-400);
 }
 
-.strand-back path {
+.helix-svg .strand-back {
   stroke: var(--p-primary-color);
 }
 
-.helix-node {
-  position: absolute;
-  width: 38px;
-  height: 38px;
-  border-radius: 50%;
-  cursor: pointer;
+.helix-svg .rung {
+  stroke: var(--p-surface-400);
+  stroke-width: 1;
+  opacity: 0.45;
+  stroke-linecap: round;
+}
+
+.cards {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+}
+
+.card-question {
+  font-size: var(--text-sm);
+  color: var(--p-text-color);
+  line-height: 1.5;
+  margin-bottom: 0.75rem;
+  font-weight: 460;
+  flex: 1;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.card-meta {
   display: flex;
   align-items: center;
-  justify-content: center;
-  transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-  z-index: 2;
-  border: none;
-  padding: 0;
-  background: none;
-  will-change: transform;
+  gap: 0.75rem;
+}
 
-  &::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: 50%;
-    background: var(--p-surface-100);
-    border: 1.5px solid var(--p-surface-200);
-    transition: all 0.3s;
+.card-tag {
+  font-size: var(--text-xs);
+  color: var(--p-primary-color);
+  font-weight: 540;
+  background: rgb(249 115 22 / 8%);
+  padding: 0.125rem 0.5rem;
+  border-radius: 100px;
+}
+
+.card-cta {
+  font-size: var(--text-xs);
+  color: var(--p-text-muted-color);
+  transition: color 0.15s;
+  margin-left: auto;
+}
+
+.card {
+  background: var(--p-surface-100);
+  border: 1px solid var(--p-surface-200);
+  border-radius: var(--p-border-radius-lg);
+  padding: 1.25rem;
+  min-height: 8.75rem;
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+  font-family: inherit;
+  color: inherit;
+  text-align: left;
+  transition:
+    transform 0.2s,
+    border-color 0.2s,
+    box-shadow 0.2s;
+
+  &:hover {
+    border-color: var(--p-surface-300);
+    transform: translateY(-2px);
+    box-shadow: 0 8px 32px rgb(0 0 0 / 25%);
+
+    .card-cta {
+      color: var(--p-primary-color);
+    }
   }
+}
+
+.card-skeleton {
+  cursor: default;
+  position: relative;
+  overflow: hidden;
 
   &::after {
     content: '';
     position: absolute;
-    inset: -4px;
-    border-radius: 50%;
-    background: transparent;
-    transition: all 0.3s;
+    inset: 0;
+    background: linear-gradient(90deg, transparent 0%, rgb(255 255 255 / 3%) 50%, transparent 100%);
+    animation: card-shimmer 1.4s ease-in-out infinite;
   }
 
   &:hover {
-    transform: scale(1.15);
-
-    &::before {
-      border-color: rgb(52 212 180 / 40%);
-      background: rgb(52 212 180 / 8%);
-    }
-
-    &::after {
-      background: rgb(52 212 180 / 6%);
-    }
-  }
-
-  &.active {
-    transform: scale(1.2);
-    animation: node-pulse 2s ease-in-out infinite;
-
-    &::before {
-      border-color: var(--p-teal-400);
-      background: rgb(52 212 180 / 10%);
-    }
-
-    &::after {
-      background: rgb(52 212 180 / 8%);
-    }
+    border-color: var(--p-surface-200);
+    transform: none;
+    box-shadow: none;
   }
 }
 
-.node-icon {
-  position: relative;
-  z-index: 1;
-  width: 16px;
-  height: 16px;
-  color: var(--p-surface-500);
-  transition: color 0.3s;
-
-  .helix-node:hover & {
-    color: var(--p-text-color);
+@keyframes card-shimmer {
+  0% {
+    transform: translateX(-100%);
   }
 
-  .helix-node.active & {
-    color: var(--p-teal-400);
-  }
-}
-
-.node-label {
-  position: absolute;
-  bottom: -22px;
-  left: 50%;
-  transform: translateX(-50%);
-  font-size: var(--text-xs);
-  color: var(--p-text-muted-color);
-  font-weight: 500;
-  white-space: nowrap;
-  letter-spacing: 0.02em;
-  transition: color 0.3s;
-  pointer-events: none;
-
-  .helix-node:hover & {
-    color: var(--p-text-color);
-  }
-
-  .helix-node.active & {
-    color: var(--p-teal-400);
-  }
-}
-
-.dna-reveal {
-  text-align: center;
-  margin-top: 1rem;
-  max-height: 0;
-  opacity: 0;
-  overflow: hidden;
-  transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-
-  &.show {
-    max-height: 80px;
-    opacity: 1;
-  }
-}
-
-.dna-prompt {
-  display: inline-block;
-  max-width: 31.25rem;
-  padding: 0.5rem 1rem;
-  background: var(--p-surface-100);
-  border: 1px solid var(--p-surface-200);
-  border-radius: 100px;
-  font: inherit;
-  font-size: var(--text-sm);
-  color: var(--p-text-color);
-  line-height: 1.5;
-  cursor: pointer;
-  transition: all 0.2s;
-  box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
-
-  &:hover {
-    border-color: var(--p-surface-300);
-  }
-}
-
-.dna-hint {
-  font-size: 0.625rem;
-  color: var(--p-text-muted-color);
-  margin-top: 0.25rem;
-}
-
-@keyframes node-pulse {
-  0%,
   100% {
-    box-shadow: 0 0 0 0 rgb(52 212 180 / 15%);
+    transform: translateX(100%);
+  }
+}
+
+.cards-empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: var(--p-text-muted-color);
+  font-size: var(--text-sm);
+  padding: 2rem;
+  border: 1px dashed var(--p-surface-200);
+  border-radius: var(--p-border-radius-lg);
+}
+
+.cards.swap-out .card {
+  animation: card-swap-out 0.35s cubic-bezier(0.4, 0, 1, 1) forwards;
+}
+
+.cards.swap-in .card {
+  animation: card-swap-in 0.45s cubic-bezier(0.2, 0.8, 0.3, 1);
+}
+
+@keyframes card-swap-out {
+  from {
+    opacity: 1;
+    transform: translateY(0);
   }
 
-  50% {
-    box-shadow: 0 0 0 10px rgb(52 212 180 / 0%);
+  to {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+}
+
+@keyframes card-swap-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (width <= 720px) {
+  .cards {
+    grid-template-columns: 1fr;
+  }
+
+  .helix-bg {
+    display: none;
+  }
+
+  .stage {
+    padding: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    transition: none;
+  }
+
+  .cards.swap-out .card,
+  .cards.swap-in .card,
+  .card-skeleton::after {
+    animation: none;
   }
 }

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
@@ -110,98 +110,13 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 0.75rem;
-}
 
-.prompt-card-question {
-  font-size: var(--text-sm);
-  color: var(--p-text-color);
-  line-height: 1.5;
-  margin-bottom: 0.75rem;
-  font-weight: 460;
-  flex: 1;
-  display: -webkit-box;
-  -webkit-line-clamp: 4;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-.prompt-card-meta {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.prompt-card-tag {
-  font-size: var(--text-xs);
-  color: var(--p-primary-color);
-  font-weight: 540;
-  background: rgb(249 115 22 / 8%);
-  padding: 0.125rem 0.5rem;
-  border-radius: 100px;
-}
-
-.prompt-card-cta {
-  font-size: var(--text-xs);
-  color: var(--p-text-muted-color);
-  transition: color 0.15s;
-  margin-left: auto;
-}
-
-.prompt-card {
-  background: var(--p-surface-100);
-  border: 1px solid var(--p-surface-200);
-  border-radius: var(--p-border-radius-lg);
-  padding: 1.25rem;
-  min-height: 8.75rem;
-  display: flex;
-  flex-direction: column;
-  cursor: pointer;
-  font-family: inherit;
-  color: inherit;
-  text-align: left;
-  transition:
-    transform 0.2s,
-    border-color 0.2s,
-    box-shadow 0.2s;
-
-  &:hover {
-    border-color: var(--p-surface-300);
-    transform: translateY(-2px);
-    box-shadow: 0 8px 32px rgb(0 0 0 / 25%);
-
-    .prompt-card-cta {
-      color: var(--p-primary-color);
-    }
-  }
-}
-
-.prompt-card-skeleton {
-  cursor: default;
-  position: relative;
-  overflow: hidden;
-
-  &::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(90deg, transparent 0%, rgb(255 255 255 / 3%) 50%, transparent 100%);
-    animation: prompt-card-shimmer 1.4s ease-in-out infinite;
+  &.swap-out {
+    animation: prompt-cards-swap-out 0.35s cubic-bezier(0.4, 0, 1, 1) forwards;
   }
 
-  &:hover {
-    border-color: var(--p-surface-200);
-    transform: none;
-    box-shadow: none;
-  }
-}
-
-@keyframes prompt-card-shimmer {
-  0% {
-    transform: translateX(-100%);
-  }
-
-  100% {
-    transform: translateX(100%);
+  &.swap-in {
+    animation: prompt-cards-swap-in 0.45s cubic-bezier(0.2, 0.8, 0.3, 1);
   }
 }
 
@@ -215,15 +130,7 @@
   border-radius: var(--p-border-radius-lg);
 }
 
-.prompt-cards.swap-out .prompt-card {
-  animation: prompt-card-swap-out 0.35s cubic-bezier(0.4, 0, 1, 1) forwards;
-}
-
-.prompt-cards.swap-in .prompt-card {
-  animation: prompt-card-swap-in 0.45s cubic-bezier(0.2, 0.8, 0.3, 1);
-}
-
-@keyframes prompt-card-swap-out {
+@keyframes prompt-cards-swap-out {
   from {
     opacity: 1;
     transform: translateY(0);
@@ -235,7 +142,7 @@
   }
 }
 
-@keyframes prompt-card-swap-in {
+@keyframes prompt-cards-swap-in {
   from {
     opacity: 0;
     transform: translateY(12px);
@@ -262,13 +169,10 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .prompt-card {
-    transition: none;
-  }
-
-  .prompt-cards.swap-out .prompt-card,
-  .prompt-cards.swap-in .prompt-card,
-  .prompt-card-skeleton::after {
-    animation: none;
+  .prompt-cards {
+    &.swap-out,
+    &.swap-in {
+      animation: none;
+    }
   }
 }

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
@@ -1,3 +1,5 @@
+@use 'shared/typescript/styles/src/shared-styles/variables' as shared;
+
 :host {
   display: block;
   width: 100%;
@@ -154,9 +156,11 @@
   }
 }
 
-@media (width <= 720px) {
+@media (width <= #{shared.$lg-breakpoint}) {
   .prompt-cards {
     grid-template-columns: 1fr;
+    max-width: 40rem;
+    margin: 0 auto;
   }
 
   .helix-bg {

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
@@ -12,8 +12,8 @@
 }
 
 .unwind-icon {
-  width: 13px;
-  height: 13px;
+  width: 0.8125rem;
+  height: 0.8125rem;
   color: var(--p-text-muted-color);
   transition:
     transform 0.9s cubic-bezier(0.5, 0, 0.5, 1),

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
@@ -62,7 +62,7 @@
 .stage {
   position: relative;
   width: 100%;
-  padding: 4rem 0;
+  padding: 3rem 0;
 }
 
 .helix-bg {

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.spec.ts
@@ -50,7 +50,7 @@ describe('ExamplePromptsComponent', () => {
     jest.useRealTimers();
   });
 
-  it('creates and fetches initial prompts with default filter', async () => {
+  it('creates and fetches initial prompts', async () => {
     await setup();
     expect(component).toBeTruthy();
     expect(listSpy).toHaveBeenCalledTimes(1);
@@ -70,32 +70,12 @@ describe('ExamplePromptsComponent', () => {
     expect(emitted).toEqual(['Question pX?']);
   });
 
-  it('refetches with a category filter when the category changes', async () => {
+  it('refresh fetches a fresh set', async () => {
     await setup();
-    listSpy.mockClear();
-    component.selectCategory(BiomedicalCategory.Neuroscience);
-    expect(listSpy).toHaveBeenCalledTimes(1);
-    const query = listSpy.mock.calls[0][0] as ExamplePromptSearchQuery;
-    expect(query.categories).toEqual([BiomedicalCategory.Neuroscience]);
-    expect(component.category()).toBe(BiomedicalCategory.Neuroscience);
-  });
-
-  it('selecting the already-active category does not refetch', async () => {
-    await setup();
-    listSpy.mockClear();
-    component.selectCategory('all');
-    expect(listSpy).not.toHaveBeenCalled();
-  });
-
-  it('refresh fetches a fresh set with the current filter', async () => {
-    await setup();
-    component.selectCategory(BiomedicalCategory.CancerBiology);
     listSpy.mockClear();
     component.refresh();
     jest.advanceTimersByTime(500);
     expect(listSpy).toHaveBeenCalledTimes(1);
-    const query = listSpy.mock.calls[0][0] as ExamplePromptSearchQuery;
-    expect(query.categories).toEqual([BiomedicalCategory.CancerBiology]);
   });
 
   it('refresh is debounced while a fetch is in-flight', async () => {
@@ -111,17 +91,27 @@ describe('ExamplePromptsComponent', () => {
   });
 
   it('renders empty state when the API returns no prompts', async () => {
-    await setup();
-    listSpy.mockImplementation(() => of({ examplePrompts: [] } as unknown as ExamplePromptPage));
-    component.selectCategory(BiomedicalCategory.Genomics);
+    listSpy = jest.fn(() => of({ examplePrompts: [] } as unknown as ExamplePromptPage));
+    await TestBed.configureTestingModule({
+      imports: [ExamplePromptsComponent],
+      providers: [{ provide: ExamplePromptService, useValue: { listExamplePrompts: listSpy } }],
+    }).compileComponents();
+    fixture = TestBed.createComponent(ExamplePromptsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
     expect(component.prompts()).toEqual([]);
     expect(component.error()).toBe(false);
   });
 
   it('sets the error flag when the API call fails', async () => {
-    await setup();
-    listSpy.mockImplementation(() => throwError(() => new Error('boom')));
-    component.selectCategory(BiomedicalCategory.Physiology);
+    listSpy = jest.fn(() => throwError(() => new Error('boom')));
+    await TestBed.configureTestingModule({
+      imports: [ExamplePromptsComponent],
+      providers: [{ provide: ExamplePromptService, useValue: { listExamplePrompts: listSpy } }],
+    }).compileComponents();
+    fixture = TestBed.createComponent(ExamplePromptsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
     expect(component.error()).toBe(true);
     expect(component.prompts()).toEqual([]);
   });

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.spec.ts
@@ -1,40 +1,139 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import {
+  BiomedicalCategory,
+  ExamplePrompt,
+  ExamplePromptPage,
+  ExamplePromptSearchQuery,
+  ExamplePromptService,
+  ExamplePromptSort,
+} from '@sagebionetworks/bixarena/api-client';
 import { ExamplePromptsComponent } from './example-prompts.component';
 
 describe('ExamplePromptsComponent', () => {
   let component: ExamplePromptsComponent;
   let fixture: ComponentFixture<ExamplePromptsComponent>;
+  let listSpy: jest.Mock;
 
-  beforeEach(async () => {
+  const makePrompts = (ids: string[]): ExamplePrompt[] =>
+    ids.map((id) => ({
+      id,
+      question: `Question ${id}?`,
+      source: 'bixarena',
+      active: true,
+      categories: [BiomedicalCategory.Genetics],
+      createdAt: '2026-04-20T00:00:00Z',
+    })) as ExamplePrompt[];
+
+  const pageOf = (ids: string[]): Partial<ExamplePromptPage> => ({
+    examplePrompts: makePrompts(ids),
+  });
+
+  async function setup(initialIds = ['p1', 'p2', 'p3']) {
+    listSpy = jest.fn(() => of(pageOf(initialIds) as ExamplePromptPage));
+
     await TestBed.configureTestingModule({
       imports: [ExamplePromptsComponent],
+      providers: [{ provide: ExamplePromptService, useValue: { listExamplePrompts: listSpy } }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ExamplePromptsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
   });
 
-  it('should create', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('creates and fetches initial prompts with default filter', async () => {
+    await setup();
     expect(component).toBeTruthy();
+    expect(listSpy).toHaveBeenCalledTimes(1);
+    const query = listSpy.mock.calls[0][0] as ExamplePromptSearchQuery;
+    expect(query.sort).toBe(ExamplePromptSort.Random);
+    expect(query.pageSize).toBe(3);
+    expect(query.active).toBe(true);
+    expect(query.categories).toBeUndefined();
+    expect(component.prompts()).toHaveLength(3);
   });
 
-  it('should have 5 helix nodes', () => {
-    expect(component.nodes).toHaveLength(5);
+  it('emits promptSelect with the question text on card click', async () => {
+    await setup(['pX']);
+    const emitted: string[] = [];
+    component.promptSelect.subscribe((q) => emitted.push(q));
+    component.onCardClick(component.prompts()[0]);
+    expect(emitted).toEqual(['Question pX?']);
   });
 
-  it('should select a prompt on node click', () => {
-    component.onNodeClick(component.nodes[0]);
-    expect(component.selectedPrompt()).toBeTruthy();
-    expect(component.selectedCategory()).toBe('Cardiology');
+  it('refetches with a category filter when the category changes', async () => {
+    await setup();
+    listSpy.mockClear();
+    component.selectCategory(BiomedicalCategory.Neuroscience);
+    expect(listSpy).toHaveBeenCalledTimes(1);
+    const query = listSpy.mock.calls[0][0] as ExamplePromptSearchQuery;
+    expect(query.categories).toEqual([BiomedicalCategory.Neuroscience]);
+    expect(component.category()).toBe(BiomedicalCategory.Neuroscience);
   });
 
-  it('should emit prompt on usePrompt', () => {
-    const spy = jest.fn();
-    component.promptSelect.subscribe(spy);
-    component.onNodeClick(component.nodes[0]);
-    component.usePrompt();
-    expect(spy).toHaveBeenCalled();
-    expect(component.selectedPrompt()).toBeNull();
+  it('selecting the already-active category does not refetch', async () => {
+    await setup();
+    listSpy.mockClear();
+    component.selectCategory('all');
+    expect(listSpy).not.toHaveBeenCalled();
+  });
+
+  it('tryAnother fetches a fresh set with the current filter', async () => {
+    await setup();
+    component.selectCategory(BiomedicalCategory.CancerBiology);
+    listSpy.mockClear();
+    component.tryAnother();
+    jest.advanceTimersByTime(500);
+    expect(listSpy).toHaveBeenCalledTimes(1);
+    const query = listSpy.mock.calls[0][0] as ExamplePromptSearchQuery;
+    expect(query.categories).toEqual([BiomedicalCategory.CancerBiology]);
+  });
+
+  it('tryAnother is debounced while a fetch is in-flight', async () => {
+    await setup();
+    listSpy.mockImplementation(() => of(pageOf(['qA']) as ExamplePromptPage));
+    component.loading.set(true);
+    component.tryAnother();
+    jest.advanceTimersByTime(500);
+    const baseline = listSpy.mock.calls.length;
+    component.tryAnother();
+    jest.advanceTimersByTime(500);
+    expect(listSpy.mock.calls.length).toBe(baseline);
+  });
+
+  it('renders empty state when the API returns no prompts', async () => {
+    await setup();
+    listSpy.mockImplementation(() => of({ examplePrompts: [] } as unknown as ExamplePromptPage));
+    component.selectCategory(BiomedicalCategory.Genomics);
+    expect(component.prompts()).toEqual([]);
+    expect(component.error()).toBe(false);
+  });
+
+  it('sets the error flag when the API call fails', async () => {
+    await setup();
+    listSpy.mockImplementation(() => throwError(() => new Error('boom')));
+    component.selectCategory(BiomedicalCategory.Physiology);
+    expect(component.error()).toBe(true);
+    expect(component.prompts()).toEqual([]);
+  });
+
+  it('exposes static helix geometry for the template', async () => {
+    await setup();
+    expect(component.frontPath.startsWith('M')).toBe(true);
+    expect(component.backPath.startsWith('M')).toBe(true);
+    expect(component.rungs.length).toBeGreaterThan(0);
+    for (const r of component.rungs) {
+      expect(typeof r.x).toBe('number');
+      expect(r.y1).not.toBe(r.y2);
+    }
   });
 });

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.spec.ts
@@ -70,6 +70,19 @@ describe('ExamplePromptsComponent', () => {
     expect(emitted).toEqual(['Question pX?']);
   });
 
+  it('categoryLabel formats multi-word slugs with preserved "and"', async () => {
+    await setup();
+    const prompt = {
+      id: 'p',
+      question: 'q?',
+      source: 'bixarena',
+      active: true,
+      categories: [BiomedicalCategory.PharmacologyAndToxicology],
+      createdAt: '2026-04-20T00:00:00Z',
+    } as ExamplePrompt;
+    expect(component.categoryLabel(prompt)).toBe('Pharmacology and Toxicology');
+  });
+
   it('refresh fetches a fresh set', async () => {
     await setup();
     listSpy.mockClear();

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.spec.ts
@@ -87,25 +87,25 @@ describe('ExamplePromptsComponent', () => {
     expect(listSpy).not.toHaveBeenCalled();
   });
 
-  it('tryAnother fetches a fresh set with the current filter', async () => {
+  it('refresh fetches a fresh set with the current filter', async () => {
     await setup();
     component.selectCategory(BiomedicalCategory.CancerBiology);
     listSpy.mockClear();
-    component.tryAnother();
+    component.refresh();
     jest.advanceTimersByTime(500);
     expect(listSpy).toHaveBeenCalledTimes(1);
     const query = listSpy.mock.calls[0][0] as ExamplePromptSearchQuery;
     expect(query.categories).toEqual([BiomedicalCategory.CancerBiology]);
   });
 
-  it('tryAnother is debounced while a fetch is in-flight', async () => {
+  it('refresh is debounced while a fetch is in-flight', async () => {
     await setup();
     listSpy.mockImplementation(() => of(pageOf(['qA']) as ExamplePromptPage));
     component.loading.set(true);
-    component.tryAnother();
+    component.refresh();
     jest.advanceTimersByTime(500);
     const baseline = listSpy.mock.calls.length;
-    component.tryAnother();
+    component.refresh();
     jest.advanceTimersByTime(500);
     expect(listSpy.mock.calls.length).toBe(baseline);
   });

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.spec.ts
@@ -21,7 +21,7 @@ describe('ExamplePromptsComponent', () => {
       question: `Question ${id}?`,
       source: 'bixarena',
       active: true,
-      categories: [BiomedicalCategory.Genetics],
+      category: BiomedicalCategory.Genetics,
       createdAt: '2026-04-20T00:00:00Z',
     })) as ExamplePrompt[];
 
@@ -77,7 +77,7 @@ describe('ExamplePromptsComponent', () => {
       question: 'q?',
       source: 'bixarena',
       active: true,
-      categories: [BiomedicalCategory.PharmacologyAndToxicology],
+      category: BiomedicalCategory.PharmacologyAndToxicology,
       createdAt: '2026-04-20T00:00:00Z',
     } as ExamplePrompt;
     expect(component.categoryLabel(prompt)).toBe('Pharmacology and Toxicology');

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
@@ -19,88 +19,13 @@ import {
   ExamplePromptSort,
 } from '@sagebionetworks/bixarena/api-client';
 import { PromptCardComponent } from '@sagebionetworks/bixarena/ui';
-
-type CategoryFilter = 'all' | BiomedicalCategory;
-
-interface RungSpec {
-  x: number;
-  y1: number;
-  y2: number;
-}
+import { buildRungs, buildStrandPath, WAVELEN } from './dna-helix';
 
 const PAGE_SIZE = 3;
-
-// DNA helix geometry.
-// Each strand is a chain of S-cubics — one cubic per full wavelength with
-// control points on OPPOSITE sides of the midline. Y(t) peaks at
-// t = 0.5 ∓ √3/6 and reaches MID ± 0.2887·CTRL_AMP, so the visible amplitude
-// is VIS_AMP when CTRL_AMP = VIS_AMP / 0.2887.
-const VB_W = 900;
-const MID_Y = 90;
-const WAVELEN = 600;
-const VIS_AMP = 65;
-const CTRL_AMP = VIS_AMP / 0.2887;
-// RUNG_STEP must divide WAVELEN evenly so the rung lattice is also
-// WAVELEN-periodic — otherwise rungs shift relative to the strands on spin
-// reset and flash at the viewBox edges.
-const RUNG_STEP = 20;
-const LEAD_WAVES = 1;
-const TRAIL_WAVES = 3;
-// Quarter-wavelength phase shift places midline X-crossings inside the
-// viewBox (at 150 / 450 / 750) instead of at the edges, so the leftmost
-// and rightmost ovals read symmetric with the middle one.
-const PHASE_OFFSET = WAVELEN / 4;
 
 const SPIN_MS = 1200;
 const SWAP_MIDPOINT_MS = 420;
 const SWAP_IN_MS = 500;
-
-function cubicFactor(t: number): number {
-  // 3·t·(1-t)·(1-2t) ∈ [-0.2887, +0.2887]
-  return 3 * t * (1 - t) * (1 - 2 * t);
-}
-
-function buildStrandPath(firstUp: boolean): string {
-  const startX = -LEAD_WAVES * WAVELEN - PHASE_OFFSET;
-  const endX = VB_W + TRAIL_WAVES * WAVELEN;
-  const count = Math.ceil((endX - startX) / WAVELEN);
-  let d = `M ${startX} ${MID_Y}`;
-  for (let i = 0; i < count; i++) {
-    const x0 = startX + i * WAVELEN;
-    const x1 = x0 + WAVELEN;
-    const c1x = x0 + WAVELEN / 3;
-    const c2x = x0 + (2 * WAVELEN) / 3;
-    const c1y = firstUp ? MID_Y - CTRL_AMP : MID_Y + CTRL_AMP;
-    const c2y = firstUp ? MID_Y + CTRL_AMP : MID_Y - CTRL_AMP;
-    d += ` C ${c1x} ${c1y} ${c2x} ${c2y} ${x1} ${MID_Y}`;
-  }
-  return d;
-}
-
-function buildRungs(): RungSpec[] {
-  const strandStartX = -LEAD_WAVES * WAVELEN - PHASE_OFFSET;
-  const rungEnd = VB_W + TRAIL_WAVES * WAVELEN;
-  const out: RungSpec[] = [];
-  for (let x = strandStartX; x <= rungEnd; x += RUNG_STEP) {
-    const offset = x - strandStartX;
-    const local = ((offset % WAVELEN) + WAVELEN) % WAVELEN;
-    const factor = cubicFactor(local / WAVELEN);
-    const yF = MID_Y - CTRL_AMP * factor;
-    const yB = MID_Y + CTRL_AMP * factor;
-    if (Math.abs(yF - yB) < 14) continue;
-    out.push({ x, y1: yF, y2: yB });
-  }
-  return out;
-}
-
-function shuffle<T>(arr: readonly T[]): T[] {
-  const a = [...arr];
-  for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [a[i], a[j]] = [a[j], a[i]];
-  }
-  return a;
-}
 
 function formatCategory(slug: BiomedicalCategory): string {
   return slug
@@ -126,7 +51,6 @@ export class ExamplePromptsComponent implements AfterViewInit, OnDestroy {
   readonly backPath = buildStrandPath(false);
   readonly rungs = buildRungs();
 
-  readonly category = signal<CategoryFilter>('all');
   readonly prompts = signal<ExamplePrompt[]>([]);
   readonly loading = signal(false);
   readonly error = signal(false);
@@ -146,12 +70,6 @@ export class ExamplePromptsComponent implements AfterViewInit, OnDestroy {
     if (this.spinRaf !== null) cancelAnimationFrame(this.spinRaf);
     if (this.swapTimer) clearTimeout(this.swapTimer);
     if (this.endTimer) clearTimeout(this.endTimer);
-  }
-
-  selectCategory(cat: CategoryFilter): void {
-    if (this.category() === cat && !this.error()) return;
-    this.category.set(cat);
-    this.commitFetch();
   }
 
   refresh(): void {
@@ -194,17 +112,13 @@ export class ExamplePromptsComponent implements AfterViewInit, OnDestroy {
   private fetchPrompts(): Observable<ExamplePrompt[]> {
     this.loading.set(true);
     this.error.set(false);
-    const cat = this.category();
     const query: ExamplePromptSearchQuery = {
       sort: ExamplePromptSort.Random,
       pageSize: PAGE_SIZE,
       active: true,
-      ...(cat !== 'all' ? { categories: [cat] } : {}),
     };
-    // Shuffle client-side because the server's RANDOM sort can return the
-    // same order for small pools.
     return this.svc.listExamplePrompts(query).pipe(
-      map((page) => shuffle(page.examplePrompts ?? [])),
+      map((page) => page.examplePrompts ?? []),
       catchError(() => {
         this.error.set(true);
         return of<ExamplePrompt[]>([]);

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
@@ -18,6 +18,7 @@ import {
   ExamplePromptService,
   ExamplePromptSort,
 } from '@sagebionetworks/bixarena/api-client';
+import { PromptCardComponent } from '@sagebionetworks/bixarena/ui';
 
 type CategoryFilter = 'all' | BiomedicalCategory;
 
@@ -110,6 +111,7 @@ function formatCategory(slug: BiomedicalCategory): string {
 
 @Component({
   selector: 'bixarena-example-prompts',
+  imports: [PromptCardComponent],
   templateUrl: './example-prompts.component.html',
   styleUrl: './example-prompts.component.scss',
 })
@@ -131,7 +133,6 @@ export class ExamplePromptsComponent implements AfterViewInit, OnDestroy {
   readonly swapClass = signal<'swap-out' | 'swap-in' | null>(null);
 
   readonly skeletonSlots = [0, 1, 2];
-  readonly formatCategory = formatCategory;
 
   private spinRaf: number | null = null;
   private swapTimer: ReturnType<typeof setTimeout> | null = null;
@@ -179,6 +180,11 @@ export class ExamplePromptsComponent implements AfterViewInit, OnDestroy {
 
   onCardClick(p: ExamplePrompt): void {
     this.promptSelect.emit(p.question);
+  }
+
+  categoryLabel(p: ExamplePrompt): string | undefined {
+    const slug = p.categories?.[0];
+    return slug ? formatCategory(slug) : undefined;
   }
 
   private commitFetch(): void {

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
@@ -24,6 +24,8 @@ import { buildRungs, buildStrandPath, WAVELEN } from './dna-helix';
 const PAGE_SIZE = 3;
 
 const SPIN_MS = 1200;
+// 70 ms past the 350 ms `.swap-out` CSS keyframe duration so the browser
+// has time to finish the fade-out paint before we swap content in.
 const SWAP_MIDPOINT_MS = 420;
 const SWAP_IN_MS = 500;
 

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
@@ -153,7 +153,7 @@ export class ExamplePromptsComponent implements AfterViewInit, OnDestroy {
     this.commitFetch();
   }
 
-  tryAnother(): void {
+  refresh(): void {
     if (this.loading() || this.swapClass() !== null) return;
 
     this.animateSpin();

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
@@ -103,8 +103,7 @@ export class ExamplePromptsComponent implements AfterViewInit, OnDestroy {
   }
 
   categoryLabel(p: ExamplePrompt): string | undefined {
-    const slug = p.categories?.[0];
-    return slug ? formatCategory(slug) : undefined;
+    return p.category ? formatCategory(p.category) : undefined;
   }
 
   private commitFetch(): void {

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
@@ -86,6 +86,17 @@ export class ExamplePromptsComponent implements AfterViewInit, OnDestroy {
     // being replaced, producing a visible flash.
     const started = performance.now();
     this.fetchPrompts().subscribe((newPrompts) => {
+      if (newPrompts === null) {
+        // Refresh failed — preserve the existing cards instead of wiping
+        // them. A transient blip shouldn't destroy content the user was
+        // already reading.
+        this.error.set(true);
+        if (this.swapTimer) clearTimeout(this.swapTimer);
+        this.swapClass.set(null);
+        return;
+      }
+
+      this.error.set(false);
       const elapsed = performance.now() - started;
       const wait = Math.max(0, SWAP_MIDPOINT_MS - elapsed);
       if (this.swapTimer) clearTimeout(this.swapTimer);
@@ -107,23 +118,30 @@ export class ExamplePromptsComponent implements AfterViewInit, OnDestroy {
   }
 
   private commitFetch(): void {
-    this.fetchPrompts().subscribe((p) => this.prompts.set(p));
+    this.fetchPrompts().subscribe((p) => {
+      if (p === null) {
+        this.error.set(true);
+        this.prompts.set([]);
+      } else {
+        this.error.set(false);
+        this.prompts.set(p);
+      }
+    });
   }
 
-  private fetchPrompts(): Observable<ExamplePrompt[]> {
+  // Returns null on fetch failure so callers can distinguish a legitimate
+  // empty result from a network/API error and decide whether to wipe the
+  // current cards.
+  private fetchPrompts(): Observable<ExamplePrompt[] | null> {
     this.loading.set(true);
-    this.error.set(false);
     const query: ExamplePromptSearchQuery = {
       sort: ExamplePromptSort.Random,
       pageSize: PAGE_SIZE,
       active: true,
     };
     return this.svc.listExamplePrompts(query).pipe(
-      map((page) => page.examplePrompts ?? []),
-      catchError(() => {
-        this.error.set(true);
-        return of<ExamplePrompt[]>([]);
-      }),
+      map((page): ExamplePrompt[] | null => page.examplePrompts ?? []),
+      catchError(() => of<ExamplePrompt[] | null>(null)),
       finalize(() => this.loading.set(false)),
     );
   }

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.ts
@@ -1,142 +1,234 @@
-import { Component, inject, OnDestroy, output, PLATFORM_ID, signal } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  inject,
+  OnDestroy,
+  output,
+  PLATFORM_ID,
+  signal,
+  viewChild,
+} from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
+import { catchError, finalize, map, Observable, of } from 'rxjs';
+import {
+  BiomedicalCategory,
+  ExamplePrompt,
+  ExamplePromptSearchQuery,
+  ExamplePromptService,
+  ExamplePromptSort,
+} from '@sagebionetworks/bixarena/api-client';
 
-interface HelixNode {
-  label: string;
-  icon: string;
-  top: number;
-  left: number;
+type CategoryFilter = 'all' | BiomedicalCategory;
+
+interface RungSpec {
+  x: number;
+  y1: number;
+  y2: number;
 }
 
-interface CategoryPrompt {
-  category: string;
-  prompts: string[];
+const PAGE_SIZE = 3;
+
+// DNA helix geometry.
+// Each strand is a chain of S-cubics — one cubic per full wavelength with
+// control points on OPPOSITE sides of the midline. Y(t) peaks at
+// t = 0.5 ∓ √3/6 and reaches MID ± 0.2887·CTRL_AMP, so the visible amplitude
+// is VIS_AMP when CTRL_AMP = VIS_AMP / 0.2887.
+const VB_W = 900;
+const MID_Y = 90;
+const WAVELEN = 600;
+const VIS_AMP = 65;
+const CTRL_AMP = VIS_AMP / 0.2887;
+// RUNG_STEP must divide WAVELEN evenly so the rung lattice is also
+// WAVELEN-periodic — otherwise rungs shift relative to the strands on spin
+// reset and flash at the viewBox edges.
+const RUNG_STEP = 20;
+const LEAD_WAVES = 1;
+const TRAIL_WAVES = 3;
+// Quarter-wavelength phase shift places midline X-crossings inside the
+// viewBox (at 150 / 450 / 750) instead of at the edges, so the leftmost
+// and rightmost ovals read symmetric with the middle one.
+const PHASE_OFFSET = WAVELEN / 4;
+
+const SPIN_MS = 1200;
+const SWAP_MIDPOINT_MS = 420;
+const SWAP_IN_MS = 500;
+
+function cubicFactor(t: number): number {
+  // 3·t·(1-t)·(1-2t) ∈ [-0.2887, +0.2887]
+  return 3 * t * (1 - t) * (1 - 2 * t);
 }
 
-const HELIX_NODES: HelixNode[] = [
-  {
-    label: 'Cardiology',
-    icon: 'M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z',
-    top: 32,
-    left: 55,
-  },
-  {
-    label: 'Oncology',
-    icon: 'M12 12m-10 0a10 10 0 1 0 20 0a10 10 0 1 0-20 0M16 12l-4-4-4 4M12 16V8',
-    top: 58,
-    left: 130,
-  },
-  {
-    label: 'Genetics',
-    icon: 'M2 15c6.667-6 13.333 0 20-6M9 22c1.798-1.998 2.518-3.995 2.807-5.993M15 2c-1.798 1.998-2.518 3.995-2.807 5.993',
-    top: 28,
-    left: 205,
-  },
-  {
-    label: 'Neuro',
-    icon: 'M12 2a8 8 0 0 0-8 8c0 6 8 12 8 12s8-6 8-12a8 8 0 0 0-8-8ZM12 10m-3 0a3 3 0 1 0 6 0a3 3 0 1 0-6 0',
-    top: 58,
-    left: 280,
-  },
-  {
-    label: 'Immuno',
-    icon: 'm10 20-1.25-2.5L6 18l1-3-2.5-1.5L6 12 4.5 10.5 7 9l-1-3 2.75.5L10 4l2 2 2-2 1.25 2.5L18 6l-1 3 2.5 1.5L18 12l1.5 1.5L17 15l1 3-2.75-.5L14 20l-2-2Z',
-    top: 32,
-    left: 355,
-  },
-];
+function buildStrandPath(firstUp: boolean): string {
+  const startX = -LEAD_WAVES * WAVELEN - PHASE_OFFSET;
+  const endX = VB_W + TRAIL_WAVES * WAVELEN;
+  const count = Math.ceil((endX - startX) / WAVELEN);
+  let d = `M ${startX} ${MID_Y}`;
+  for (let i = 0; i < count; i++) {
+    const x0 = startX + i * WAVELEN;
+    const x1 = x0 + WAVELEN;
+    const c1x = x0 + WAVELEN / 3;
+    const c2x = x0 + (2 * WAVELEN) / 3;
+    const c1y = firstUp ? MID_Y - CTRL_AMP : MID_Y + CTRL_AMP;
+    const c2y = firstUp ? MID_Y + CTRL_AMP : MID_Y - CTRL_AMP;
+    d += ` C ${c1x} ${c1y} ${c2x} ${c2y} ${x1} ${MID_Y}`;
+  }
+  return d;
+}
 
-// Mock data — will be replaced by API with category support
-const MOCK_PROMPTS: CategoryPrompt[] = [
-  {
-    category: 'Cardiology',
-    prompts: [
-      'What are the latest guidelines for managing atrial fibrillation?',
-      'How does SGLT2 inhibitor therapy benefit heart failure patients?',
-      'What is the role of cardiac MRI in diagnosing myocarditis?',
-    ],
-  },
-  {
-    category: 'Oncology',
-    prompts: [
-      'What are the current immunotherapy options for non-small cell lung cancer?',
-      'How do checkpoint inhibitors work in cancer treatment?',
-      'What is the role of liquid biopsy in cancer diagnosis?',
-    ],
-  },
-  {
-    category: 'Genetics',
-    prompts: [
-      'How does CRISPR-Cas9 gene editing work and what are its clinical applications?',
-      'What are the ethical considerations of germline gene therapy?',
-      'How do polygenic risk scores help predict disease susceptibility?',
-    ],
-  },
-  {
-    category: 'Neuro',
-    prompts: [
-      "What are the emerging biomarkers for early detection of Alzheimer's disease?",
-      "How does deep brain stimulation work for Parkinson's disease?",
-      'What is the current understanding of long COVID neurological effects?',
-    ],
-  },
-  {
-    category: 'Immuno',
-    prompts: [
-      'How do mRNA vaccines trigger an immune response?',
-      'What is the role of T-cell exhaustion in chronic infections?',
-      'How do autoimmune diseases develop and what are common treatment approaches?',
-    ],
-  },
-];
+function buildRungs(): RungSpec[] {
+  const strandStartX = -LEAD_WAVES * WAVELEN - PHASE_OFFSET;
+  const rungEnd = VB_W + TRAIL_WAVES * WAVELEN;
+  const out: RungSpec[] = [];
+  for (let x = strandStartX; x <= rungEnd; x += RUNG_STEP) {
+    const offset = x - strandStartX;
+    const local = ((offset % WAVELEN) + WAVELEN) % WAVELEN;
+    const factor = cubicFactor(local / WAVELEN);
+    const yF = MID_Y - CTRL_AMP * factor;
+    const yB = MID_Y + CTRL_AMP * factor;
+    if (Math.abs(yF - yB) < 14) continue;
+    out.push({ x, y1: yF, y2: yB });
+  }
+  return out;
+}
+
+function shuffle<T>(arr: readonly T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+function formatCategory(slug: BiomedicalCategory): string {
+  return slug
+    .split('-')
+    .map((w, i) => (i > 0 && w === 'and' ? w : w.charAt(0).toUpperCase() + w.slice(1)))
+    .join(' ');
+}
 
 @Component({
   selector: 'bixarena-example-prompts',
   templateUrl: './example-prompts.component.html',
   styleUrl: './example-prompts.component.scss',
 })
-export class ExamplePromptsComponent implements OnDestroy {
-  readonly promptSelect = output<string>();
-  readonly nodes = HELIX_NODES;
-  readonly selectedPrompt = signal<string | null>(null);
-  readonly selectedCategory = signal<string | null>(null);
-
-  private readonly onDocClick = (e: MouseEvent) => {
-    const target = e.target as HTMLElement;
-    if (!target.closest('.helix-node') && !target.closest('.dna-prompt')) {
-      this.selectedPrompt.set(null);
-      this.selectedCategory.set(null);
-    }
-  };
-
+export class ExamplePromptsComponent implements AfterViewInit, OnDestroy {
+  private readonly svc = inject(ExamplePromptService);
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+  private readonly flowGroupRef = viewChild<ElementRef<SVGGElement>>('flowGroup');
 
-  constructor() {
-    if (this.isBrowser) {
-      document.addEventListener('click', this.onDocClick);
-    }
+  readonly promptSelect = output<string>();
+
+  readonly frontPath = buildStrandPath(true);
+  readonly backPath = buildStrandPath(false);
+  readonly rungs = buildRungs();
+
+  readonly category = signal<CategoryFilter>('all');
+  readonly prompts = signal<ExamplePrompt[]>([]);
+  readonly loading = signal(false);
+  readonly error = signal(false);
+  readonly swapClass = signal<'swap-out' | 'swap-in' | null>(null);
+
+  readonly skeletonSlots = [0, 1, 2];
+  readonly formatCategory = formatCategory;
+
+  private spinRaf: number | null = null;
+  private swapTimer: ReturnType<typeof setTimeout> | null = null;
+  private endTimer: ReturnType<typeof setTimeout> | null = null;
+
+  ngAfterViewInit(): void {
+    this.commitFetch();
   }
 
   ngOnDestroy(): void {
-    if (this.isBrowser) {
-      document.removeEventListener('click', this.onDocClick);
-    }
+    if (this.spinRaf !== null) cancelAnimationFrame(this.spinRaf);
+    if (this.swapTimer) clearTimeout(this.swapTimer);
+    if (this.endTimer) clearTimeout(this.endTimer);
   }
 
-  onNodeClick(node: HelixNode): void {
-    const category = MOCK_PROMPTS.find((c) => c.category === node.label);
-    if (!category) return;
-    const randomPrompt = category.prompts[Math.floor(Math.random() * category.prompts.length)];
-    this.selectedPrompt.set(randomPrompt);
-    this.selectedCategory.set(node.label);
+  selectCategory(cat: CategoryFilter): void {
+    if (this.category() === cat && !this.error()) return;
+    this.category.set(cat);
+    this.commitFetch();
   }
 
-  usePrompt(): void {
-    const prompt = this.selectedPrompt();
-    if (prompt) {
-      this.promptSelect.emit(prompt);
-      this.selectedPrompt.set(null);
-      this.selectedCategory.set(null);
-    }
+  tryAnother(): void {
+    if (this.loading() || this.swapClass() !== null) return;
+
+    this.animateSpin();
+    this.swapClass.set('swap-out');
+
+    // Fetch in parallel with the fade-out, then commit + trigger fade-in
+    // only once BOTH the fade-out timing has elapsed AND the fetch has
+    // resolved. Otherwise the stale cards fade back in for a frame before
+    // being replaced, producing a visible flash.
+    const started = performance.now();
+    this.fetchPrompts().subscribe((newPrompts) => {
+      const elapsed = performance.now() - started;
+      const wait = Math.max(0, SWAP_MIDPOINT_MS - elapsed);
+      if (this.swapTimer) clearTimeout(this.swapTimer);
+      this.swapTimer = setTimeout(() => {
+        this.prompts.set(newPrompts);
+        this.swapClass.set('swap-in');
+        if (this.endTimer) clearTimeout(this.endTimer);
+        this.endTimer = setTimeout(() => this.swapClass.set(null), SWAP_IN_MS);
+      }, wait);
+    });
+  }
+
+  onCardClick(p: ExamplePrompt): void {
+    this.promptSelect.emit(p.question);
+  }
+
+  private commitFetch(): void {
+    this.fetchPrompts().subscribe((p) => this.prompts.set(p));
+  }
+
+  private fetchPrompts(): Observable<ExamplePrompt[]> {
+    this.loading.set(true);
+    this.error.set(false);
+    const cat = this.category();
+    const query: ExamplePromptSearchQuery = {
+      sort: ExamplePromptSort.Random,
+      pageSize: PAGE_SIZE,
+      active: true,
+      ...(cat !== 'all' ? { categories: [cat] } : {}),
+    };
+    // Shuffle client-side because the server's RANDOM sort can return the
+    // same order for small pools.
+    return this.svc.listExamplePrompts(query).pipe(
+      map((page) => shuffle(page.examplePrompts ?? [])),
+      catchError(() => {
+        this.error.set(true);
+        return of<ExamplePrompt[]>([]);
+      }),
+      finalize(() => this.loading.set(false)),
+    );
+  }
+
+  // Translates the strand group by -WAVELEN in SVG user-space. Because the
+  // wave is periodic at WAVELEN, snapping back to 0 at the end is visually
+  // identical to the final frame — no edge flash.
+  private animateSpin(): void {
+    if (!this.isBrowser) return;
+    const g = this.flowGroupRef()?.nativeElement;
+    if (!g) return;
+    if (this.spinRaf !== null) cancelAnimationFrame(this.spinRaf);
+    const start = performance.now();
+    const target = -WAVELEN;
+    const step = (now: number) => {
+      const t = Math.min((now - start) / SPIN_MS, 1);
+      const eased = t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+      const tx = target * eased;
+      g.setAttribute('transform', `translate(${tx.toFixed(3)} 0)`);
+      if (t < 1) {
+        this.spinRaf = requestAnimationFrame(step);
+      } else {
+        g.setAttribute('transform', 'translate(0 0)');
+        this.spinRaf = null;
+      }
+    };
+    this.spinRaf = requestAnimationFrame(step);
   }
 }

--- a/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.scss
+++ b/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.scss
@@ -23,11 +23,12 @@
 .input {
   width: 100%;
   min-height: 3.5rem;
-  max-height: 8.75rem;
+  max-height: 14rem;
   padding: 1rem 1.125rem 0.5rem;
   border: none;
   outline: none;
   resize: none;
+  overflow-y: auto;
   font: inherit;
   font-size: var(--text-md);
   line-height: 1.5;

--- a/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.scss
+++ b/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.scss
@@ -23,7 +23,7 @@
 .input {
   width: 100%;
   min-height: 3.5rem;
-  max-height: 14rem;
+  max-height: 8rem;
   padding: 1rem 1.125rem 0.5rem;
   border: none;
   outline: none;

--- a/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.ts
+++ b/libs/bixarena/battle/src/lib/prompt-composer/prompt-composer.component.ts
@@ -21,7 +21,8 @@ export class PromptComposerComponent {
     const el = event.target as HTMLTextAreaElement;
     this.text.set(el.value);
     el.style.height = 'auto';
-    el.style.height = `${el.scrollHeight}px`;
+    const max = parseFloat(getComputedStyle(el).maxHeight) || Infinity;
+    el.style.height = `${Math.min(el.scrollHeight, max)}px`;
   }
 
   onKeydown(event: KeyboardEvent): void {

--- a/libs/bixarena/ui/src/index.ts
+++ b/libs/bixarena/ui/src/index.ts
@@ -3,3 +3,4 @@ export * from './lib/login-modal/login-modal.component';
 export * from './lib/modal-dialog/modal-dialog.component';
 export * from './lib/nav/nav.component';
 export * from './lib/onboarding-modal/onboarding-modal.component';
+export * from './lib/prompt-card/prompt-card.component';

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.html
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.html
@@ -1,19 +1,19 @@
 @if (skeleton()) {
-  <div class="prompt-card prompt-card-skeleton" aria-hidden="true"></div>
+  <div class="prompt-card skeleton" aria-hidden="true"></div>
 } @else {
   <button class="prompt-card" type="button" (click)="onClick()">
-    <div class="prompt-card-question">{{ question() }}</div>
-    <div class="prompt-card-meta">
+    <div class="question">{{ question() }}</div>
+    <div class="meta">
       @if (category()) {
-        <span class="prompt-card-tag">{{ category() }}</span>
+        <span class="tag">{{ category() }}</span>
       }
       @if (count() !== undefined) {
-        <span class="prompt-card-stat">{{ count() }} {{ countLabel() }}</span>
+        <span class="stat">{{ count() }} {{ countLabel() }}</span>
       }
-      <span class="prompt-card-cta">
-        <span class="prompt-card-cta-text">{{ ctaText() }}</span>
+      <span class="cta">
+        <span class="cta-text">{{ ctaText() }}</span>
         <svg
-          class="prompt-card-cta-icon"
+          class="cta-icon"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.html
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.html
@@ -1,0 +1,16 @@
+@if (skeleton()) {
+  <div class="prompt-card prompt-card-skeleton" aria-hidden="true"></div>
+} @else {
+  <button class="prompt-card" type="button" (click)="onClick()">
+    <div class="prompt-card-question">{{ question() }}</div>
+    <div class="prompt-card-meta">
+      @if (category()) {
+        <span class="prompt-card-tag">{{ category() }}</span>
+      }
+      @if (count() !== undefined) {
+        <span class="prompt-card-stat">{{ count() }} {{ countLabel() }}</span>
+      }
+      <span class="prompt-card-cta">{{ ctaText() }} &rarr;</span>
+    </div>
+  </button>
+}

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.html
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.html
@@ -11,7 +11,7 @@
         <span class="prompt-card-stat">{{ count() }} {{ countLabel() }}</span>
       }
       <span class="prompt-card-cta">
-        {{ ctaText() }}
+        <span class="prompt-card-cta-text">{{ ctaText() }}</span>
         <svg
           class="prompt-card-cta-icon"
           viewBox="0 0 24 24"

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.html
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.html
@@ -10,7 +10,28 @@
       @if (count() !== undefined) {
         <span class="prompt-card-stat">{{ count() }} {{ countLabel() }}</span>
       }
-      <span class="prompt-card-cta">{{ ctaText() }} &rarr;</span>
+      <span class="prompt-card-cta">
+        {{ ctaText() }}
+        <svg
+          class="prompt-card-cta-icon"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M14.5 17.5 3 6V3h3l11.5 11.5" />
+          <path d="m13 19 6-6" />
+          <path d="m16 16 4 4" />
+          <path d="m19 21 2-2" />
+          <path d="M14.5 6.5 18 3h3v3l-3.5 3.5" />
+          <path d="m5 14 4 4" />
+          <path d="m7 17-3 3" />
+          <path d="M4 20h2" />
+        </svg>
+      </span>
     </div>
   </button>
 }

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
@@ -4,7 +4,7 @@
   display: block;
 }
 
-.prompt-card-question {
+.question {
   font-size: var(--text-sm);
   color: var(--p-text-color);
   line-height: 1.5;
@@ -13,14 +13,14 @@
   flex: 1;
 }
 
-.prompt-card-meta {
+.meta {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: 0.75rem;
 }
 
-.prompt-card-tag {
+.tag {
   font-size: var(--text-xs);
   color: var(--p-text-muted-color);
   font-weight: 500;
@@ -31,13 +31,13 @@
   white-space: nowrap;
 }
 
-.prompt-card-stat {
+.stat {
   font-size: var(--text-xs);
   color: var(--p-text-muted-color);
   font-weight: 440;
 }
 
-.prompt-card-cta {
+.cta {
   display: inline-flex;
   align-items: center;
   gap: 0.3125rem;
@@ -48,13 +48,13 @@
   white-space: nowrap;
 }
 
-.prompt-card-cta-icon {
+.cta-icon {
   width: 0.875rem;
   height: 0.875rem;
 }
 
 @media (#{shared.$lg-breakpoint} < width <= #{shared.$xl-breakpoint}) {
-  .prompt-card-cta-text {
+  .cta-text {
     display: none;
   }
 }
@@ -83,13 +83,13 @@
     transform: translateY(-2px);
     box-shadow: 0 8px 32px rgb(0 0 0 / 25%);
 
-    .prompt-card-cta {
+    .cta {
       color: var(--p-primary-color);
     }
   }
 }
 
-.prompt-card-skeleton {
+.skeleton {
   cursor: default;
   position: relative;
   overflow: hidden;
@@ -124,7 +124,7 @@
     transition: none;
   }
 
-  .prompt-card-skeleton::after {
+  .skeleton::after {
     animation: none;
   }
 }

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
@@ -24,7 +24,7 @@
   background: rgb(249 115 22 / 8%);
   padding: 0.125rem 0.5rem;
   border-radius: 100px;
-  margin-left: -0.5rem;
+  margin-left: -0.25rem;
 }
 
 .prompt-card-stat {

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
@@ -19,12 +19,11 @@
 
 .prompt-card-tag {
   font-size: var(--text-xs);
-  color: var(--p-primary-color);
-  font-weight: 540;
-  background: rgb(249 115 22 / 8%);
+  color: var(--p-text-muted-color);
+  font-weight: 500;
+  border: 1px solid var(--p-surface-200);
   padding: 0.125rem 0.5rem;
-  border-radius: 100px;
-  margin-left: -0.25rem;
+  border-radius: 999px;
 }
 
 .prompt-card-stat {
@@ -43,7 +42,7 @@
 .prompt-card {
   background: var(--p-surface-100);
   border: 1px solid var(--p-surface-200);
-  border-radius: var(--p-border-radius-lg);
+  border-radius: var(--p-border-radius-xl);
   padding: 1.25rem;
   min-height: 8.75rem;
   width: 100%;

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
@@ -24,6 +24,7 @@
   border: 1px solid var(--p-surface-200);
   padding: 0.125rem 0.5rem;
   border-radius: 999px;
+  margin-left: -0.25rem;
 }
 
 .prompt-card-stat {

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
@@ -6,13 +6,9 @@
   font-size: var(--text-sm);
   color: var(--p-text-color);
   line-height: 1.5;
-  margin-bottom: 0.75rem;
+  margin-bottom: 1rem;
   font-weight: 460;
   flex: 1;
-  display: -webkit-box;
-  -webkit-line-clamp: 4;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
 }
 
 .prompt-card-meta {
@@ -28,6 +24,7 @@
   background: rgb(249 115 22 / 8%);
   padding: 0.125rem 0.5rem;
   border-radius: 100px;
+  margin-left: -0.5rem;
 }
 
 .prompt-card-stat {
@@ -50,6 +47,7 @@
   padding: 1.25rem;
   min-height: 8.75rem;
   width: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
   cursor: pointer;

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
@@ -1,3 +1,5 @@
+@use 'shared/typescript/styles/src/shared-styles/variables' as shared;
+
 :host {
   display: block;
 }
@@ -14,6 +16,7 @@
 .prompt-card-meta {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.75rem;
 }
 
@@ -25,6 +28,7 @@
   padding: 0.125rem 0.5rem;
   border-radius: 999px;
   margin-left: -0.25rem;
+  white-space: nowrap;
 }
 
 .prompt-card-stat {
@@ -41,11 +45,18 @@
   color: var(--p-text-muted-color);
   transition: color 0.15s;
   margin-left: auto;
+  white-space: nowrap;
 }
 
 .prompt-card-cta-icon {
   width: 0.875rem;
   height: 0.875rem;
+}
+
+@media (#{shared.$lg-breakpoint} < width <= #{shared.$xl-breakpoint}) {
+  .prompt-card-cta-text {
+    display: none;
+  }
 }
 
 .prompt-card {

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
@@ -98,7 +98,7 @@
     content: '';
     position: absolute;
     inset: 0;
-    background: linear-gradient(90deg, transparent 0%, rgb(255 255 255 / 3%) 50%, transparent 100%);
+    background: linear-gradient(90deg, transparent 0%, var(--p-surface-200) 50%, transparent 100%);
     animation: prompt-card-shimmer 1.4s ease-in-out infinite;
   }
 

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
@@ -1,0 +1,113 @@
+:host {
+  display: block;
+}
+
+.prompt-card-question {
+  font-size: var(--text-sm);
+  color: var(--p-text-color);
+  line-height: 1.5;
+  margin-bottom: 0.75rem;
+  font-weight: 460;
+  flex: 1;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.prompt-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.prompt-card-tag {
+  font-size: var(--text-xs);
+  color: var(--p-primary-color);
+  font-weight: 540;
+  background: rgb(249 115 22 / 8%);
+  padding: 0.125rem 0.5rem;
+  border-radius: 100px;
+}
+
+.prompt-card-stat {
+  font-size: var(--text-xs);
+  color: var(--p-text-muted-color);
+  font-weight: 440;
+}
+
+.prompt-card-cta {
+  font-size: var(--text-xs);
+  color: var(--p-text-muted-color);
+  transition: color 0.15s;
+  margin-left: auto;
+}
+
+.prompt-card {
+  background: var(--p-surface-100);
+  border: 1px solid var(--p-surface-200);
+  border-radius: var(--p-border-radius-lg);
+  padding: 1.25rem;
+  min-height: 8.75rem;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+  font-family: inherit;
+  color: inherit;
+  text-align: left;
+  transition:
+    transform 0.2s,
+    border-color 0.2s,
+    box-shadow 0.2s;
+
+  &:hover {
+    border-color: var(--p-surface-300);
+    transform: translateY(-2px);
+    box-shadow: 0 8px 32px rgb(0 0 0 / 25%);
+
+    .prompt-card-cta {
+      color: var(--p-primary-color);
+    }
+  }
+}
+
+.prompt-card-skeleton {
+  cursor: default;
+  position: relative;
+  overflow: hidden;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent 0%, rgb(255 255 255 / 3%) 50%, transparent 100%);
+    animation: prompt-card-shimmer 1.4s ease-in-out infinite;
+  }
+
+  &:hover {
+    border-color: var(--p-surface-200);
+    transform: none;
+    box-shadow: none;
+  }
+}
+
+@keyframes prompt-card-shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .prompt-card {
+    transition: none;
+  }
+
+  .prompt-card-skeleton::after {
+    animation: none;
+  }
+}

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
@@ -34,10 +34,18 @@
 }
 
 .prompt-card-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3125rem;
   font-size: var(--text-xs);
   color: var(--p-text-muted-color);
   transition: color 0.15s;
   margin-left: auto;
+}
+
+.prompt-card-cta-icon {
+  width: 0.875rem;
+  height: 0.875rem;
 }
 
 .prompt-card {

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.spec.ts
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.spec.ts
@@ -1,0 +1,67 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { PromptCardComponent } from './prompt-card.component';
+
+describe('PromptCardComponent', () => {
+  let fixture: ComponentFixture<PromptCardComponent>;
+  let component: PromptCardComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [PromptCardComponent] }).compileComponents();
+    fixture = TestBed.createComponent(PromptCardComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('question', 'What is CRISPR?');
+    fixture.detectChanges();
+  });
+
+  it('renders the question and default CTA text', () => {
+    const q = fixture.debugElement.query(By.css('.prompt-card-question')).nativeElement;
+    const cta = fixture.debugElement.query(By.css('.prompt-card-cta')).nativeElement;
+    expect(q.textContent).toContain('What is CRISPR?');
+    expect(cta.textContent).toContain('Battle this');
+  });
+
+  it('hides category chip when category is undefined', () => {
+    expect(fixture.debugElement.query(By.css('.prompt-card-tag'))).toBeNull();
+  });
+
+  it('shows category chip when category is set', () => {
+    fixture.componentRef.setInput('category', 'Genetics');
+    fixture.detectChanges();
+    const tag = fixture.debugElement.query(By.css('.prompt-card-tag')).nativeElement;
+    expect(tag.textContent).toContain('Genetics');
+  });
+
+  it('hides count stat when count is undefined', () => {
+    expect(fixture.debugElement.query(By.css('.prompt-card-stat'))).toBeNull();
+  });
+
+  it('shows count stat with default label when count is set', () => {
+    fixture.componentRef.setInput('count', 42);
+    fixture.detectChanges();
+    const stat = fixture.debugElement.query(By.css('.prompt-card-stat')).nativeElement;
+    expect(stat.textContent.replace(/\s+/g, ' ').trim()).toBe('42 battles');
+  });
+
+  it('uses countLabel when provided', () => {
+    fixture.componentRef.setInput('count', 7);
+    fixture.componentRef.setInput('countLabel', 'matches');
+    fixture.detectChanges();
+    const stat = fixture.debugElement.query(By.css('.prompt-card-stat')).nativeElement;
+    expect(stat.textContent.replace(/\s+/g, ' ').trim()).toBe('7 matches');
+  });
+
+  it('emits cardClick when the button is clicked', () => {
+    const spy = jest.fn();
+    component.cardClick.subscribe(spy);
+    fixture.debugElement.query(By.css('.prompt-card')).nativeElement.click();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders as a non-interactive skeleton when skeleton is true', () => {
+    fixture.componentRef.setInput('skeleton', true);
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('button.prompt-card'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('div.prompt-card.prompt-card-skeleton'))).toBeTruthy();
+  });
+});

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.spec.ts
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.spec.ts
@@ -15,31 +15,31 @@ describe('PromptCardComponent', () => {
   });
 
   it('renders the question and default CTA text', () => {
-    const q = fixture.debugElement.query(By.css('.prompt-card-question')).nativeElement;
-    const cta = fixture.debugElement.query(By.css('.prompt-card-cta')).nativeElement;
+    const q = fixture.debugElement.query(By.css('.question')).nativeElement;
+    const cta = fixture.debugElement.query(By.css('.cta')).nativeElement;
     expect(q.textContent).toContain('What is CRISPR?');
     expect(cta.textContent).toContain('Battle this');
   });
 
   it('hides category chip when category is undefined', () => {
-    expect(fixture.debugElement.query(By.css('.prompt-card-tag'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('.tag'))).toBeNull();
   });
 
   it('shows category chip when category is set', () => {
     fixture.componentRef.setInput('category', 'Genetics');
     fixture.detectChanges();
-    const tag = fixture.debugElement.query(By.css('.prompt-card-tag')).nativeElement;
+    const tag = fixture.debugElement.query(By.css('.tag')).nativeElement;
     expect(tag.textContent).toContain('Genetics');
   });
 
   it('hides count stat when count is undefined', () => {
-    expect(fixture.debugElement.query(By.css('.prompt-card-stat'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('.stat'))).toBeNull();
   });
 
   it('shows count stat with default label when count is set', () => {
     fixture.componentRef.setInput('count', 42);
     fixture.detectChanges();
-    const stat = fixture.debugElement.query(By.css('.prompt-card-stat')).nativeElement;
+    const stat = fixture.debugElement.query(By.css('.stat')).nativeElement;
     expect(stat.textContent.replace(/\s+/g, ' ').trim()).toBe('42 battles');
   });
 
@@ -47,7 +47,7 @@ describe('PromptCardComponent', () => {
     fixture.componentRef.setInput('count', 7);
     fixture.componentRef.setInput('countLabel', 'matches');
     fixture.detectChanges();
-    const stat = fixture.debugElement.query(By.css('.prompt-card-stat')).nativeElement;
+    const stat = fixture.debugElement.query(By.css('.stat')).nativeElement;
     expect(stat.textContent.replace(/\s+/g, ' ').trim()).toBe('7 matches');
   });
 
@@ -62,6 +62,6 @@ describe('PromptCardComponent', () => {
     fixture.componentRef.setInput('skeleton', true);
     fixture.detectChanges();
     expect(fixture.debugElement.query(By.css('button.prompt-card'))).toBeNull();
-    expect(fixture.debugElement.query(By.css('div.prompt-card.prompt-card-skeleton'))).toBeTruthy();
+    expect(fixture.debugElement.query(By.css('div.prompt-card.skeleton'))).toBeTruthy();
   });
 });

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.ts
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.ts
@@ -1,0 +1,22 @@
+import { Component, input, output } from '@angular/core';
+
+@Component({
+  selector: 'bixarena-prompt-card',
+  templateUrl: './prompt-card.component.html',
+  styleUrl: './prompt-card.component.scss',
+})
+export class PromptCardComponent {
+  readonly question = input.required<string>();
+  readonly category = input<string | undefined>(undefined);
+  readonly count = input<number | undefined>(undefined);
+  readonly countLabel = input<string>('battles');
+  readonly ctaText = input<string>('Battle this');
+  readonly skeleton = input<boolean>(false);
+
+  readonly cardClick = output<void>();
+
+  onClick(): void {
+    if (this.skeleton()) return;
+    this.cardClick.emit();
+  }
+}


### PR DESCRIPTION
## Description

Reworks the battle landing's example prompt cards, wrapping them in a DNA helix backdrop that ties the picker back to the BioArena brand. Clicking a card still submits the prompt straight into the composer, and each card surfaces its category as a small chip when one is set. The cards are extracted into a reusable `bixarena-prompt-card` component , so the upcoming home-page trending cards can share the same building block.

The chip is read-only - a deliberate step back from the earlier prototype that exposed every category as a clickable filter node. Showing all categories on the landing felt like a poor fit for non-expert users who don't think in taxonomies, so the picker stays focused on the prompt itself rather than doubling as a category navigator.

## Related Issue

[SMR-749](https://sagebionetworks.jira.com/browse/SMR-749)

## Changelog

- Replace the static 5-category helix-node picker with an API-driven 3-card grid rendered by a new reusable `bixarena-prompt-card` component
- Turn the DNA helix into a decorative animated backdrop with a spin on refresh and fade-out/fade-in on card swap, honoring `prefers-reduced-motion`
- Extract helix geometry (`buildStrandPath`, `buildRungs`) into a standalone `dna-helix.ts` module
- Tighten landing spacing and pin the composer and disclaimer to the viewport bottom with a responsive breakpoint scale (single column below `$lg`, icon-only CTA between `$lg` and `$xl`)
- Cap the prompt-composer textarea at 8rem with internal scroll so long prompts cannot push the disclaimer off-screen
- Expand test coverage for initial fetch, click emission, refresh, empty and error states, helix geometry, and category label formatting

## Preview

https://github.com/user-attachments/assets/aa88e37f-748a-4169-9ad4-e5fc632f6faf


[SMR-749]: https://sagebionetworks.jira.com/browse/SMR-749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ