### PR TITLE
feat(bixarena): add leaderboard visualization barchart view 

### DIFF
--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/chart-bar.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/chart-bar.ts
@@ -1,0 +1,10 @@
+export interface ChartBar {
+  readonly id: string;
+  readonly rank: number;
+  readonly modelName: string;
+  readonly modelOrganization: string | null;
+  readonly score: number;
+  readonly heightPct: number;
+  readonly orgLogoUrl: string | null;
+  readonly orgLogoMono: boolean;
+}

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/chart-bar.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/chart-bar.ts
@@ -1,19 +1,14 @@
-// View-model for one bar in the leaderboard chart. Computed from a LeaderboardEntry.
 export interface ChartBar {
   readonly id: string;
   readonly rank: number;
-  // Model slug (e.g. "claude-opus-4.1"); shown beneath the bar.
   readonly slug: string;
-  // Full model name (e.g. "Anthropic: Claude Opus 4.1"); used for hover title and aria-label.
   readonly modelName: string;
   readonly modelOrganization: string | null;
-  // Rounded BT score; rendered above the bar tip.
   readonly score: number;
-  // Bar height as a percentage of the chart track. Floored so the shortest bar still has room for the logo.
+  // Bar height as a percentage of the track. Floored so the shortest bar still fits the logo.
   readonly heightPct: number;
-  // CSS gradient string for the bar fill. Top-3 ranks use brand colors; rank 4+ use silver/slate.
+  // CSS gradient. Ranks 1-3 use the brand podium gradient; rank 4+ use the silver gradient.
   readonly barGradient: string;
   readonly orgLogoUrl: string | null;
-  // True for monochrome SVG logos that need dark-mode inversion via CSS filter.
   readonly orgLogoMono: boolean;
 }

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/chart-bar.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/chart-bar.ts
@@ -1,10 +1,12 @@
 export interface ChartBar {
   readonly id: string;
   readonly rank: number;
+  readonly slug: string;
   readonly modelName: string;
   readonly modelOrganization: string | null;
   readonly score: number;
   readonly heightPct: number;
+  readonly barGradient: string;
   readonly orgLogoUrl: string | null;
   readonly orgLogoMono: boolean;
 }

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/chart-bar.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/chart-bar.ts
@@ -1,12 +1,19 @@
+// View-model for one bar in the leaderboard chart. Computed from a LeaderboardEntry.
 export interface ChartBar {
   readonly id: string;
   readonly rank: number;
+  // Model slug (e.g. "claude-opus-4.1"); shown beneath the bar.
   readonly slug: string;
+  // Full model name (e.g. "Anthropic: Claude Opus 4.1"); used for hover title and aria-label.
   readonly modelName: string;
   readonly modelOrganization: string | null;
+  // Rounded BT score; rendered above the bar tip.
   readonly score: number;
+  // Bar height as a percentage of the chart track. Floored so the shortest bar still has room for the logo.
   readonly heightPct: number;
+  // CSS gradient string for the bar fill. Top-3 ranks use brand colors; rank 4+ use silver/slate.
   readonly barGradient: string;
   readonly orgLogoUrl: string | null;
+  // True for monochrome SVG logos that need dark-mode inversion via CSS filter.
   readonly orgLogoMono: boolean;
 }

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.html
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.html
@@ -1,21 +1,20 @@
 <ol class="chart-row" role="list">
-  @for (bar of bars(); track bar.id) {
+  @for (bar of bars(); track bar.id; let i = $index) {
     <li
       class="chart-bar"
       [attr.aria-label]="'Rank ' + bar.rank + ': ' + bar.modelName + ', score ' + bar.score"
     >
-      <div class="bar-track">
-        <div class="bar-fill" [style.height.%]="bar.heightPct" [style.background]="bar.barGradient">
-          <span class="bar-score">{{ bar.score }}</span>
-          <bixarena-avatar
-            class="bar-logo"
-            [class.is-mono]="bar.orgLogoMono"
-            shape="bare"
-            size="md"
-            [imageUrl]="bar.orgLogoUrl"
-            [name]="bar.modelOrganization ?? bar.modelName"
-          />
-        </div>
+      <div class="bar-track" [style.--bar-final-height.%]="bar.heightPct" [style.--bar-index]="i">
+        <div class="bar-shape" [style.background]="bar.barGradient"></div>
+        <span class="bar-score">{{ bar.score }}</span>
+        <bixarena-avatar
+          class="bar-logo"
+          [class.is-mono]="bar.orgLogoMono"
+          shape="bare"
+          size="md"
+          [imageUrl]="bar.orgLogoUrl"
+          [name]="bar.modelOrganization ?? bar.modelName"
+        />
       </div>
       <span class="bar-name" [title]="bar.modelName">{{ bar.slug }}</span>
     </li>

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.html
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.html
@@ -4,9 +4,9 @@
       class="chart-bar"
       [attr.aria-label]="'Rank ' + bar.rank + ': ' + bar.modelName + ', score ' + bar.score"
     >
-      <span class="bar-score">{{ bar.score }}</span>
       <div class="bar-track">
-        <div class="bar-fill" [style.height.%]="bar.heightPct">
+        <div class="bar-fill" [style.height.%]="bar.heightPct" [style.background]="bar.barGradient">
+          <span class="bar-score">{{ bar.score }}</span>
           <bixarena-avatar
             class="bar-logo"
             [class.is-mono]="bar.orgLogoMono"
@@ -17,7 +17,7 @@
           />
         </div>
       </div>
-      <span class="bar-name" [title]="bar.modelName">{{ bar.modelName }}</span>
+      <span class="bar-name" [title]="bar.modelName">{{ bar.slug }}</span>
     </li>
   }
 </ol>

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.html
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.html
@@ -1,0 +1,23 @@
+<ol class="chart-row" role="list">
+  @for (bar of bars(); track bar.id) {
+    <li
+      class="chart-bar"
+      [attr.aria-label]="'Rank ' + bar.rank + ': ' + bar.modelName + ', score ' + bar.score"
+    >
+      <span class="bar-score">{{ bar.score }}</span>
+      <div class="bar-track">
+        <div class="bar-fill" [style.height.%]="bar.heightPct">
+          <bixarena-avatar
+            class="bar-logo"
+            [class.is-mono]="bar.orgLogoMono"
+            shape="bare"
+            size="md"
+            [imageUrl]="bar.orgLogoUrl"
+            [name]="bar.modelOrganization ?? bar.modelName"
+          />
+        </div>
+      </div>
+      <span class="bar-name" [title]="bar.modelName">{{ bar.modelName }}</span>
+    </li>
+  }
+</ol>

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.html
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.html
@@ -1,3 +1,13 @@
+<!--
+  Layout per bar:
+    .chart-bar (column)
+      .bar-track (the 16rem-tall positioning context)
+        .bar-shape   ← animated colored rectangle (bar fill)
+        .bar-score   ← absolute, anchored above bar tip via --bar-final-height
+        .bar-logo    ← absolute, anchored inside bar tip via --bar-final-height
+      .bar-name      ← slug label below the track
+  Track exposes --bar-final-height (% of track) and --bar-index (for staggered animation).
+-->
 <ol class="chart-row" role="list">
   @for (bar of bars(); track bar.id; let i = $index) {
     <li

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.scss
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.scss
@@ -2,6 +2,8 @@
   display: block;
 }
 
+// Horizontal row of bars. Centers when content fits, scrolls horizontally otherwise.
+// Top padding leaves room for the score labels that float above the tallest bar.
 .chart-row {
   display: flex;
   gap: 1.25rem;
@@ -12,6 +14,7 @@
   justify-content: safe center;
 }
 
+// One column per bar: track on top, slug label beneath.
 .chart-bar {
   flex: 0 0 auto;
   width: 6rem;
@@ -21,12 +24,15 @@
   gap: 0.75rem;
 }
 
+// Positioning context for the bar shape, score, and logo. Receives two custom props
+// from the template: --bar-final-height (target % of track) and --bar-index (for stagger).
 .bar-track {
   position: relative;
   width: 3.5rem;
   height: 16rem;
 }
 
+// The animated colored rectangle. Empty element so transform/height changes don't drag children.
 .bar-shape {
   position: absolute;
   bottom: 0;
@@ -48,6 +54,7 @@
   }
 }
 
+// Score label floats just above the bar tip; fades in after the bar finishes rising.
 .bar-score {
   position: absolute;
   left: 0;
@@ -62,6 +69,7 @@
   animation-delay: calc(var(--bar-index, 0) * 60ms + 0.55s);
 }
 
+// Org logo sits inside the bar near its tip. Fades in slightly after the score.
 .bar-logo {
   position: absolute;
   left: 50%;

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.scss
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.scss
@@ -5,10 +5,11 @@
 .chart-row {
   display: flex;
   gap: 1.25rem;
-  padding: 1rem 0.5rem;
+  padding: 3rem 1rem 1.5rem;
   margin: 0;
   list-style: none;
   overflow: auto hidden;
+  justify-content: safe center;
 }
 
 .chart-bar {
@@ -17,13 +18,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
-}
-
-.bar-score {
-  font-size: var(--text-sm);
-  color: var(--p-text-color);
-  font-weight: 600;
+  gap: 0.75rem;
 }
 
 .bar-track {
@@ -32,29 +27,46 @@
   display: flex;
   align-items: flex-end;
   justify-content: center;
-  position: relative;
 }
 
 .bar-fill {
+  position: relative;
   width: 100%;
-  background: var(--p-primary-500);
   border-radius: var(--p-border-radius-md) var(--p-border-radius-md) 0 0;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
+  padding-top: 0.6rem;
   transition: height 0.2s ease;
 }
 
+.bar-score {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: -1.4rem;
+  text-align: center;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--p-text-color);
+}
+
 .bar-logo {
-  /* Avatar component centers itself within the bar fill */
+  display: block;
+  margin-top: 0.75rem;
 }
 
 .bar-name {
   font-size: var(--text-xs);
   color: var(--p-text-muted-color);
+  font-family: var(--font-mono, ui-monospace, monospace);
   text-align: center;
   max-width: 6rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  word-break: break-word;
+  line-height: 1.25;
 }

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.scss
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.scss
@@ -104,3 +104,12 @@
   word-break: break-word;
   line-height: 1.25;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .bar-shape,
+  .bar-score,
+  .bar-logo {
+    animation: none;
+    opacity: 1;
+  }
+}

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.scss
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.scss
@@ -22,38 +22,64 @@
 }
 
 .bar-track {
+  position: relative;
   width: 3.5rem;
   height: 16rem;
-  display: flex;
-  align-items: flex-end;
-  justify-content: center;
 }
 
-.bar-fill {
-  position: relative;
-  width: 100%;
+.bar-shape {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: var(--bar-final-height, 0);
   border-radius: var(--p-border-radius-md) var(--p-border-radius-md) 0 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding-top: 0.6rem;
-  transition: height 0.2s ease;
+  animation: bar-rise 0.7s cubic-bezier(0.22, 1, 0.36, 1) backwards;
+  animation-delay: calc(var(--bar-index, 0) * 60ms);
+}
+
+@keyframes bar-rise {
+  from {
+    height: 0;
+  }
+
+  to {
+    height: var(--bar-final-height);
+  }
 }
 
 .bar-score {
   position: absolute;
   left: 0;
   right: 0;
-  top: -1.4rem;
+  bottom: calc(var(--bar-final-height) + 0.4rem);
   text-align: center;
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--p-text-color);
+  opacity: 0;
+  animation: bar-content-appear 0.3s ease forwards;
+  animation-delay: calc(var(--bar-index, 0) * 60ms + 0.55s);
 }
 
 .bar-logo {
-  display: block;
-  margin-top: 0.75rem;
+  position: absolute;
+  left: 50%;
+  bottom: calc(var(--bar-final-height) - 2.6rem);
+  transform: translateX(-50%);
+  opacity: 0;
+  animation: bar-content-appear 0.3s ease forwards;
+  animation-delay: calc(var(--bar-index, 0) * 60ms + 0.6s);
+}
+
+@keyframes bar-content-appear {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 .bar-name {

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.scss
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.scss
@@ -1,0 +1,60 @@
+:host {
+  display: block;
+}
+
+.chart-row {
+  display: flex;
+  gap: 1.25rem;
+  padding: 1rem 0.5rem;
+  margin: 0;
+  list-style: none;
+  overflow: auto hidden;
+}
+
+.chart-bar {
+  flex: 0 0 auto;
+  width: 6rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.bar-score {
+  font-size: var(--text-sm);
+  color: var(--p-text-color);
+  font-weight: 600;
+}
+
+.bar-track {
+  width: 3.5rem;
+  height: 16rem;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  position: relative;
+}
+
+.bar-fill {
+  width: 100%;
+  background: var(--p-primary-500);
+  border-radius: var(--p-border-radius-md) var(--p-border-radius-md) 0 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: height 0.2s ease;
+}
+
+.bar-logo {
+  /* Avatar component centers itself within the bar fill */
+}
+
+.bar-name {
+  font-size: var(--text-xs);
+  color: var(--p-text-muted-color);
+  text-align: center;
+  max-width: 6rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.spec.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.spec.ts
@@ -1,0 +1,76 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LeaderboardEntry } from '@sagebionetworks/bixarena/api-client';
+import { LEADERBOARD_BAR_CHART_TOP_N } from '../leaderboard.constants';
+import { LeaderboardBarChartComponent } from './leaderboard-bar-chart.component';
+
+function buildEntry(overrides: Partial<LeaderboardEntry> = {}): LeaderboardEntry {
+  return {
+    id: 'entry-1',
+    modelId: 'test-model',
+    modelName: 'Test Model',
+    modelOrganization: null,
+    modelUrl: 'https://example.com',
+    license: 'open-source',
+    btScore: 1000,
+    voteCount: 100,
+    rank: 1,
+    bootstrapQ025: 950,
+    bootstrapQ975: 1050,
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function buildEntries(count: number): LeaderboardEntry[] {
+  return Array.from({ length: count }, (_, i) =>
+    buildEntry({
+      id: `entry-${i + 1}`,
+      modelId: `model-${i + 1}`,
+      modelName: `Model ${i + 1}`,
+      rank: i + 1,
+      btScore: 1500 - i * 10,
+    }),
+  );
+}
+
+describe('LeaderboardBarChartComponent', () => {
+  let fixture: ComponentFixture<LeaderboardBarChartComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LeaderboardBarChartComponent],
+    }).compileComponents();
+    fixture = TestBed.createComponent(LeaderboardBarChartComponent);
+  });
+
+  it(`renders at most ${LEADERBOARD_BAR_CHART_TOP_N} bars when given more entries`, () => {
+    fixture.componentRef.setInput('entries', buildEntries(25));
+    fixture.detectChanges();
+    const bars = (fixture.nativeElement as HTMLElement).querySelectorAll('.chart-bar');
+    expect(bars.length).toBe(LEADERBOARD_BAR_CHART_TOP_N);
+  });
+
+  it('renders one bar per entry when fewer than top-N entries are given', () => {
+    fixture.componentRef.setInput('entries', buildEntries(5));
+    fixture.detectChanges();
+    const bars = (fixture.nativeElement as HTMLElement).querySelectorAll('.chart-bar');
+    expect(bars.length).toBe(5);
+  });
+
+  it('normalizes height — top entry at 100, lowest at the floor (>= 8)', () => {
+    fixture.componentRef.setInput('entries', buildEntries(3));
+    fixture.detectChanges();
+    const bars = fixture.componentInstance.bars();
+    expect(bars[0].heightPct).toBe(100);
+    expect(bars[bars.length - 1].heightPct).toBeGreaterThanOrEqual(8);
+  });
+
+  it('exposes rank, model name, and score via aria-label', () => {
+    fixture.componentRef.setInput('entries', [
+      buildEntry({ rank: 3, modelName: 'GPT-X', btScore: 1234.6 }),
+    ]);
+    fixture.detectChanges();
+    const bar = (fixture.nativeElement as HTMLElement).querySelector('.chart-bar');
+    expect(bar?.getAttribute('aria-label')).toBe('Rank 3: GPT-X, score 1235');
+  });
+});

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.spec.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.spec.ts
@@ -57,12 +57,24 @@ describe('LeaderboardBarChartComponent', () => {
     expect(bars.length).toBe(5);
   });
 
-  it('normalizes height — top entry at 100, lowest at the floor (>= 8)', () => {
+  it('maps height linearly so the lowest bar sits at the floor and others scale proportionally', () => {
     fixture.componentRef.setInput('entries', buildEntries(3));
     fixture.detectChanges();
     const bars = fixture.componentInstance.bars();
     expect(bars[0].heightPct).toBe(100);
-    expect(bars[bars.length - 1].heightPct).toBeGreaterThanOrEqual(8);
+    expect(bars[bars.length - 1].heightPct).toBe(32);
+    expect(bars[1].heightPct).toBeGreaterThan(32);
+    expect(bars[1].heightPct).toBeLessThan(100);
+  });
+
+  it('uses brand gradient for top three and silver gradient for the rest', () => {
+    fixture.componentRef.setInput('entries', buildEntries(5));
+    fixture.detectChanges();
+    const bars = fixture.componentInstance.bars();
+    expect(bars[0].barGradient).toContain('--p-primary-300');
+    expect(bars[2].barGradient).toContain('--p-primary-500');
+    expect(bars[3].barGradient).toContain('--p-slate-300');
+    expect(bars[4].barGradient).toContain('--p-slate-500');
   });
 
   it('exposes rank, model name, and score via aria-label', () => {

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.ts
@@ -5,6 +5,9 @@ import { LEADERBOARD_BAR_CHART_TOP_N } from '../leaderboard.constants';
 import { getOrgLogoUrl, isMonoOrgLogo } from '../model-org-logo';
 import { ChartBar } from './chart-bar';
 
+// Top-N bar chart visualization for the leaderboard. Pure HTML/SCSS — no chart library.
+// Sibling of LeaderboardTableComponent; both consume the same `entries` signal from
+// LeaderboardFacadeService. The parent toolbar drives which view is rendered.
 @Component({
   selector: 'bixarena-leaderboard-bar-chart',
   imports: [AvatarComponent],
@@ -15,6 +18,8 @@ import { ChartBar } from './chart-bar';
 export class LeaderboardBarChartComponent {
   readonly entries = input.required<LeaderboardEntry[]>();
 
+  // Map raw entries → ChartBar view-models. Slices to top-N, normalizes heights to
+  // a [MIN_HEIGHT_PCT, 100] range, and assigns brand vs silver gradient by rank.
   readonly bars = computed<ChartBar[]>(() => {
     const visible = this.entries().slice(0, LEADERBOARD_BAR_CHART_TOP_N);
     if (visible.length === 0) return [];
@@ -25,9 +30,11 @@ export class LeaderboardBarChartComponent {
       if (e.btScore < minScore) minScore = e.btScore;
       if (e.btScore > maxScore) maxScore = e.btScore;
     }
+    // Floor keeps even the shortest bar tall enough to fit the logo.
     const MIN_HEIGHT_PCT = 32;
     const scoreRange = maxScore - minScore || 1;
 
+    // Top 3 ranks get the warm brand gradient (podium); the rest get a neutral silver.
     const podiumGradient = 'linear-gradient(to bottom, var(--p-primary-300), var(--p-primary-500))';
     const silverGradient = 'linear-gradient(to bottom, var(--p-slate-300), var(--p-slate-500))';
     return visible.map((entry, index) => {

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.ts
@@ -1,0 +1,42 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { LeaderboardEntry } from '@sagebionetworks/bixarena/api-client';
+import { AvatarComponent } from '@sagebionetworks/bixarena/ui';
+import { LEADERBOARD_BAR_CHART_TOP_N } from '../leaderboard.constants';
+import { getOrgLogoUrl, isMonoOrgLogo } from '../model-org-logo';
+import { ChartBar } from './chart-bar';
+
+@Component({
+  selector: 'bixarena-leaderboard-bar-chart',
+  imports: [AvatarComponent],
+  templateUrl: './leaderboard-bar-chart.component.html',
+  styleUrl: './leaderboard-bar-chart.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LeaderboardBarChartComponent {
+  readonly entries = input.required<LeaderboardEntry[]>();
+
+  readonly bars = computed<ChartBar[]>(() => {
+    const visible = this.entries().slice(0, LEADERBOARD_BAR_CHART_TOP_N);
+    if (visible.length === 0) return [];
+
+    let minScore = Infinity;
+    let maxScore = -Infinity;
+    for (const e of visible) {
+      if (e.btScore < minScore) minScore = e.btScore;
+      if (e.btScore > maxScore) maxScore = e.btScore;
+    }
+    const floor = minScore - 10;
+    const range = maxScore - floor || 1;
+
+    return visible.map((entry) => ({
+      id: entry.id,
+      rank: entry.rank,
+      modelName: entry.modelName,
+      modelOrganization: entry.modelOrganization ?? null,
+      score: Math.round(entry.btScore),
+      heightPct: Math.max(8, ((entry.btScore - floor) / range) * 100),
+      orgLogoUrl: getOrgLogoUrl(entry.modelOrganization),
+      orgLogoMono: isMonoOrgLogo(entry.modelOrganization),
+    }));
+  });
+}

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.ts
@@ -32,13 +32,17 @@ export class LeaderboardBarChartComponent {
     }
     // Floor keeps even the shortest bar tall enough to fit the logo.
     const MIN_HEIGHT_PCT = 32;
-    const scoreRange = maxScore - minScore || 1;
+    const scoreRange = maxScore - minScore;
 
     // Top 3 ranks get the warm brand gradient (podium); the rest get a neutral silver.
     const podiumGradient = 'linear-gradient(to bottom, var(--p-primary-300), var(--p-primary-500))';
     const silverGradient = 'linear-gradient(to bottom, var(--p-slate-300), var(--p-slate-500))';
-    return visible.map((entry, index) => {
-      const rawRatio = (entry.btScore - minScore) / scoreRange;
+    return visible.map((entry) => {
+      // When all visible entries share the same score, render at full height instead of the floor.
+      const heightPct =
+        scoreRange === 0
+          ? 100
+          : MIN_HEIGHT_PCT + ((entry.btScore - minScore) / scoreRange) * (100 - MIN_HEIGHT_PCT);
       return {
         id: entry.id,
         rank: entry.rank,
@@ -46,8 +50,8 @@ export class LeaderboardBarChartComponent {
         modelName: entry.modelName,
         modelOrganization: entry.modelOrganization ?? null,
         score: Math.round(entry.btScore),
-        heightPct: MIN_HEIGHT_PCT + rawRatio * (100 - MIN_HEIGHT_PCT),
-        barGradient: index < 3 ? podiumGradient : silverGradient,
+        heightPct,
+        barGradient: entry.rank <= 3 ? podiumGradient : silverGradient,
         orgLogoUrl: getOrgLogoUrl(entry.modelOrganization),
         orgLogoMono: isMonoOrgLogo(entry.modelOrganization),
       };

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.ts
@@ -25,18 +25,25 @@ export class LeaderboardBarChartComponent {
       if (e.btScore < minScore) minScore = e.btScore;
       if (e.btScore > maxScore) maxScore = e.btScore;
     }
-    const floor = minScore - 10;
-    const range = maxScore - floor || 1;
+    const MIN_HEIGHT_PCT = 32;
+    const scoreRange = maxScore - minScore || 1;
 
-    return visible.map((entry) => ({
-      id: entry.id,
-      rank: entry.rank,
-      modelName: entry.modelName,
-      modelOrganization: entry.modelOrganization ?? null,
-      score: Math.round(entry.btScore),
-      heightPct: Math.max(8, ((entry.btScore - floor) / range) * 100),
-      orgLogoUrl: getOrgLogoUrl(entry.modelOrganization),
-      orgLogoMono: isMonoOrgLogo(entry.modelOrganization),
-    }));
+    const podiumGradient = 'linear-gradient(to bottom, var(--p-primary-300), var(--p-primary-500))';
+    const silverGradient = 'linear-gradient(to bottom, var(--p-slate-300), var(--p-slate-500))';
+    return visible.map((entry, index) => {
+      const rawRatio = (entry.btScore - minScore) / scoreRange;
+      return {
+        id: entry.id,
+        rank: entry.rank,
+        slug: entry.modelId,
+        modelName: entry.modelName,
+        modelOrganization: entry.modelOrganization ?? null,
+        score: Math.round(entry.btScore),
+        heightPct: MIN_HEIGHT_PCT + rawRatio * (100 - MIN_HEIGHT_PCT),
+        barGradient: index < 3 ? podiumGradient : silverGradient,
+        orgLogoUrl: getOrgLogoUrl(entry.modelOrganization),
+        orgLogoMono: isMonoOrgLogo(entry.modelOrganization),
+      };
+    });
   });
 }

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-toolbar/leaderboard-toolbar.component.html
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-toolbar/leaderboard-toolbar.component.html
@@ -115,6 +115,54 @@
     </button>
   }
 
+  <div class="view-toggle" role="group" aria-label="View mode">
+    <button
+      type="button"
+      class="view-btn"
+      [class.is-active]="view() === 'table'"
+      [attr.aria-pressed]="view() === 'table'"
+      aria-label="Table view"
+      (click)="setView('table')"
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <rect x="3" y="3" width="18" height="18" rx="2" />
+        <path d="M3 9h18M3 15h18M9 3v18M15 3v18" />
+      </svg>
+    </button>
+    <button
+      type="button"
+      class="view-btn"
+      [class.is-active]="view() === 'chart'"
+      [attr.aria-pressed]="view() === 'chart'"
+      aria-label="Chart view"
+      (click)="setView('chart')"
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M5 21V10M12 21V4M19 21v-7" />
+      </svg>
+    </button>
+  </div>
+
   <button
     type="button"
     class="filters-trigger"

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-toolbar/leaderboard-toolbar.component.html
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-toolbar/leaderboard-toolbar.component.html
@@ -160,6 +160,8 @@
       >
         <path d="M5 21V10M12 21V4M19 21v-7" />
       </svg>
+      <!-- TODO: remove this NEW badge in a future release once chart view is well known. -->
+      <span class="new-badge">NEW</span>
     </button>
   </div>
 

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-toolbar/leaderboard-toolbar.component.scss
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-toolbar/leaderboard-toolbar.component.scss
@@ -8,6 +8,11 @@
   gap: 0.75rem;
   margin-bottom: 0.75rem;
   flex-wrap: wrap;
+
+  // Keep empty p-popover hosts out of flex layout so the trailing gap is gone.
+  > p-popover {
+    display: contents;
+  }
 }
 
 .category-trigger {

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-toolbar/leaderboard-toolbar.component.scss
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-toolbar/leaderboard-toolbar.component.scss
@@ -202,6 +202,7 @@
 }
 
 .view-btn {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -224,6 +225,22 @@
     background: var(--p-surface-100);
     color: var(--p-text-color);
   }
+}
+
+// TODO: remove together with the matching span in the template once the chart view is no longer "new".
+.new-badge {
+  position: absolute;
+  top: -6px;
+  right: -10px;
+  padding: 1px 5px;
+  background: var(--p-primary-500);
+  color: var(--p-primary-contrast-color, #fff);
+  font-size: 0.55rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  line-height: 1.4;
+  border-radius: 999px;
+  pointer-events: none;
 }
 
 .filters-trigger {

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-toolbar/leaderboard-toolbar.component.scss
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-toolbar/leaderboard-toolbar.component.scss
@@ -186,6 +186,41 @@
   }
 }
 
+.view-toggle {
+  display: inline-flex;
+  align-items: center;
+  height: 2.25rem;
+  padding: 0.15rem;
+  border: 1px solid var(--p-surface-200);
+  border-radius: var(--p-border-radius-md);
+  background: transparent;
+}
+
+.view-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.85rem;
+  height: 100%;
+  border: 0;
+  border-radius: calc(var(--p-border-radius-md) - 2px);
+  background: transparent;
+  color: var(--p-surface-500);
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+
+  &:hover {
+    color: var(--p-text-color);
+  }
+
+  &.is-active {
+    background: var(--p-surface-100);
+    color: var(--p-text-color);
+  }
+}
+
 .filters-trigger {
   display: inline-flex;
   align-items: center;

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-toolbar/leaderboard-toolbar.component.spec.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-toolbar/leaderboard-toolbar.component.spec.ts
@@ -146,4 +146,26 @@ describe('LeaderboardToolbarComponent', () => {
     component.clearAllFilters();
     expect(emitted).toEqual([{ license: null }]);
   });
+
+  it('should mark the active view button with is-active', () => {
+    fixture.componentRef.setInput('view', 'chart');
+    fixture.detectChanges();
+    const buttons = (fixture.nativeElement as HTMLElement).querySelectorAll('.view-btn');
+    expect(buttons[0].classList.contains('is-active')).toBe(false);
+    expect(buttons[1].classList.contains('is-active')).toBe(true);
+  });
+
+  it('should emit viewChange when a different view is clicked', () => {
+    const emitted: string[] = [];
+    component.viewChange.subscribe((v) => emitted.push(v));
+    component.setView('chart');
+    expect(emitted).toEqual(['chart']);
+  });
+
+  it('should not emit viewChange when clicking the already-active view', () => {
+    const emitted: string[] = [];
+    component.viewChange.subscribe((v) => emitted.push(v));
+    component.setView('table');
+    expect(emitted).toEqual([]);
+  });
 });

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-toolbar/leaderboard-toolbar.component.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-toolbar/leaderboard-toolbar.component.ts
@@ -21,6 +21,8 @@ export interface LeaderboardCategoryOption {
   readonly name: string;
 }
 
+export type LeaderboardView = 'table' | 'chart';
+
 @Component({
   selector: 'bixarena-leaderboard-toolbar',
   imports: [PopoverModule, KebabToTitlePipe],
@@ -33,10 +35,12 @@ export class LeaderboardToolbarComponent {
   readonly activeCategoryId = input.required<string>();
   readonly searchTerm = input<string>('');
   readonly filters = input<LeaderboardFilters>(DEFAULT_LEADERBOARD_FILTERS);
+  readonly view = input<LeaderboardView>('table');
 
   readonly categoryChange = output<string>();
   readonly searchChange = output<string>();
   readonly filtersChange = output<LeaderboardFilters>();
+  readonly viewChange = output<LeaderboardView>();
 
   private readonly categoryPicker = viewChild.required<Popover>('categoryPicker');
   private readonly filterPopover = viewChild.required<Popover>('filterPopover');
@@ -122,5 +126,9 @@ export class LeaderboardToolbarComponent {
 
   clearAllFilters(): void {
     this.filtersChange.emit(DEFAULT_LEADERBOARD_FILTERS);
+  }
+
+  setView(next: LeaderboardView): void {
+    if (this.view() !== next) this.viewChange.emit(next);
   }
 }

--- a/libs/bixarena/leaderboard/src/lib/leaderboard.component.html
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard.component.html
@@ -28,9 +28,11 @@
     [activeCategoryId]="activeCategoryId()"
     [searchTerm]="searchTerm()"
     [filters]="filters()"
+    [view]="view()"
     (categoryChange)="onCategoryChange($event)"
     (searchChange)="onSearchInput($event)"
     (filtersChange)="onFiltersChange($event)"
+    (viewChange)="onViewChange($event)"
   />
 
   <section class="table-wrap">
@@ -41,6 +43,8 @@
         <span>Unable to load leaderboard.</span>
         <button type="button" class="retry-btn" (click)="retry()">Retry</button>
       </div>
+    } @else if (view() === 'chart') {
+      <bixarena-leaderboard-bar-chart [entries]="facade.entries()" />
     } @else {
       <bixarena-leaderboard-table
         [entries]="facade.entries()"
@@ -51,7 +55,7 @@
     }
   </section>
 
-  @if (!facade.loading() && !facade.error() && facade.totalElements() > 0) {
+  @if (view() === 'table' && !facade.loading() && !facade.error() && facade.totalElements() > 0) {
     <p-paginator
       class="leaderboard-paginator"
       [first]="pageFirst()"

--- a/libs/bixarena/leaderboard/src/lib/leaderboard.component.spec.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard.component.spec.ts
@@ -69,6 +69,24 @@ describe('LeaderboardComponent', () => {
     expect(title?.textContent).toContain('Leader');
   });
 
+  describe('view toggle', () => {
+    it('defaults to table view', () => {
+      const fixture = createFixture();
+      expect(fixture.componentInstance.view()).toBe('table');
+    });
+
+    it('switches to chart view and hides the paginator', async () => {
+      const fixture = createFixture();
+      await fixture.whenStable();
+      fixture.componentInstance.view.set('chart');
+      fixture.detectChanges();
+      const root = fixture.nativeElement as HTMLElement;
+      expect(root.querySelector('bixarena-leaderboard-bar-chart')).not.toBeNull();
+      expect(root.querySelector('bixarena-leaderboard-table')).toBeNull();
+      expect(root.querySelector('p-paginator')).toBeNull();
+    });
+  });
+
   describe('categoryOptions filtering', () => {
     it('hides categories with no latestSnapshot', async () => {
       apiStub.listLeaderboards.mockReturnValueOnce(

--- a/libs/bixarena/leaderboard/src/lib/leaderboard.component.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard.component.ts
@@ -12,7 +12,11 @@ import {
   LeaderboardSortField,
   LeaderboardTableComponent,
 } from './leaderboard-table/leaderboard-table.component';
-import { LeaderboardToolbarComponent } from './leaderboard-toolbar/leaderboard-toolbar.component';
+import {
+  LeaderboardToolbarComponent,
+  LeaderboardView,
+} from './leaderboard-toolbar/leaderboard-toolbar.component';
+import { LeaderboardBarChartComponent } from './leaderboard-bar-chart/leaderboard-bar-chart.component';
 import { DEFAULT_LEADERBOARD_FILTERS, LeaderboardFilters } from './leaderboard.filters';
 import {
   DEFAULT_PAGE_SIZE,
@@ -35,6 +39,7 @@ const SORT_FIELD_MAP: Record<LeaderboardSortField, LeaderboardSort> = {
   imports: [
     LeaderboardTableComponent,
     LeaderboardToolbarComponent,
+    LeaderboardBarChartComponent,
     PaginatorModule,
     DatePipe,
     DecimalPipe,
@@ -56,6 +61,8 @@ export class LeaderboardComponent {
 
   readonly sortField = signal<LeaderboardSortField>(DEFAULT_SORT_FIELD);
   readonly sortOrder = signal<1 | -1>(DEFAULT_SORT_ORDER);
+
+  readonly view = signal<LeaderboardView>('table');
 
   private readonly debouncedSearch = signal('');
   private searchTimer?: ReturnType<typeof setTimeout>;
@@ -129,5 +136,9 @@ export class LeaderboardComponent {
 
   retry(): void {
     void this.facade.load(this.activeCategoryId(), this.query());
+  }
+
+  onViewChange(next: LeaderboardView): void {
+    this.view.set(next);
   }
 }

--- a/libs/bixarena/leaderboard/src/lib/leaderboard.constants.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard.constants.ts
@@ -7,3 +7,4 @@ export const LOOKBACK_DAYS = 7;
 export const DEFAULT_SORT_FIELD = 'rank';
 export const DEFAULT_SORT_ORDER: 1 | -1 = 1;
 export const LEADERBOARD_TABLE_COLUMN_COUNT = 7;
+export const LEADERBOARD_BAR_CHART_TOP_N = 10;


### PR DESCRIPTION
## Description

Adds a chart visualization view to the leaderboard alongside the existing table view, surfacing the top-ranked models at a glance. A toolbar toggle switches between table and chart while sharing filter, sort, and search state across both views.

## Related Issue

N/A

## Changelog

- Add `LeaderboardBarChartComponent` rendering the top 10 entries (matched the min_total_battles) with a podium gradient for ranks 1-3 and a neutral gradient for the remainder
- Add a table/chart view toggle to the leaderboard toolbar, marked with a temporary "NEW" badge
- Wire the chart view into the parent leaderboard component so filters, sorting, and search apply to both views
- Animate bars with a staggered rise and fade-in labels, with a `prefers-reduced-motion` fallback
- Fix pre-existing toolbar misalignment so the filters button sits flush with the table's right edge

## Testing

https://github.com/user-attachments/assets/3827d29d-c8f7-44ac-8259-5e92bcae69a6


