### PR TITLE
feat(agora): add drug details summary tab (AG-2068)

### DIFF
--- a/apps/agora/app/e2e/drug-details.spec.ts
+++ b/apps/agora/app/e2e/drug-details.spec.ts
@@ -66,10 +66,10 @@ test.describe('drug details - summary', () => {
     await expect(page.getByText('Linked Targets')).toBeVisible();
     const jak1Link = page.getByRole('link', { name: 'JAK1' });
     await expect(jak1Link).toBeVisible();
-    await expect(jak1Link).toHaveAttribute('href', 'genes/ENSG00000162434');
+    await expect(jak1Link).toHaveAttribute('href', '/genes/ENSG00000162434');
     const jak2Link = page.getByRole('link', { name: 'JAK2' });
     await expect(jak2Link).toBeVisible();
-    await expect(jak2Link).toHaveAttribute('href', 'genes/ENSG00000096968');
+    await expect(jak2Link).toHaveAttribute('href', '/genes/ENSG00000096968');
   });
 
   test('linked target navigates to gene details page', async ({ page }) => {

--- a/apps/agora/app/e2e/drug-details.spec.ts
+++ b/apps/agora/app/e2e/drug-details.spec.ts
@@ -14,7 +14,7 @@ test.describe('drug details', () => {
 
   test('default tab is summary', async ({ page }) => {
     await page.goto(drugPath);
-    await expect(page.getByRole('heading', { level: 2, name: 'Summary' })).toBeVisible();
+    await expect(page.getByText('Modality')).toBeVisible();
   });
 
   test('correct tab is loaded from url', async ({ page }) => {
@@ -25,7 +25,58 @@ test.describe('drug details', () => {
   test('invalid tab in url defaults to first available tab', async ({ page }) => {
     await page.goto(`${drugPath}/does-not-exist`);
     await page.waitForURL(drugPath);
-    await expect(page.getByRole('heading', { level: 2, name: 'Summary' })).toBeVisible();
+    await expect(page.getByText('Modality')).toBeVisible();
+  });
+});
+
+test.describe('drug details - summary', () => {
+  const summaryUrl = `/drugs/${chemblId}`;
+
+  test('displays modality', async ({ page }) => {
+    await page.goto(summaryUrl);
+    await expect(page.getByText('Modality')).toBeVisible();
+    await expect(page.getByText('Small molecule', { exact: true })).toBeVisible();
+  });
+
+  test('displays max clinical trial phase', async ({ page }) => {
+    await page.goto(summaryUrl);
+    await expect(page.getByText('Max Clinical Trial Phase')).toBeVisible();
+    await expect(page.getByText('Preclinical', { exact: true })).toBeVisible();
+  });
+
+  test('displays year of first approval', async ({ page }) => {
+    await page.goto(summaryUrl);
+    await expect(page.getByText('Year of first approval')).toBeVisible();
+    await expect(page.getByText('2017', { exact: true })).toBeVisible();
+  });
+
+  test('displays mechanisms of action', async ({ page }) => {
+    await page.goto(summaryUrl);
+    await expect(page.getByText('Mechanisms of Action')).toBeVisible();
+    await expect(
+      page.getByText('Tyrosine-protein kinase JAK1 inhibitor', { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText('Tyrosine-protein kinase JAK2 inhibitor', { exact: true }),
+    ).toBeVisible();
+  });
+
+  test('displays linked targets with links', async ({ page }) => {
+    await page.goto(summaryUrl);
+    await expect(page.getByText('Linked Targets')).toBeVisible();
+    const jak1Link = page.getByRole('link', { name: 'JAK1' });
+    await expect(jak1Link).toBeVisible();
+    await expect(jak1Link).toHaveAttribute('href', 'genes/ENSG00000162434');
+    const jak2Link = page.getByRole('link', { name: 'JAK2' });
+    await expect(jak2Link).toBeVisible();
+    await expect(jak2Link).toHaveAttribute('href', 'genes/ENSG00000096968');
+  });
+
+  test('linked target navigates to gene details page', async ({ page }) => {
+    await page.goto(summaryUrl);
+    await page.getByRole('link', { name: 'JAK1' }).click();
+    await expect(page).toHaveURL(/\/genes\/ENSG00000162434/);
+    await expect(page.getByRole('heading', { level: 1, name: 'JAK1' })).toBeVisible();
   });
 });
 

--- a/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.html
+++ b/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.html
@@ -8,9 +8,11 @@
     <p>{{ drug().maximum_clinical_trial_phase }}</p>
     <br />
 
-    <p class="drug-details-label">Year of first approval</p>
-    <p>{{ drug().year_of_first_approval }}</p>
-    <br />
+    @if (drug().year_of_first_approval) {
+      <p class="drug-details-label">Year of first approval</p>
+      <p>{{ drug().year_of_first_approval }}</p>
+      <br />
+    }
 
     @if (drug().mechanisms_of_action.length > 0) {
       <p class="drug-details-label">Mechanisms of Action</p>

--- a/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.html
+++ b/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.html
@@ -1,0 +1,38 @@
+<div class="drug-details-summary">
+  <section>
+    <p class="drug-details-label">Modality</p>
+    <p>{{ drug().modality }}</p>
+    <br />
+
+    <p class="drug-details-label">Max Clinical Trial Phase</p>
+    <p>{{ drug().maximum_clinical_trial_phase }}</p>
+    <br />
+
+    <p class="drug-details-label">Year of first approval</p>
+    <p>{{ drug().year_of_first_approval }}</p>
+    <br />
+
+    @if (drug().mechanisms_of_action.length > 0) {
+      <p class="drug-details-label">Mechanisms of Action</p>
+      <ul>
+        @for (mechanism of drug().mechanisms_of_action; track mechanism) {
+          <li>{{ mechanism }}</li>
+        }
+      </ul>
+      <br />
+    }
+
+    @if (drug().linked_targets.length > 0) {
+      <p class="drug-details-label">Linked Targets</p>
+      <ul>
+        @for (target of drug().linked_targets; track target) {
+          <li>
+            <a [href]="`${ROUTE_PATHS.DETAILS}/${target.ensembl_gene_id}`">{{
+              target.hgnc_symbol || target.ensembl_gene_id
+            }}</a>
+          </li>
+        }
+      </ul>
+    }
+  </section>
+</div>

--- a/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.html
+++ b/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.html
@@ -29,7 +29,7 @@
       <ul>
         @for (target of drug().linked_targets; track target) {
           <li>
-            <a [href]="`${ROUTE_PATHS.DETAILS}/${target.ensembl_gene_id}`">{{
+            <a [routerLink]="['/' + ROUTE_PATHS.DETAILS, target.ensembl_gene_id]">{{
               target.hgnc_symbol || target.ensembl_gene_id
             }}</a>
           </li>

--- a/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.scss
+++ b/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.scss
@@ -1,0 +1,18 @@
+@use 'agora/styles/src/mixins' as mixins;
+
+.drug-details-summary {
+  .drug-details-label {
+    font-weight: 700;
+  }
+
+  ul {
+    margin-top: 10px;
+    list-style: unset;
+    padding-left: 1.5rem;
+  }
+
+  a {
+    @include mixins.link;
+    @include mixins.link-hover;
+  }
+}

--- a/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.spec.ts
+++ b/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.spec.ts
@@ -24,10 +24,17 @@ describe('DrugDetailsSummaryComponent', () => {
     expect(screen.getByText(drugMock.maximum_clinical_trial_phase as string)).toBeInTheDocument();
   });
 
-  it('should display year of first approval', async () => {
-    await setup();
-    expect(screen.getByText('Year of first approval')).toBeInTheDocument();
-    expect(screen.getByText(String(drugMock.year_of_first_approval))).toBeInTheDocument();
+  describe('year of first approval', () => {
+    it('should display year when present', async () => {
+      await setup();
+      expect(screen.getByText('Year of first approval')).toBeInTheDocument();
+      expect(screen.getByText(String(drugMock.year_of_first_approval))).toBeInTheDocument();
+    });
+
+    it('should not display year when null', async () => {
+      await setup({ year_of_first_approval: null });
+      expect(screen.queryByText('Year of first approval')).not.toBeInTheDocument();
+    });
   });
 
   describe('mechanisms of action', () => {

--- a/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.spec.ts
+++ b/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.spec.ts
@@ -1,0 +1,69 @@
+import { Drug } from '@sagebionetworks/agora/api-client';
+import { drugMock } from '@sagebionetworks/agora/testing';
+import { render, screen } from '@testing-library/angular';
+import { DrugDetailsSummaryComponent } from './drug-details-summary.component';
+
+async function setup(drugOverrides: Partial<Drug> = {}) {
+  return render(DrugDetailsSummaryComponent, {
+    componentInputs: {
+      drug: { ...drugMock, ...drugOverrides },
+    },
+  });
+}
+
+describe('DrugDetailsSummaryComponent', () => {
+  it('should display modality', async () => {
+    await setup();
+    expect(screen.getByText('Modality')).toBeInTheDocument();
+    expect(screen.getByText(drugMock.modality)).toBeInTheDocument();
+  });
+
+  it('should display max clinical trial phase', async () => {
+    await setup();
+    expect(screen.getByText('Max Clinical Trial Phase')).toBeInTheDocument();
+    expect(screen.getByText(drugMock.maximum_clinical_trial_phase as string)).toBeInTheDocument();
+  });
+
+  it('should display year of first approval', async () => {
+    await setup();
+    expect(screen.getByText('Year of first approval')).toBeInTheDocument();
+    expect(screen.getByText(String(drugMock.year_of_first_approval))).toBeInTheDocument();
+  });
+
+  describe('mechanisms of action', () => {
+    it('should display mechanisms when present', async () => {
+      await setup();
+      expect(screen.getByText('Mechanisms of Action')).toBeInTheDocument();
+      expect(screen.getByText('Cytochrome P450 19A1 inhibitor')).toBeInTheDocument();
+    });
+
+    it('should not display mechanisms section when empty', async () => {
+      await setup({ mechanisms_of_action: [] });
+      expect(screen.queryByText('Mechanisms of Action')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('linked targets', () => {
+    it('should display linked targets when present', async () => {
+      await setup();
+      expect(screen.getByText('Linked Targets')).toBeInTheDocument();
+      const link = screen.getByRole('link', { name: 'CYP19A1' });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', 'genes/ENSG00000137869');
+    });
+
+    it('should fall back to ensembl_gene_id when hgnc_symbol is missing', async () => {
+      await setup({
+        linked_targets: [{ ensembl_gene_id: 'ENSG00000000001', hgnc_symbol: '' }],
+      });
+      const link = screen.getByRole('link', { name: 'ENSG00000000001' });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', 'genes/ENSG00000000001');
+    });
+
+    it('should not display linked targets section when empty', async () => {
+      await setup({ linked_targets: [] });
+      expect(screen.queryByText('Linked Targets')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.spec.ts
+++ b/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.spec.ts
@@ -15,7 +15,7 @@ describe('DrugDetailsSummaryComponent', () => {
   it('should display modality', async () => {
     await setup();
     expect(screen.getByText('Modality')).toBeInTheDocument();
-    expect(screen.getByText(drugMock.modality)).toBeInTheDocument();
+    expect(screen.getByText(drugMock.modality as string)).toBeInTheDocument();
   });
 
   it('should display max clinical trial phase', async () => {

--- a/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.spec.ts
+++ b/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.spec.ts
@@ -1,3 +1,4 @@
+import { provideRouter } from '@angular/router';
 import { Drug } from '@sagebionetworks/agora/api-client';
 import { drugMock } from '@sagebionetworks/agora/testing';
 import { render, screen } from '@testing-library/angular';
@@ -8,6 +9,7 @@ async function setup(drugOverrides: Partial<Drug> = {}) {
     componentInputs: {
       drug: { ...drugMock, ...drugOverrides },
     },
+    providers: [provideRouter([])],
   });
 }
 
@@ -56,7 +58,7 @@ describe('DrugDetailsSummaryComponent', () => {
       expect(screen.getByText('Linked Targets')).toBeInTheDocument();
       const link = screen.getByRole('link', { name: 'CYP19A1' });
       expect(link).toBeInTheDocument();
-      expect(link).toHaveAttribute('href', 'genes/ENSG00000137869');
+      expect(link).toHaveAttribute('href', '/genes/ENSG00000137869');
     });
 
     it('should fall back to ensembl_gene_id when hgnc_symbol is missing', async () => {
@@ -65,7 +67,7 @@ describe('DrugDetailsSummaryComponent', () => {
       });
       const link = screen.getByRole('link', { name: 'ENSG00000000001' });
       expect(link).toBeInTheDocument();
-      expect(link).toHaveAttribute('href', 'genes/ENSG00000000001');
+      expect(link).toHaveAttribute('href', '/genes/ENSG00000000001');
     });
 
     it('should not display linked targets section when empty', async () => {

--- a/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.ts
+++ b/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.ts
@@ -1,10 +1,11 @@
 import { Component, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { Drug } from '@sagebionetworks/agora/api-client';
 import { ROUTE_PATHS } from '@sagebionetworks/agora/config';
 
 @Component({
   selector: 'agora-drug-details-summary',
-  imports: [],
+  imports: [RouterLink],
   templateUrl: './drug-details-summary.component.html',
   styleUrls: ['./drug-details-summary.component.scss'],
 })

--- a/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.ts
+++ b/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.ts
@@ -1,0 +1,15 @@
+import { Component, input } from '@angular/core';
+import { Drug } from '@sagebionetworks/agora/api-client';
+import { ROUTE_PATHS } from '@sagebionetworks/agora/config';
+
+@Component({
+  selector: 'agora-drug-details-summary',
+  imports: [],
+  templateUrl: './drug-details-summary.component.html',
+  styleUrls: ['./drug-details-summary.component.scss'],
+})
+export class DrugDetailsSummaryComponent {
+  ROUTE_PATHS = ROUTE_PATHS;
+
+  drug = input.required<Drug>();
+}

--- a/libs/agora/drug-details/src/lib/drug-details.component.html
+++ b/libs/agora/drug-details/src/lib/drug-details.component.html
@@ -15,7 +15,7 @@
     <div class="panel-content">
       @switch (activePanel) {
         @case ('summary') {
-          <h2>Summary</h2>
+          <agora-drug-details-summary [drug]="drug" />
         }
         @case ('resources') {
           <agora-drug-details-resources [drug]="drug" />

--- a/libs/agora/drug-details/src/lib/drug-details.component.ts
+++ b/libs/agora/drug-details/src/lib/drug-details.component.ts
@@ -16,6 +16,7 @@ import { PanelNavigationComponent } from '@sagebionetworks/explorers/ui';
 import { LoadingIconComponent } from '@sagebionetworks/explorers/util';
 import { DrugDetailsHeroComponent } from './components/drug-details-hero/drug-details-hero.component';
 import { DrugDetailsResourcesComponent } from './components/drug-details-resources/drug-details-resources.component';
+import { DrugDetailsSummaryComponent } from './components/drug-details-summary/drug-details-summary.component';
 
 @Component({
   selector: 'agora-drug-details',
@@ -24,6 +25,7 @@ import { DrugDetailsResourcesComponent } from './components/drug-details-resourc
     LoadingIconComponent,
     DrugDetailsResourcesComponent,
     DrugDetailsHeroComponent,
+    DrugDetailsSummaryComponent,
   ],
   templateUrl: './drug-details.component.html',
   styleUrls: ['./drug-details.component.scss'],


### PR DESCRIPTION
## Description

Implement the Summary tab for the drug details page, replacing the placeholder `<h2>Summary</h2>` with a fully functional component. The summary displays drug metadata (modality, clinical trial phase, year of first approval) along with conditionally rendered sections for mechanisms of action and linked gene targets with navigation links to gene details pages.

## Related Issue

- [AG-2068](https://sagebionetworks.jira.com/browse/AG-2068)

## Changelog

- Add `DrugDetailsSummaryComponent` displaying drug modality, max clinical trial phase, and year of first approval
- Add unit and e2e tests for the summary tab 

## Preview

`agora-build-images && agora-docker-start`

Summary with all fields displayed including multiple mechanisms of action and linked targets: 

`http://localhost:8000/drugs/CHEMBL10878`

<img width="1624" height="1056" alt="AG-2068_allFields" src="https://github.com/user-attachments/assets/616e040b-e1df-42b1-8a40-0a14a8c92a3e" />

Summary where missing fields (year of first approval, mechanisms of action, and linked targets) are hidden: 

`http://localhost:8000/drugs/CHEMBL154111`

<img width="1624" height="1056" alt="AG-2068_missingFields" src="https://github.com/user-attachments/assets/8b9324c1-220b-45eb-b1e7-7c62512cdb66" />

Linked targets open gene details pages: 

https://github.com/user-attachments/assets/d5fb7a57-6e01-437b-8489-2e8d4e654f5c

[AG-2068]: https://sagebionetworks.jira.com/browse/AG-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ