### PR TITLE
fix(synapse): set explicit bot identity for automated commit attribution (SMR-756)

### DIFF
--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -129,6 +129,8 @@ jobs:
         # under 'sudo -u ubuntu bash -lc ...', or add a thin wrapper that exports required env vars.
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           branch: synapse/update-synapse-api
           delete-branch: true
           draft: false


### PR DESCRIPTION
## Description

The `update-synapse-api` workflow attributes automated commits to whichever user last pushed to the triggering branch (via `github.actor`) instead of the bot. This is because `peter-evans/create-pull-request` defaults its `author` and `committer` to the actor context. Explicitly setting both to `github-actions[bot]` ensures consistent, accurate attribution for automated commits regardless of how the workflow is triggered.

## Related Issue

- [SMR-756](https://sagebionetworks.jira.com/browse/SMR-756)

## Changelog

- Set explicit `author` and `committer` on the `create-pull-request` step to `github-actions[bot]`


[SMR-756]: https://sagebionetworks.jira.com/browse/SMR-756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ