### PR TITLE
feat(agora): add support for sentry post config change, align sentry release info (AG-2031)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,6 @@
     "NX_CLOUD_ENCRYPTION_KEY": "${localEnv:NX_CLOUD_ENCRYPTION_KEY}",
     "NX_HEAD": "${localEnv:NX_HEAD}",
     "SENTRY_AUTH_TOKEN": "${localEnv:SENTRY_AUTH_TOKEN}",
-    "SENTRY_RELEASE": "${localEnv:SENTRY_RELEASE}",
     "SONAR_PULL_REQUEST_NUMBER": "${localEnv:SONAR_PULL_REQUEST_NUMBER}",
     "SONAR_TOKEN": "${localEnv:SONAR_TOKEN}",
     "UV_CACHE_DIR": "${containerWorkspaceFolder}/.cache/uv"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,12 +89,12 @@ jobs:
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo \
             --remote-env SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN" \
-            --remote-env SENTRY_RELEASE="$SENTRY_RELEASE" \
+            --remote-env SENTRY_RELEASE_SUFFIX="$SENTRY_RELEASE_SUFFIX" \
             bash -c ". ./dev-env.sh \
             && nx affected --target=sentry-sourcemaps"
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_RELEASE: edge+${{ env.SHORT_SHA }}
+          SENTRY_RELEASE_SUFFIX: edge+${{ env.SHORT_SHA }}
 
       - name: Remove the dev container
         run: docker rm -f sage_devcontainer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,9 +70,9 @@ jobs:
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo \
             --remote-env SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN" \
-            --remote-env SENTRY_RELEASE="$SENTRY_RELEASE" \
+            --remote-env SENTRY_RELEASE_SUFFIX="$SENTRY_RELEASE_SUFFIX" \
             bash -c '. ./dev-env.sh \
             && nx run-many --target=sentry-sourcemaps --projects="${{ env.PRODUCT }}-*"'
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_RELEASE: ${{ env.VERSION }}+${{ env.SHORT_SHA }}
+          SENTRY_RELEASE_SUFFIX: ${{ env.VERSION }}+${{ env.SHORT_SHA }}

--- a/apps/agora/app/project.json
+++ b/apps/agora/app/project.json
@@ -154,7 +154,7 @@
       "options": {
         "commands": [
           "sentry-cli sourcemaps inject dist/apps/agora/app",
-          "sentry-cli sourcemaps upload --org sage-bionetworks --project agora --release agora@$SENTRY_RELEASE dist/apps/agora/app",
+          "sentry-cli sourcemaps upload --org sage-bionetworks --project agora --release agora@$SENTRY_RELEASE_SUFFIX dist/apps/agora/app",
           "find dist/apps/agora/app -name '*.map' -delete"
         ],
         "parallel": false

--- a/apps/agora/app/project.json
+++ b/apps/agora/app/project.json
@@ -154,7 +154,7 @@
       "options": {
         "commands": [
           "sentry-cli sourcemaps inject dist/apps/agora/app",
-          "sentry-cli sourcemaps upload --org sage-bionetworks --project agora --release $SENTRY_RELEASE dist/apps/agora/app",
+          "sentry-cli sourcemaps upload --org sage-bionetworks --project agora --release agora@$SENTRY_RELEASE dist/apps/agora/app",
           "find dist/apps/agora/app -name '*.map' -delete"
         ],
         "parallel": false

--- a/apps/agora/app/src/app/app.config.ts
+++ b/apps/agora/app/src/app/app.config.ts
@@ -17,6 +17,7 @@ import {
 } from '@angular/router';
 import { BASE_PATH as API_CLIENT_BASE_PATH } from '@sagebionetworks/agora/api-client';
 import { configFactory, ConfigService } from '@sagebionetworks/agora/config';
+import { initSentry } from '@sagebionetworks/explorers/sentry';
 import { LoggerService, provideExplorersConfig } from '@sagebionetworks/explorers/services';
 import { provideLogger } from '@sagebionetworks/web-shared/angular/logger';
 import { httpErrorInterceptor } from '@sagebionetworks/explorers/util';
@@ -42,10 +43,12 @@ export const appConfig: ApplicationConfig = {
     provideAppInitializer(() => {
       const configService = inject(ConfigService);
       return configFactory(configService)().then(() => {
-        const release = configService.config.sentryRelease;
-        if (release) {
-          Sentry.addEventProcessor((event) => ({ ...event, release }));
-        }
+        const { sentryDsn, sentryEnvironment, sentryRelease } = configService.config;
+        initSentry({
+          dsn: sentryDsn,
+          environment: sentryEnvironment,
+          release: sentryRelease,
+        });
       });
     }),
     provideExplorersConfig({

--- a/apps/agora/app/src/config/application.yaml
+++ b/apps/agora/app/src/config/application.yaml
@@ -10,5 +10,7 @@ ssrApiUrl: http://agora-api:3333/v1
 apiDocsUrl: http://localhost:8000/api-docs
 googleTagManagerEnabled: true
 googleTagManagerId: ''
+sentryDsn: ''
+sentryEnvironment: ''
 sentryRelease: ''
 environment: dev

--- a/apps/agora/app/src/main.ts
+++ b/apps/agora/app/src/main.ts
@@ -1,16 +1,5 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { getSentryEnvironment } from '@sagebionetworks/explorers/sentry';
-import * as Sentry from '@sentry/angular';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
-
-Sentry.init({
-  dsn: 'https://3cfc84951936511803f5c86d82eb9cad@o4510881207418880.ingest.us.sentry.io/4510897622679552',
-  environment: getSentryEnvironment({
-    'agora-dev.adknowledgeportal.org': 'dev',
-    'agora-stage.adknowledgeportal.org': 'stage',
-    'agora.adknowledgeportal.org': 'prod',
-  }),
-});
 
 bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));

--- a/apps/model-ad/app/project.json
+++ b/apps/model-ad/app/project.json
@@ -159,7 +159,7 @@
       "options": {
         "commands": [
           "sentry-cli sourcemaps inject dist/apps/model-ad/app",
-          "sentry-cli sourcemaps upload --org sage-bionetworks --project model-ad --release model-ad@$SENTRY_RELEASE dist/apps/model-ad/app",
+          "sentry-cli sourcemaps upload --org sage-bionetworks --project model-ad --release model-ad@$SENTRY_RELEASE_SUFFIX dist/apps/model-ad/app",
           "find dist/apps/model-ad/app -name '*.map' -delete"
         ],
         "parallel": false

--- a/apps/model-ad/app/project.json
+++ b/apps/model-ad/app/project.json
@@ -159,7 +159,7 @@
       "options": {
         "commands": [
           "sentry-cli sourcemaps inject dist/apps/model-ad/app",
-          "sentry-cli sourcemaps upload --org sage-bionetworks --project model-ad --release $SENTRY_RELEASE dist/apps/model-ad/app",
+          "sentry-cli sourcemaps upload --org sage-bionetworks --project model-ad --release model-ad@$SENTRY_RELEASE dist/apps/model-ad/app",
           "find dist/apps/model-ad/app -name '*.map' -delete"
         ],
         "parallel": false

--- a/apps/model-ad/app/src/app/app.config.ts
+++ b/apps/model-ad/app/src/app/app.config.ts
@@ -15,6 +15,7 @@ import {
   withComponentInputBinding,
   withInMemoryScrolling,
 } from '@angular/router';
+import { initSentry } from '@sagebionetworks/explorers/sentry';
 import { LoggerService, provideExplorersConfig } from '@sagebionetworks/explorers/services';
 import { httpErrorInterceptor } from '@sagebionetworks/explorers/util';
 import { BASE_PATH as API_CLIENT_BASE_PATH } from '@sagebionetworks/model-ad/api-client';
@@ -36,10 +37,12 @@ export const appConfig: ApplicationConfig = {
     provideAppInitializer(() => {
       const configService = inject(ConfigService);
       return configFactory(configService)().then(() => {
-        const release = configService.config.sentryRelease;
-        if (release) {
-          Sentry.addEventProcessor((event) => ({ ...event, release }));
-        }
+        const { sentryDsn, sentryEnvironment, sentryRelease } = configService.config;
+        initSentry({
+          dsn: sentryDsn,
+          environment: sentryEnvironment,
+          release: sentryRelease,
+        });
       });
     }),
     provideExplorersConfig({

--- a/apps/model-ad/app/src/config/application.yaml
+++ b/apps/model-ad/app/src/config/application.yaml
@@ -10,5 +10,7 @@ ssrApiUrl: http://model-ad-api:3333/v1
 apiDocsUrl: http://localhost:8000/api-docs
 googleTagManagerEnabled: true
 googleTagManagerId: ''
+sentryDsn: ''
+sentryEnvironment: ''
 sentryRelease: ''
 environment: dev

--- a/apps/model-ad/app/src/main.ts
+++ b/apps/model-ad/app/src/main.ts
@@ -1,16 +1,5 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { getSentryEnvironment } from '@sagebionetworks/explorers/sentry';
-import * as Sentry from '@sentry/angular';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
-
-Sentry.init({
-  dsn: 'https://bbf0d51ab53013fe73d95348a6bffe61@o4510881207418880.ingest.us.sentry.io/4510896864559104',
-  environment: getSentryEnvironment({
-    'dev.modeladexplorer.org': 'dev',
-    'stage.modeladexplorer.org': 'stage',
-    'modeladexplorer.org': 'prod',
-  }),
-});
 
 bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));

--- a/libs/agora/testing/src/lib/mocks/config-mocks.ts
+++ b/libs/agora/testing/src/lib/mocks/config-mocks.ts
@@ -8,6 +8,8 @@ export const configMock: RuntimeServerConfig = {
   apiDocsUrl: 'http://localhost:8000/api-docs',
   googleTagManagerEnabled: false,
   googleTagManagerId: '',
+  sentryDsn: '',
+  sentryEnvironment: '',
   sentryRelease: '',
   environment: 'dev',
   isPlatformServer: true,

--- a/libs/explorers/config/src/lib/client-config.schema.ts
+++ b/libs/explorers/config/src/lib/client-config.schema.ts
@@ -8,6 +8,8 @@ export const ClientConfigSchema = BaseConfigSchema.extend({
   csrApiUrl: z.url(),
   googleTagManagerEnabled: z.boolean(),
   googleTagManagerId: z.string().default(''),
+  sentryDsn: z.string().default(''),
+  sentryEnvironment: z.string().default(''),
   sentryRelease: z.string().default(''),
 });
 

--- a/libs/explorers/config/src/lib/config-transformer.ts
+++ b/libs/explorers/config/src/lib/config-transformer.ts
@@ -10,6 +10,8 @@ export function transformServerToClientConfig(serverConfig: AppConfig): ClientCo
     csrApiUrl: serverConfig.csrApiUrl,
     googleTagManagerEnabled: serverConfig.googleTagManagerEnabled,
     googleTagManagerId: serverConfig.googleTagManagerId,
+    sentryDsn: serverConfig.sentryDsn,
+    sentryEnvironment: serverConfig.sentryEnvironment,
     sentryRelease: serverConfig.sentryRelease,
   };
 }

--- a/libs/explorers/config/src/lib/config.schema.ts
+++ b/libs/explorers/config/src/lib/config.schema.ts
@@ -9,6 +9,8 @@ export const AppConfigSchema = BaseConfigSchema.extend({
   ssrApiUrl: z.url(),
   googleTagManagerEnabled: z.boolean(),
   googleTagManagerId: z.string().default(''),
+  sentryDsn: z.string().default(''),
+  sentryEnvironment: z.string().default(''),
   sentryRelease: z.string().default(''),
 });
 

--- a/libs/explorers/sentry/src/lib/init-sentry.spec.ts
+++ b/libs/explorers/sentry/src/lib/init-sentry.spec.ts
@@ -1,72 +1,62 @@
 import * as Sentry from '@sentry/angular';
-import { getSentryEnvironment, initSentry, SentryConfig } from './init-sentry';
+import { initSentry, SentryConfig } from './init-sentry';
 
 jest.mock('@sentry/angular', () => ({
   init: jest.fn(),
 }));
 
-const hostEnvironmentMap: Record<string, string> = {
-  'app-dev.example.com': 'dev',
-  'app-stage.example.com': 'stage',
-  'app.example.com': 'prod',
-};
-
 const mockConfig: SentryConfig = {
   dsn: 'https://test-dsn@sentry.io/123',
-  hostEnvironmentMap,
+  environment: 'dev',
 };
-
-describe('getSentryEnvironment', () => {
-  // The "server" (SSR) path cannot be tested in jsdom since window is always defined,
-  // and passing undefined explicitly triggers the default parameter which reads window.location.hostname.
-
-  it('should return "localhost" for localhost', () => {
-    expect(getSentryEnvironment(hostEnvironmentMap, 'localhost')).toBe('localhost');
-  });
-
-  it('should return "localhost" for 127.0.0.1', () => {
-    expect(getSentryEnvironment(hostEnvironmentMap, '127.0.0.1')).toBe('localhost');
-  });
-
-  it('should resolve a mapped hostname to its environment', () => {
-    expect(getSentryEnvironment(hostEnvironmentMap, 'app-dev.example.com')).toBe('dev');
-    expect(getSentryEnvironment(hostEnvironmentMap, 'app-stage.example.com')).toBe('stage');
-    expect(getSentryEnvironment(hostEnvironmentMap, 'app.example.com')).toBe('prod');
-  });
-
-  it('should fall back to the raw hostname when not in the map', () => {
-    expect(getSentryEnvironment(hostEnvironmentMap, 'unknown-host.example.com')).toBe(
-      'unknown-host.example.com',
-    );
-  });
-});
 
 describe('initSentry', () => {
   afterEach(() => {
     (Sentry.init as jest.Mock).mockClear();
   });
 
-  it('should initialize Sentry with release from config', () => {
+  it('initializes Sentry with dsn, environment, and release', () => {
     initSentry({ ...mockConfig, release: '1.0.0+abc1234' });
 
-    expect(Sentry.init).toHaveBeenCalledWith(
-      expect.objectContaining({
-        dsn: mockConfig.dsn,
-        release: '1.0.0+abc1234',
-        sendDefaultPii: false,
-      }),
-    );
+    expect(Sentry.init).toHaveBeenCalledWith({
+      dsn: mockConfig.dsn,
+      environment: 'dev',
+      release: '1.0.0+abc1234',
+      sendDefaultPii: false,
+    });
   });
 
-  it('should initialize Sentry without release when release is not provided', () => {
+  it('passes release: undefined when release is not provided', () => {
     initSentry(mockConfig);
 
     expect(Sentry.init).toHaveBeenCalledWith(expect.objectContaining({ release: undefined }));
   });
 
-  it('should initialize Sentry without release when release is empty string', () => {
+  it('passes release: undefined when release is empty', () => {
     initSentry({ ...mockConfig, release: '' });
 
     expect(Sentry.init).toHaveBeenCalledWith(expect.objectContaining({ release: undefined }));
+  });
+
+  it('does not call Sentry.init when environment is empty', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    initSentry({ ...mockConfig, environment: '' });
+
+    expect(Sentry.init).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('SENTRY_ENVIRONMENT'));
+
+    warnSpy.mockRestore();
+  });
+
+  it('does not call Sentry.init when dsn is empty', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    initSentry({ ...mockConfig, dsn: '' });
+
+    expect(Sentry.init).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('SENTRY_DSN'));
+
+    warnSpy.mockRestore();
   });
 });

--- a/libs/explorers/sentry/src/lib/init-sentry.spec.ts
+++ b/libs/explorers/sentry/src/lib/init-sentry.spec.ts
@@ -16,12 +16,12 @@ describe('initSentry', () => {
   });
 
   it('initializes Sentry with dsn, environment, and release', () => {
-    initSentry({ ...mockConfig, release: '1.0.0+abc1234' });
+    initSentry({ ...mockConfig, release: 'agora@1.0.0+abc1234' });
 
     expect(Sentry.init).toHaveBeenCalledWith({
       dsn: mockConfig.dsn,
       environment: 'dev',
-      release: '1.0.0+abc1234',
+      release: 'agora@1.0.0+abc1234',
       sendDefaultPii: false,
     });
   });

--- a/libs/explorers/sentry/src/lib/init-sentry.ts
+++ b/libs/explorers/sentry/src/lib/init-sentry.ts
@@ -2,26 +2,24 @@ import * as Sentry from '@sentry/angular';
 
 export interface SentryConfig {
   dsn: string;
-  hostEnvironmentMap: Record<string, string>;
+  environment: string;
   release?: string;
-}
-
-export function getSentryEnvironment(
-  hostEnvironmentMap: Record<string, string>,
-  hostname = typeof window !== 'undefined' ? window.location.hostname : undefined,
-): string {
-  if (!hostname) return 'server';
-  if (hostname === 'localhost' || hostname === '127.0.0.1') return 'localhost';
-
-  return hostEnvironmentMap[hostname] ?? hostname;
 }
 
 export function initSentry(config: SentryConfig): void {
   if (typeof window === 'undefined') return;
+  if (!config.dsn) {
+    console.warn('[Sentry] SENTRY_DSN is empty; skipping init.');
+    return;
+  }
+  if (!config.environment) {
+    console.warn('[Sentry] SENTRY_DSN is set but SENTRY_ENVIRONMENT is empty; skipping init.');
+    return;
+  }
 
   Sentry.init({
     dsn: config.dsn,
-    environment: getSentryEnvironment(config.hostEnvironmentMap),
+    environment: config.environment,
     release: config.release || undefined,
     sendDefaultPii: false,
   });

--- a/libs/model-ad/testing/src/lib/mocks/config-mocks.ts
+++ b/libs/model-ad/testing/src/lib/mocks/config-mocks.ts
@@ -8,6 +8,8 @@ export const configMock: RuntimeServerConfig = {
   apiDocsUrl: 'http://localhost:8000/api-docs',
   googleTagManagerEnabled: false,
   googleTagManagerId: '',
+  sentryDsn: '',
+  sentryEnvironment: '',
   sentryRelease: '',
   environment: 'dev',
   isPlatformServer: true,


### PR DESCRIPTION
## Description
This PR replaces the initial exploratory implementation of Sentry and aligns with the changes made to the infra repos to support better Sentry integration.

## Related Issue

[AG-2031](https://sagebionetworks.jira.com/browse/AG-2031)

## Changelog

- Add `sentryDsn` and `sentryEnvironment` to the explorers config schema, transformer, application YAMLs, and test mocks
- Move Sentry initialization from `main.ts` into the app initializer in `app.config.ts` using the shared `initSentry()` so it runs after runtime config is loaded
- Replace the hostname-to-environment mapping (`getSentryEnvironment` / `hostEnvironmentMap`) with a config-driven `environment` value and remove the old helper
- Skip Sentry init when `dsn` is empty, and warn + skip when `environment` is empty so misconfigured deployments fail loudly instead of silently reporting to the wrong project
- Prefix the `sentry-cli sourcemaps upload --release` value with the project slug (`agora@$SENTRY_RELEASE`, `model-ad@$SENTRY_RELEASE`) to match Sentry's release identifier convention
- Update `init-sentry` unit tests to cover the new dsn/environment guards and remove the obsolete `getSentryEnvironment` tests

## Testing
- Testing will require a follow-up to see that errors are logged in the Sentry UI.

[AG-2031]: https://sagebionetworks.jira.com/browse/AG-2031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ