### PR TITLE
feat(model-ad): update home page copy and support HTML in home card description (MG-866)

### DIFF
--- a/libs/explorers/ui/src/lib/components/home-card/home-card.component.html
+++ b/libs/explorers/ui/src/lib/components/home-card/home-card.component.html
@@ -2,7 +2,7 @@
   <div class="home-card">
     <div>
       <h2>{{ title() }}</h2>
-      <p>{{ description() }}</p>
+      <p [innerHTML]="description()"></p>
     </div>
     @if (!!routerLink()) {
       <div class="icon-container">

--- a/libs/model-ad/home/src/lib/home.component.html
+++ b/libs/model-ad/home/src/lib/home.component.html
@@ -6,15 +6,15 @@
           <h1 class="home-heading">Find the right model for your research</h1>
         </div>
         <p class="description">
-          Explore gene expression and pathology data from next-generation mouse models of
-          Alzheimer's Disease (AD) developed by the MODEL-AD consortium.
+          Explore next-generation mouse models of Alzheimer's Disease (AD) generated, characterized,
+          and validated by the MODEL-AD consortium.
         </p>
       </div>
       <div class="card-container">
         <explorers-home-card
           [title]="'Model Overview'"
           [description]="
-            'View summary information about the available mouse models, see what data is currently available, and quickly navigate to detailed information and results. New data and analyses will be incorporated as they are available.'
+            'See an overview of the mouse models and currently available results, and quickly navigate to detailed model-specific information, source data, and visualizations.'
           "
           [routerLink]="ROUTE_PATHS.MODEL_OVERVIEW"
           [imagePath]="'model-ad-assets/images/mouse-with-brain-network.svg'"
@@ -23,7 +23,7 @@
         <explorers-home-card
           [title]="'Model Search'"
           [description]="
-            'Find a mouse model by name, JAX ID, or RRID to view detailed information and experimental evidence, including pathology and biomarker results.'
+            'Find a mouse model by name, JAX ID, or RRID to explore <strong>Biomarker</strong> data, <strong>Pathology</strong> results, and detailed model information.'
           "
         >
           <model-ad-search-input


### PR DESCRIPTION
## Description

Updated home page copy and added the ability to style descriptions in the home page cards.

## Related Issue

[MG-866](https://sagebionetworks.jira.com/browse/MG-866)

## Changelog

- Updated copy on the home page
- Added the ability to style descriptions in the home page cards

## Testing

Copy is updated on the home page cards (see below):

| AFTER        | BEFORE         |
|---------------|---------------|
|  <img width="1177" height="1000" alt="image" src="https://github.com/user-attachments/assets/f87f8ce1-2bce-43c1-a672-0b2bd6392240" /> | <img width="2334" height="1990" alt="image" src="https://github.com/user-attachments/assets/8b789680-b35b-45cd-a2d0-ee11b450e856" /> |



[MG-866]: https://sagebionetworks.jira.com/browse/MG-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ