### PR TITLE
feat(bixarena): support long and truncated LLM responses in battle (SMR-757, SMR-758)

### DIFF
--- a/apps/bixarena/ai-service/bixarena_ai_service/models/message_create.py
+++ b/apps/bixarena/ai-service/bixarena_ai_service/models/message_create.py
@@ -34,7 +34,7 @@ class MessageCreate(BaseModel):
     """  # noqa: E501
 
     role: MessageRole
-    content: Annotated[str, Field(strict=True, max_length=10000)] = Field(
+    content: Annotated[str, Field(strict=True, max_length=50000)] = Field(
         description="The content of a message."
     )
     __properties: ClassVar[List[str]] = ["role", "content"]

--- a/apps/bixarena/ai-service/bixarena_ai_service/models/model_chat_completion_chunk.py
+++ b/apps/bixarena/ai-service/bixarena_ai_service/models/model_chat_completion_chunk.py
@@ -33,7 +33,7 @@ class ModelChatCompletionChunk(BaseModel):
     A streaming event chunk from the model chat completion
     """  # noqa: E501
 
-    content: Optional[Annotated[str, Field(strict=True, max_length=10000)]] = Field(
+    content: Optional[Annotated[str, Field(strict=True, max_length=50000)]] = Field(
         default=None, description="The content of a message."
     )
     status: StrictStr = Field(description="Current state of the streaming response")

--- a/apps/bixarena/api/src/main/java/org/sagebionetworks/bixarena/api/model/dto/MessageCreateDto.java
+++ b/apps/bixarena/api/src/main/java/org/sagebionetworks/bixarena/api/model/dto/MessageCreateDto.java
@@ -71,7 +71,7 @@ public class MessageCreateDto {
    * The content of a message.
    * @return content
    */
-  @NotNull @Size(max = 10000) 
+  @NotNull @Size(max = 50000) 
   @Schema(name = "content", example = "What is the capital of France?", description = "The content of a message.", requiredMode = Schema.RequiredMode.REQUIRED)
   @JsonProperty("content")
   public String getContent() {

--- a/apps/bixarena/api/src/main/java/org/sagebionetworks/bixarena/api/model/dto/ModelChatCompletionChunkDto.java
+++ b/apps/bixarena/api/src/main/java/org/sagebionetworks/bixarena/api/model/dto/ModelChatCompletionChunkDto.java
@@ -132,7 +132,7 @@ public class ModelChatCompletionChunkDto {
    * The content of a message.
    * @return content
    */
-  @Size(max = 10000) 
+  @Size(max = 50000) 
   @Schema(name = "content", example = "What is the capital of France?", description = "The content of a message.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("content")
   public @Nullable String getContent() {

--- a/apps/bixarena/api/src/main/java/org/sagebionetworks/bixarena/api/model/entity/MessageEntity.java
+++ b/apps/bixarena/api/src/main/java/org/sagebionetworks/bixarena/api/model/entity/MessageEntity.java
@@ -30,7 +30,7 @@ public class MessageEntity {
   @Column(name = "role", nullable = false, length = 20)
   private String role;
 
-  @Column(name = "content", nullable = false, length = 10000)
+  @Column(name = "content", nullable = false, length = 50000)
   private String content;
 
   @CreationTimestamp

--- a/apps/bixarena/api/src/main/resources/db/migration/common/V10__expand_message_content.sql
+++ b/apps/bixarena/api/src/main/resources/db/migration/common/V10__expand_message_content.sql
@@ -1,0 +1,11 @@
+-- Expand message.content from VARCHAR(10000) to VARCHAR(50000).
+--
+-- The previous 10000-char cap (V5, SMR-623) still truncates or rejects long
+-- LLM responses on write: chat_max_response_tokens is 4096 and a token can
+-- represent 3-10 chars depending on content (non-English, code, formatted
+-- output), so real responses can exceed 10000 chars. 50000 covers the
+-- realistic worst case with headroom. Metadata-only change in Postgres
+-- (no index or constraint on content), no table rewrite.
+
+ALTER TABLE api.message
+  ALTER COLUMN content TYPE VARCHAR(50000);

--- a/apps/bixarena/api/src/main/resources/openapi.yaml
+++ b/apps/bixarena/api/src/main/resources/openapi.yaml
@@ -2904,7 +2904,7 @@ components:
     MessageContent:
       description: The content of a message.
       example: What is the capital of France?
-      maxLength: 10000
+      maxLength: 50000
       type: string
     MessageCreate:
       description: Payload used to create a message.
@@ -2914,7 +2914,7 @@ components:
         content:
           description: The content of a message.
           example: What is the capital of France?
-          maxLength: 10000
+          maxLength: 50000
           type: string
       required:
         - content
@@ -3061,7 +3061,7 @@ components:
         content:
           description: The content of a message.
           example: What is the capital of France?
-          maxLength: 10000
+          maxLength: 50000
           type: string
         status:
           description: Current state of the streaming response

--- a/libs/bixarena/api-client-python/bixarena_api_client/models/message_create.py
+++ b/libs/bixarena/api-client-python/bixarena_api_client/models/message_create.py
@@ -30,7 +30,7 @@ class MessageCreate(BaseModel):
     """  # noqa: E501
 
     role: MessageRole
-    content: Annotated[str, Field(strict=True, max_length=10000)] = Field(
+    content: Annotated[str, Field(strict=True, max_length=50000)] = Field(
         description="The content of a message."
     )
     __properties: ClassVar[List[str]] = ["role", "content"]

--- a/libs/bixarena/api-client-python/bixarena_api_client/models/model_chat_completion_chunk.py
+++ b/libs/bixarena/api-client-python/bixarena_api_client/models/model_chat_completion_chunk.py
@@ -29,7 +29,7 @@ class ModelChatCompletionChunk(BaseModel):
     A streaming event chunk from the model chat completion
     """  # noqa: E501
 
-    content: Optional[Annotated[str, Field(strict=True, max_length=10000)]] = Field(
+    content: Optional[Annotated[str, Field(strict=True, max_length=50000)]] = Field(
         default=None, description="The content of a message."
     )
     status: StrictStr = Field(description="Current state of the streaming response")

--- a/libs/bixarena/api-description/openapi/ai-public.openapi.yaml
+++ b/libs/bixarena/api-description/openapi/ai-public.openapi.yaml
@@ -62,7 +62,7 @@ components:
     MessageContent:
       type: string
       description: The content of a message.
-      maxLength: 10000
+      maxLength: 50000
       example: What is the capital of France?
     MessageCreate:
       type: object

--- a/libs/bixarena/api-description/openapi/ai-service.openapi.yaml
+++ b/libs/bixarena/api-description/openapi/ai-service.openapi.yaml
@@ -380,7 +380,7 @@ components:
     MessageContent:
       type: string
       description: The content of a message.
-      maxLength: 10000
+      maxLength: 50000
       example: What is the capital of France?
     MessageCreate:
       type: object

--- a/libs/bixarena/api-description/openapi/api-public.openapi.yaml
+++ b/libs/bixarena/api-description/openapi/api-public.openapi.yaml
@@ -1970,7 +1970,7 @@ components:
     MessageContent:
       type: string
       description: The content of a message.
-      maxLength: 10000
+      maxLength: 50000
       example: What is the capital of France?
     MessageCreate:
       type: object

--- a/libs/bixarena/api-description/openapi/api-service.openapi.yaml
+++ b/libs/bixarena/api-description/openapi/api-service.openapi.yaml
@@ -1970,7 +1970,7 @@ components:
     MessageContent:
       type: string
       description: The content of a message.
-      maxLength: 10000
+      maxLength: 50000
       example: What is the capital of France?
     MessageCreate:
       type: object

--- a/libs/bixarena/api-description/openapi/openapi.yaml
+++ b/libs/bixarena/api-description/openapi/openapi.yaml
@@ -1753,7 +1753,7 @@ components:
     MessageContent:
       type: string
       description: The content of a message.
-      maxLength: 10000
+      maxLength: 50000
       example: What is the capital of France?
     MessageCreate:
       type: object

--- a/libs/bixarena/api-description/src/components/schemas/MessageContent.yaml
+++ b/libs/bixarena/api-description/src/components/schemas/MessageContent.yaml
@@ -1,4 +1,4 @@
 type: string
 description: The content of a message.
-maxLength: 10000
+maxLength: 50000
 example: 'What is the capital of France?'

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -48,7 +48,7 @@
           [selectedOutcome]="state.selectedOutcome()"
           [hoveredModel]="hoverSide()"
           (retry)="state.retry()"
-          (continue)="state.continueRound()"
+          (continue)="state.continueRound('model1')"
         />
         <bixarena-model-panel
           modelId="model2"
@@ -57,7 +57,7 @@
           [selectedOutcome]="state.selectedOutcome()"
           [hoveredModel]="hoverSide()"
           (retry)="state.retry()"
-          (continue)="state.continueRound()"
+          (continue)="state.continueRound('model2')"
         />
       </div>
       <bixarena-voting-bar

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -48,6 +48,7 @@
           [selectedOutcome]="state.selectedOutcome()"
           [hoveredModel]="hoverSide()"
           (retry)="state.retry()"
+          (continue)="state.continueRound()"
         />
         <bixarena-model-panel
           modelId="model2"
@@ -56,6 +57,7 @@
           [selectedOutcome]="state.selectedOutcome()"
           [hoveredModel]="hoverSide()"
           (retry)="state.retry()"
+          (continue)="state.continueRound()"
         />
       </div>
       <bixarena-voting-bar

--- a/libs/bixarena/battle/src/lib/battle.constants.ts
+++ b/libs/bixarena/battle/src/lib/battle.constants.ts
@@ -2,3 +2,4 @@ export const SLOW_MODEL_THRESHOLD_MS = 30_000;
 export const MODEL_TIMEOUT_MS = 300_000;
 export const STREAM_CURSOR = '\u258C'; // ▌
 export const VALIDATION_UI_MS = 2500;
+export const CONTINUE_PROMPT = 'Continue where you left off.';

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
@@ -23,7 +23,9 @@
   >
     @for (msg of streamState().messages; track $index) {
       @if (msg.role === 'user') {
-        <div class="user-msg">{{ msg.content }}</div>
+        @if (msg.content !== continuePrompt) {
+          <div class="user-msg">{{ msg.content }}</div>
+        }
       } @else {
         <div class="content">
           <markdown [data]="msg.content" />
@@ -55,9 +57,9 @@
       <span class="thk-lbl">Generating response...</span>
     </div>
     @if (streamState().status === 'error') {
-      <div class="error-line">
+      <div class="action-line">
         @if (streamState().retryable) {
-          <button class="retry-btn" (click)="retry.emit()" title="Retry" aria-label="Retry">
+          <button class="action-btn" type="button" (click)="retry.emit()" title="Retry">
             <svg
               viewBox="0 0 16 16"
               fill="none"
@@ -69,13 +71,37 @@
               <path d="M13.5 8A5.5 5.5 0 1 1 10 3.07" />
               <polyline points="13.5 2 13.5 5.5 10 5.5" />
             </svg>
+            <span>{{ streamState().errorMessage }}</span>
           </button>
+        } @else {
+          <span class="action-text">{{ streamState().errorMessage }}</span>
         }
-        <span class="error-line-text">{{ streamState().errorMessage }}</span>
       </div>
     } @else if (streamState().text) {
       <div class="content">
         <markdown [data]="displayText()" />
+      </div>
+    }
+    @if (streamState().status === 'complete' && streamState().finishReason === 'length') {
+      <div class="action-line">
+        <button
+          class="action-btn"
+          type="button"
+          (click)="continue.emit()"
+          title="Continue generating"
+        >
+          <svg
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <polyline points="4 6 8 10 12 6" />
+          </svg>
+          <span>Continue the response</span>
+        </button>
       </div>
     }
   </div>

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
@@ -190,42 +190,41 @@
   }
 }
 
-.error-line {
+.action-line {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 0.25rem;
   clear: both;
+  margin-top: 0.5rem;
 }
 
-.error-line-text {
-  font-size: var(--text-sm);
-  color: var(--p-surface-500);
-}
-
-.retry-btn {
-  display: flex;
+.action-btn {
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
+  gap: 0.375rem;
   padding: 0;
   border: none;
   background: none;
-  color: var(--p-surface-400);
+  color: var(--p-surface-500);
+  font: inherit;
+  font-size: var(--text-sm);
   cursor: pointer;
-  border-radius: 50%;
   transition: color 0.15s;
-  flex-shrink: 0;
 
   svg {
     width: 13px;
     height: 13px;
+    flex-shrink: 0;
   }
 
   &:hover {
-    color: var(--p-surface-600);
+    color: var(--p-text-color);
   }
+}
+
+.action-text {
+  font-size: var(--text-sm);
+  color: var(--p-surface-500);
 }
 
 .footer {

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { provideMarkdown } from 'ngx-markdown';
 import { ModelPanelComponent } from './model-panel.component';
 import { INITIAL_STREAM_STATE } from '../battle.types';
+import { CONTINUE_PROMPT } from '../battle.constants';
 
 describe('ModelPanelComponent', () => {
   let component: ModelPanelComponent;
@@ -9,6 +12,7 @@ describe('ModelPanelComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ModelPanelComponent],
+      providers: [provideMarkdown()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ModelPanelComponent);
@@ -50,5 +54,77 @@ describe('ModelPanelComponent', () => {
       status: 'streaming',
     });
     expect(component.streamState().status).toBe('streaming');
+  });
+
+  describe('continue button', () => {
+    it('renders when complete and finishReason is length', () => {
+      fixture.componentRef.setInput('streamState', {
+        ...INITIAL_STREAM_STATE,
+        status: 'complete',
+        finishReason: 'length',
+      });
+      fixture.detectChanges();
+
+      const btn = fixture.debugElement.query(By.css('.action-btn'));
+      expect(btn).toBeTruthy();
+      expect(btn.nativeElement.getAttribute('title')).toBe('Continue generating');
+      expect(btn.nativeElement.textContent).toContain('Continue the response');
+    });
+
+    it('does not render when finishReason is stop', () => {
+      fixture.componentRef.setInput('streamState', {
+        ...INITIAL_STREAM_STATE,
+        status: 'complete',
+        finishReason: 'stop',
+      });
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.action-btn'))).toBeNull();
+    });
+
+    it('does not render while still streaming', () => {
+      fixture.componentRef.setInput('streamState', {
+        ...INITIAL_STREAM_STATE,
+        status: 'streaming',
+        finishReason: 'length',
+      });
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.action-btn'))).toBeNull();
+    });
+
+    it('hides the continue prompt from the rendered transcript', () => {
+      fixture.componentRef.setInput('streamState', {
+        ...INITIAL_STREAM_STATE,
+        messages: [
+          { role: 'user', content: 'Original question' },
+          { role: 'assistant', content: 'Truncated answer' },
+          { role: 'user', content: CONTINUE_PROMPT },
+          { role: 'assistant', content: 'Continuation text' },
+        ],
+        status: 'complete',
+        finishReason: 'stop',
+      });
+      fixture.detectChanges();
+
+      const userMsgs = fixture.debugElement
+        .queryAll(By.css('.user-msg'))
+        .map((e) => e.nativeElement.textContent.trim());
+      expect(userMsgs).toEqual(['Original question']);
+    });
+
+    it('emits continue when clicked', () => {
+      fixture.componentRef.setInput('streamState', {
+        ...INITIAL_STREAM_STATE,
+        status: 'complete',
+        finishReason: 'length',
+      });
+      fixture.detectChanges();
+
+      const spy = jest.fn();
+      component.continue.subscribe(spy);
+      fixture.debugElement.query(By.css('.action-btn')).nativeElement.click();
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
@@ -13,7 +13,7 @@ import { isPlatformBrowser } from '@angular/common';
 import { MarkdownComponent } from 'ngx-markdown';
 import { BattleEvaluationOutcome } from '@sagebionetworks/bixarena/api-client';
 import { ModelStreamState } from '../battle.types';
-import { STREAM_CURSOR } from '../battle.constants';
+import { CONTINUE_PROMPT, STREAM_CURSOR } from '../battle.constants';
 
 @Component({
   selector: 'bixarena-model-panel',
@@ -31,6 +31,9 @@ export class ModelPanelComponent {
   readonly selectedOutcome = input<BattleEvaluationOutcome | null>(null);
   readonly hoveredModel = input<BattleEvaluationOutcome | null>(null);
   readonly retry = output<void>();
+  readonly continue = output<void>();
+
+  protected readonly continuePrompt = CONTINUE_PROMPT;
 
   readonly isSelected = computed(() => {
     const o = this.selectedOutcome();

--- a/libs/bixarena/battle/src/lib/services/battle.service.spec.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.spec.ts
@@ -227,18 +227,28 @@ describe('BattleStateService', () => {
   });
 
   describe('continueRound', () => {
-    it('creates a new round with a continuation prompt', async () => {
+    it('creates a new round and streams only the target side', async () => {
       await service.submitPrompt('test');
       battleApi.createBattleRound.mockClear();
+      streamService.streamCompletion.mockClear();
 
-      await service.continueRound();
+      await service.continueRound('model1');
 
       expect(battleApi.createBattleRound).toHaveBeenCalledWith('battle-1', {
-        promptMessage: {
-          role: 'user',
-          content: CONTINUE_PROMPT,
-        },
+        promptMessage: { role: 'user', content: CONTINUE_PROMPT },
       });
+      expect(streamService.streamCompletion).toHaveBeenCalledTimes(1);
+      expect(streamService.streamCompletion).toHaveBeenCalledWith('battle-1', 'round-1', 'model-1');
+    });
+
+    it('streams only model2 when continuing the model2 side', async () => {
+      await service.submitPrompt('test');
+      streamService.streamCompletion.mockClear();
+
+      await service.continueRound('model2');
+
+      expect(streamService.streamCompletion).toHaveBeenCalledTimes(1);
+      expect(streamService.streamCompletion).toHaveBeenCalledWith('battle-1', 'round-1', 'model-2');
     });
   });
 });

--- a/libs/bixarena/battle/src/lib/services/battle.service.spec.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.spec.ts
@@ -6,6 +6,7 @@ import {
   BattleEvaluationOutcome,
 } from '@sagebionetworks/bixarena/api-client';
 import { ConfigService } from '@sagebionetworks/bixarena/config';
+import { CONTINUE_PROMPT } from '../battle.constants';
 import { BattleStateService } from './battle.service';
 import { BattleStreamService } from './battle-stream.service';
 
@@ -222,6 +223,22 @@ describe('BattleStateService', () => {
       expect(service.phase()).toBe('landing');
       expect(service.battleId()).toBeNull();
       expect(service.model1()).toBeNull();
+    });
+  });
+
+  describe('continueRound', () => {
+    it('creates a new round with a continuation prompt', async () => {
+      await service.submitPrompt('test');
+      battleApi.createBattleRound.mockClear();
+
+      await service.continueRound();
+
+      expect(battleApi.createBattleRound).toHaveBeenCalledWith('battle-1', {
+        promptMessage: {
+          role: 'user',
+          content: CONTINUE_PROMPT,
+        },
+      });
     });
   });
 });

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -127,12 +127,57 @@ export class BattleStateService {
     }
   }
 
-  // Continue a truncated response. Consumes a round — the LLM sees the prior
-  // context (including the cut-off assistant message) plus a terse "continue"
-  // instruction and resumes from where it stopped. The prompt text is filtered
-  // out of the rendered transcript so users don't see the internal instruction.
-  async continueRound(): Promise<void> {
-    await this.submitFollowUp(CONTINUE_PROMPT);
+  // Streams only the target side; the backend's round history assembly
+  // tolerates a null assistant message for the skipped side.
+  async continueRound(which: 'model1' | 'model2'): Promise<void> {
+    const battleId = this.battleId();
+    const model1 = this.model1();
+    const model2 = this.model2();
+    if (!battleId || !model1 || !model2) return;
+
+    if (this.completedRounds >= this.roundLimit) {
+      this.setStreamError(
+        "You've reached the limit for this battle. Vote or start a new battle",
+        false,
+      );
+      return;
+    }
+
+    const userMsg = { role: 'user' as const, content: CONTINUE_PROMPT };
+    const target = which === 'model1' ? this.model1Stream : this.model2Stream;
+    const other = which === 'model1' ? this.model2Stream : this.model1Stream;
+    const targetModelId = which === 'model1' ? model1.id : model2.id;
+
+    this.cleanupStreams();
+    other.update((s) => ({ ...s, messages: [...s.messages, userMsg] }));
+    target.set({
+      ...INITIAL_STREAM_STATE,
+      messages: [...target().messages, userMsg],
+      status: 'waiting',
+    });
+
+    try {
+      const round = await firstValueFrom(
+        this.battleApi.createBattleRound(battleId, { promptMessage: userMsg }),
+      );
+      if (!round) throw new Error('Failed to create continuation round');
+      this.roundId.set(round.id);
+      this.phase.set('streaming');
+
+      const sub = this.subscribeToStream(battleId, round.id, targetModelId, target);
+      if (which === 'model1') this.model1Sub = sub;
+      else this.model2Sub = sub;
+      this.startTimeouts(target, which);
+    } catch (err) {
+      console.error('Failed to continue round', err);
+      target.update((s) => ({
+        ...s,
+        status: 'error',
+        errorMessage: 'Something went wrong',
+        retryable: true,
+        isSlowHint: false,
+      }));
+    }
   }
 
   async submitFollowUp(prompt: string): Promise<void> {

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -8,7 +8,12 @@ import {
 } from '@sagebionetworks/bixarena/api-client';
 import { ConfigService } from '@sagebionetworks/bixarena/config';
 import { BattlePhase, INITIAL_STREAM_STATE, ModelStreamState } from '../battle.types';
-import { SLOW_MODEL_THRESHOLD_MS, MODEL_TIMEOUT_MS, VALIDATION_UI_MS } from '../battle.constants';
+import {
+  CONTINUE_PROMPT,
+  MODEL_TIMEOUT_MS,
+  SLOW_MODEL_THRESHOLD_MS,
+  VALIDATION_UI_MS,
+} from '../battle.constants';
 import { StreamHttpError, mapStreamHttpError } from '../battle-errors';
 import { BattleStreamService } from './battle-stream.service';
 
@@ -120,6 +125,14 @@ export class BattleStateService {
       console.error('Failed to start streaming', err);
       this.setStreamError('Something went wrong', true);
     }
+  }
+
+  // Continue a truncated response. Consumes a round — the LLM sees the prior
+  // context (including the cut-off assistant message) plus a terse "continue"
+  // instruction and resumes from where it stopped. The prompt text is filtered
+  // out of the rendered transcript so users don't see the internal instruction.
+  async continueRound(): Promise<void> {
+    await this.submitFollowUp(CONTINUE_PROMPT);
   }
 
   async submitFollowUp(prompt: string): Promise<void> {


### PR DESCRIPTION
## Description

The battle view silently loses long LLM responses because `api.message.content` is capped at `VARCHAR(10000)`, and there's no user affordance when a response truncates mid-generation. This PR expands the column to accommodate realistic LLM output and adds a per-side Continue action so users can resume a cut-off response — streaming only the truncated side to avoid wasting tokens on the model that already finished.

## Related Issue

[SMR-757](https://sagebionetworks.jira.com/browse/SMR-757)
[SMR-758](https://sagebionetworks.jira.com/browse/SMR-758)

## Changelog

- Expand `api.message.content` from `VARCHAR(10000)` to `VARCHAR(50000)` with matching OpenAPI schema bump and regenerated clients
- Surface truncation in the model panel with an explicit indicator when `finish_reason === 'length'`
- Add per-side Continue action that creates a new round with a terse resume prompt and streams only the truncated model; the completed side stays intact
- Filter the internal continue-prompt marker from the rendered transcript so users don't see the technical instruction
- Unify Retry and Continue affordances under shared `.action-btn` / `.action-line` styles for consistent "status + action" treatment

## Testing

Testing with 200 max response token:

https://github.com/user-attachments/assets/608e009c-c421-4602-a268-b4a7ab0c3e77



[SMR-757]: https://sagebionetworks.jira.com/browse/SMR-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SMR-758]: https://sagebionetworks.jira.com/browse/SMR-758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ