### PR TITLE
fix(model-ad): use flexbox app shell layout to fix forced scrolling past footer (MG-807)

### DIFF
--- a/apps/model-ad/app/src/app/app.component.scss
+++ b/apps/model-ad/app/src/app/app.component.scss
@@ -1,0 +1,11 @@
+#container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}

--- a/libs/model-ad/gene-details/src/lib/gene-details.component.scss
+++ b/libs/model-ad/gene-details/src/lib/gene-details.component.scss
@@ -1,14 +1,13 @@
 @use 'model-ad/styles/src/variables' as vars;
 
 .gene-details {
-  min-height: calc(100vh - var(--header-height) - var(--footer-height));
-
   &.loading {
     display: flex;
   }
 
   #loading {
-    flex: 1 1 auto;
+    width: 100%;
+    min-height: calc(100vh - var(--header-height) - var(--footer-height));
     display: flex;
     align-items: center;
     justify-content: center;

--- a/libs/model-ad/model-details/src/lib/model-details.component.scss
+++ b/libs/model-ad/model-details/src/lib/model-details.component.scss
@@ -1,7 +1,6 @@
 @use 'model-ad/styles/src/variables' as vars;
 
 .model-details {
-  min-height: calc(100vh - var(--header-height) - var(--footer-height));
   overflow-x: clip;
 
   &.loading {
@@ -9,7 +8,8 @@
   }
 
   #loading {
-    flex: 1 1 auto;
+    width: 100%;
+    min-height: calc(100vh - var(--header-height) - var(--footer-height));
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Description

The gene-details and model-details pages always forced users to scroll past whitespace to reach the footer, regardless of viewport height. The root cause was a `min-height: calc(100vh - var(--header-height) - var(--footer-height))` on the page container that subtracted 84px for each of the header and footer, but their actual rendered heights are 104px (84px `min-height` + 20px vertical padding under `content-box` sizing). This guaranteed at least 40px of overflow on every page load. Rather than patching the arithmetic, this PR adds a flexbox layout to the Model-AD app shell -- the same pattern Agora already uses -- so the footer is positioned by flex, not by fragile CSS variable math.

## Related Issue

- [MG-807](https://sagebionetworks.jira.com/browse/MG-807)

## Changelog

- Add flexbox column layout to the Model-AD app shell, matching the proven Agora app shell pattern
- Move the `min-height` viewport calculation from the page container to the `#loading` element in gene-details and model-details so it only applies during loading, not on the loaded page

## Preview

`model-ad-build-images && model-ad-docker-start`

page | state | dev (current) | this pr (updated) 
:---: | :---: | :---: | :---: 
gene details | loaded | <img width="1624" height="1056" alt="MG-807_geneDetails_loaded_dev" src="https://github.com/user-attachments/assets/501772db-07b0-4a18-89b6-9e552431d3a8" /> | <img width="1624" height="1056" alt="MG-807_geneDetails_loaded_pr" src="https://github.com/user-attachments/assets/67b2fed3-95be-4b61-b7f7-6aeccae9368c" />
gene details | loading | <img width="1624" height="1056" alt="MG-807_geneDetails_loading_dev" src="https://github.com/user-attachments/assets/83e9ad25-0893-4faf-a51c-5c0f410e0119" /> | <img width="1624" height="1056" alt="MG-807_geneDetails_loading_pr" src="https://github.com/user-attachments/assets/9d07027e-3472-4a49-b2e8-964342e67967" />
model details | loaded | <img width="1624" height="1056" alt="MG-807_modelDetails_dev" src="https://github.com/user-attachments/assets/7ed6cd1e-b173-4dc3-adc0-1bd6345bd909" /> | <img width="1624" height="1056" alt="MG-807_modelDetails_pr" src="https://github.com/user-attachments/assets/574d9a03-c644-471c-abb6-f70ce29ed517" />


[MG-807]: https://sagebionetworks.jira.com/browse/MG-807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ