### PR TITLE
fix(sage-monorepo): explicitly pass SYNAPSE_AUTH_TOKEN to e2e-explorer workflow (SMR-752)

### DIFF
--- a/.github/workflows/e2e-explorer.yaml
+++ b/.github/workflows/e2e-explorer.yaml
@@ -6,6 +6,10 @@ on:
         required: true
         type: string
         description: The name of the Explorer to run e2e tests for
+    secrets:
+      SYNAPSE_AUTH_TOKEN:
+        required: false
+        description: Synapse PAT for explorer data sources
 
 permissions:
   contents: read
@@ -123,10 +127,8 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
               && ${cmd}"
 
-      # SYNAPSE_AUTH_TOKEN is stored as an environment secret on the {explorer} and
-      # {explorer}-pr environments (see the environment comment on this job above), so it
-      # resolves via `secrets.*` here without the caller passing it through. This is why
-      # the caller workflow does not need `secrets: inherit` or an explicit `secrets:` block.
+      # SYNAPSE_AUTH_TOKEN must be passed explicitly from the caller workflow (not via
+      # `secrets: inherit`) so only this one secret is exposed to the reusable workflow.
       - name: Write Synapse PAT for Explorer
         run: |
           env_filename="apps/${{ inputs.explorer }}/data/.env"

--- a/.github/workflows/e2e-explorers.yaml
+++ b/.github/workflows/e2e-explorers.yaml
@@ -22,3 +22,5 @@ jobs:
     uses: ./.github/workflows/e2e-explorer.yaml
     with:
       explorer: ${{ matrix.explorer }}
+    secrets:
+      SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}


### PR DESCRIPTION
## Description

Fixes a regression from #3992 where removing `secrets: inherit` from the e2e-explorers caller workflow caused `SYNAPSE_AUTH_TOKEN` to be unavailable in the reusable e2e-explorer workflow. The Synapse client fell back to anonymous access, resulting in a 403 on data download. Reusable workflows require the caller to pass secrets explicitly even when the secret is configured on the callee job's environment.

## Related Issue

- [SMR-752](https://sagebionetworks.jira.com/browse/SMR-752)

## Changelog

- Declare `SYNAPSE_AUTH_TOKEN` in the callee's `workflow_call.secrets` block so it can be received from the caller
- Add an explicit `secrets:` mapping in the caller to pass only `SYNAPSE_AUTH_TOKEN` (preserving the least-privilege improvement from #3992)
- Update inline comment to reflect that the secret must be passed explicitly rather than relying on environment-only resolution

[SMR-752]: https://sagebionetworks.jira.com/browse/SMR-752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ