### PR TITLE
feat(bixarena): animate battle validation after vote (SMR-750)

### DIFF
--- a/libs/bixarena/battle/src/lib/battle.constants.ts
+++ b/libs/bixarena/battle/src/lib/battle.constants.ts
@@ -1,3 +1,4 @@
 export const SLOW_MODEL_THRESHOLD_MS = 30_000;
 export const MODEL_TIMEOUT_MS = 300_000;
 export const STREAM_CURSOR = '\u258C'; // ▌
+export const VALIDATION_MS = 2500;

--- a/libs/bixarena/battle/src/lib/battle.constants.ts
+++ b/libs/bixarena/battle/src/lib/battle.constants.ts
@@ -1,4 +1,4 @@
 export const SLOW_MODEL_THRESHOLD_MS = 30_000;
 export const MODEL_TIMEOUT_MS = 300_000;
 export const STREAM_CURSOR = '\u258C'; // ▌
-export const VALIDATION_MS = 2500;
+export const VALIDATION_UI_MS = 2500;

--- a/libs/bixarena/battle/src/lib/battle.types.ts
+++ b/libs/bixarena/battle/src/lib/battle.types.ts
@@ -1,4 +1,11 @@
-export type BattlePhase = 'landing' | 'creating' | 'streaming' | 'voting' | 'reveal' | 'error';
+export type BattlePhase =
+  | 'landing'
+  | 'creating'
+  | 'streaming'
+  | 'voting'
+  | 'validating'
+  | 'reveal'
+  | 'error';
 
 // Per-model streaming state. 'text' holds in-progress chunks; on complete it moves to 'messages'.
 export interface ModelStreamState {

--- a/libs/bixarena/battle/src/lib/services/battle.service.spec.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.spec.ts
@@ -124,19 +124,43 @@ describe('BattleStateService', () => {
       });
     });
 
-    it('should submit evaluation and transition to reveal', async () => {
-      await service.submitVote(BattleEvaluationOutcome.Model1);
-      expect(battleApi.createBattleEvaluation).toHaveBeenCalledWith('battle-1', {
-        outcome: 'model1',
-      });
-      expect(service.phase()).toBe('reveal');
-      expect(service.selectedOutcome()).toBe('model1');
+    it('should submit evaluation and transition voting -> validating -> reveal', async () => {
+      jest.useFakeTimers();
+      try {
+        await service.submitVote(BattleEvaluationOutcome.Model1);
+        expect(battleApi.createBattleEvaluation).toHaveBeenCalledWith('battle-1', {
+          outcome: 'model1',
+        });
+        expect(service.phase()).toBe('validating');
+        expect(service.selectedOutcome()).toBe('model1');
+
+        jest.advanceTimersByTime(2500);
+        expect(service.phase()).toBe('reveal');
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('should decrement prompt uses remaining', async () => {
       const before = service.promptUsesRemaining();
       await service.submitVote(BattleEvaluationOutcome.Tie);
       expect(service.promptUsesRemaining()).toBe(before - 1);
+    });
+
+    it('reset during validation cancels the pending reveal', async () => {
+      jest.useFakeTimers();
+      try {
+        await service.submitVote(BattleEvaluationOutcome.Model1);
+        expect(service.phase()).toBe('validating');
+
+        service.reset();
+        expect(service.phase()).toBe('landing');
+
+        jest.advanceTimersByTime(5000);
+        expect(service.phase()).toBe('landing');
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -8,7 +8,7 @@ import {
 } from '@sagebionetworks/bixarena/api-client';
 import { ConfigService } from '@sagebionetworks/bixarena/config';
 import { BattlePhase, INITIAL_STREAM_STATE, ModelStreamState } from '../battle.types';
-import { SLOW_MODEL_THRESHOLD_MS, MODEL_TIMEOUT_MS } from '../battle.constants';
+import { SLOW_MODEL_THRESHOLD_MS, MODEL_TIMEOUT_MS, VALIDATION_MS } from '../battle.constants';
 import { StreamHttpError, mapStreamHttpError } from '../battle-errors';
 import { BattleStreamService } from './battle-stream.service';
 
@@ -83,6 +83,7 @@ export class BattleStateService {
   private model2Timeout?: ReturnType<typeof setTimeout>;
   private model1SlowTimeout?: ReturnType<typeof setTimeout>;
   private model2SlowTimeout?: ReturnType<typeof setTimeout>;
+  private validationTimer?: ReturnType<typeof setTimeout>;
   private isVoting = false;
 
   async submitPrompt(prompt: string): Promise<void> {
@@ -202,16 +203,29 @@ export class BattleStateService {
 
     this.selectedOutcome.set(outcome);
     this.promptUsesRemaining.update((n) => Math.max(0, n - 1));
-    this.phase.set('reveal');
+    this.phase.set('validating');
     this.isVoting = false;
 
     firstValueFrom(this.battleApi.updateBattle(battleId, { endedAt: new Date().toISOString() }))
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       .catch(() => {});
+
+    // Hold on the validation animation for a fixed window so the user sees the
+    // biomedical-relevance check signaled visually, then reveal results.
+    // Backend validation is fire-and-forget, so this is a UX beat, not a wait.
+    if (this.validationTimer) clearTimeout(this.validationTimer);
+    this.validationTimer = setTimeout(() => {
+      this.validationTimer = undefined;
+      this.phase.set('reveal');
+    }, VALIDATION_MS);
   }
 
   reset(): void {
     this.cleanupStreams();
+    if (this.validationTimer) {
+      clearTimeout(this.validationTimer);
+      this.validationTimer = undefined;
+    }
     this.completedRounds = 0;
     this.phase.set('landing');
     this.battleId.set(null);

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -8,7 +8,7 @@ import {
 } from '@sagebionetworks/bixarena/api-client';
 import { ConfigService } from '@sagebionetworks/bixarena/config';
 import { BattlePhase, INITIAL_STREAM_STATE, ModelStreamState } from '../battle.types';
-import { SLOW_MODEL_THRESHOLD_MS, MODEL_TIMEOUT_MS, VALIDATION_MS } from '../battle.constants';
+import { SLOW_MODEL_THRESHOLD_MS, MODEL_TIMEOUT_MS, VALIDATION_UI_MS } from '../battle.constants';
 import { StreamHttpError, mapStreamHttpError } from '../battle-errors';
 import { BattleStreamService } from './battle-stream.service';
 
@@ -217,7 +217,7 @@ export class BattleStateService {
     this.validationTimer = setTimeout(() => {
       this.validationTimer = undefined;
       this.phase.set('reveal');
-    }, VALIDATION_MS);
+    }, VALIDATION_UI_MS);
   }
 
   reset(): void {

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -20,8 +20,13 @@ export class BattleStateService {
   private readonly config = inject(ConfigService).config;
 
   constructor() {
-    // Cancel active streams when the service is destroyed
-    inject(DestroyRef).onDestroy(() => this.cleanupStreams());
+    inject(DestroyRef).onDestroy(() => {
+      this.cleanupStreams();
+      if (this.validationTimer) {
+        clearTimeout(this.validationTimer);
+        this.validationTimer = undefined;
+      }
+    });
   }
 
   // Phase state machine
@@ -57,7 +62,8 @@ export class BattleStateService {
   );
   readonly currentMatch = computed(() => {
     const completed = this.completedMatches();
-    return this.phase() === 'reveal' ? completed : completed + 1;
+    const phase = this.phase();
+    return phase === 'reveal' || phase === 'validating' ? completed : completed + 1;
   });
   readonly allMatchesComplete = computed(
     () => this.completedMatches() >= this.config.battle.promptUseLimit,

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
@@ -75,6 +75,22 @@
     </div>
   }
 
+  @if (phase() === 'validating') {
+    <div class="validation-row" role="status" aria-live="polite">
+      <svg class="validation-spinner" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <circle cx="12" cy="12" r="10" stroke="var(--p-surface-300)" stroke-width="2.5" />
+        <path
+          d="M22 12a10 10 0 0 0-10-10"
+          stroke="var(--p-primary-color)"
+          stroke-width="2.5"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span class="validation-text">Validating <b>biomedical relevance</b></span>
+      <div class="validation-track"><div class="validation-fill"></div></div>
+    </div>
+  }
+
   @if (phase() === 'reveal' || phase() === 'error') {
     <div class="nudge">
       @if (canReuse()) {

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
@@ -81,7 +81,7 @@
         <circle cx="12" cy="12" r="10" stroke="var(--p-surface-300)" stroke-width="2.5" />
         <path
           d="M22 12a10 10 0 0 0-10-10"
-          stroke="var(--p-primary-color)"
+          stroke="var(--p-teal-400)"
           stroke-width="2.5"
           stroke-linecap="round"
         />

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
@@ -65,3 +65,66 @@
   flex-wrap: wrap;
   justify-content: center;
 }
+
+.validation-row {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.validation-spinner {
+  width: 1.125rem;
+  height: 1.125rem;
+  flex-shrink: 0;
+  animation: validation-spin 1s linear infinite;
+}
+
+.validation-text {
+  font-size: var(--text-sm);
+  color: var(--p-text-muted-color);
+
+  b {
+    color: var(--p-primary-color);
+    font-weight: 600;
+  }
+}
+
+.validation-track {
+  width: 6.25rem;
+  height: 0.125rem;
+  background: var(--p-surface-200);
+  border-radius: 0.125rem;
+  overflow: hidden;
+}
+
+.validation-fill {
+  height: 100%;
+  width: 0;
+  background: var(--p-primary-color);
+  border-radius: 0.125rem;
+  box-shadow: 0 0 0.5rem color-mix(in srgb, var(--p-primary-color) 30%, transparent);
+  animation: validation-progress 2.2s ease-out forwards;
+}
+
+@keyframes validation-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes validation-progress {
+  to {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .validation-spinner {
+    animation: none;
+  }
+
+  .validation-fill {
+    animation: none;
+    width: 100%;
+  }
+}

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
@@ -84,7 +84,7 @@
   color: var(--p-text-muted-color);
 
   b {
-    color: var(--p-primary-color);
+    color: var(--p-teal-400);
     font-weight: 600;
   }
 }
@@ -100,9 +100,9 @@
 .validation-fill {
   height: 100%;
   width: 0;
-  background: var(--p-primary-color);
+  background: var(--p-teal-400);
   border-radius: 0.125rem;
-  box-shadow: 0 0 0.5rem color-mix(in srgb, var(--p-primary-color) 30%, transparent);
+  box-shadow: 0 0 0.5rem color-mix(in srgb, var(--p-teal-400) 30%, transparent);
   animation: validation-progress 2.2s ease-out forwards;
 }
 

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { VotingBarComponent } from './voting-bar.component';
 
 describe('VotingBarComponent', () => {
@@ -39,5 +40,38 @@ describe('VotingBarComponent', () => {
     component.vote.subscribe(spy);
     component.voteModel2();
     expect(spy).toHaveBeenCalledWith('model2');
+  });
+
+  describe('validating phase', () => {
+    it('renders the validation row with copy and progress bar', () => {
+      fixture.componentRef.setInput('phase', 'validating');
+      fixture.detectChanges();
+
+      const row = fixture.debugElement.query(By.css('.validation-row'));
+      expect(row).toBeTruthy();
+      expect(row.nativeElement.getAttribute('role')).toBe('status');
+      expect(row.nativeElement.textContent).toContain('Validating');
+      expect(row.nativeElement.textContent).toContain('biomedical relevance');
+      expect(fixture.debugElement.query(By.css('.validation-spinner'))).toBeTruthy();
+      expect(fixture.debugElement.query(By.css('.validation-fill'))).toBeTruthy();
+    });
+
+    it('hides vote buttons and post-reveal nudge during validation', () => {
+      fixture.componentRef.setInput('phase', 'validating');
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.vb'))).toBeNull();
+      expect(fixture.debugElement.query(By.css('.nudge'))).toBeNull();
+    });
+
+    it('does not render the validation row in voting or reveal phases', () => {
+      fixture.componentRef.setInput('phase', 'voting');
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('.validation-row'))).toBeNull();
+
+      fixture.componentRef.setInput('phase', 'reveal');
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('.validation-row'))).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Description

Adds a short post-vote animation to the battle page that signals "validating biomedical relevance" before results are revealed. This closes the expectation gap between the landing page's promise that only biomedical battles count and the previously instant voting-to-reveal transition, giving users a visible acknowledgment that the backend's biomedical-relevance check is running.

## Related Issue

[SMR-750](https://sagebionetworks.jira.com/browse/SMR-750)

## Changelog

- Add a `validating` phase to the battle state machine between `voting` and `reveal`
- Render a teal spinner, "Validating biomedical relevance" copy, and progress bar inline in the voting bar during the new phase
- Hold the validating phase for a fixed 2.5s window on a service-owned timer; cancel the timer on battle reset to prevent a stale reveal after rapid navigation
- Respect `prefers-reduced-motion` by stopping the spinner and pre-filling the progress bar
- Add unit coverage for the voting → validating → reveal sequence and for the reset-cancels-timer edge case

## Preview


https://github.com/user-attachments/assets/37b9fd0d-83e0-47e7-b805-2ff119f953f9





[SMR-750]: https://sagebionetworks.jira.com/browse/SMR-750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ