### PR TITLE
fix(sage-monorepo): fix ci.yml race condition (SMR-761)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
         run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
 
       - name: Build and publish the images of the affected projects
+        # Only publish on the post-merge push to main.
+        if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_ACTOR: ${{ github.actor }}


### PR DESCRIPTION
## Description

When a PR merges through GitHub's merge queue, the push job in ci.yml executes twice — once on the `merge_group` event and once on the `push` event after the merge lands on main. Today, both invocations call `nx affected --target=build-image --configuration=edge`, which pushes container images to GHCR. The two pushes race, producing different image digests for the same source, and the later one moves the type=sha tag off the post-merge :edge manifest.

This PR gates the "Build and publish the images" step on github.event_name == 'push' so only the post-merge run publishes. The merge queue still validates the affected projects (lint, build, test, integration-test) — it just doesn't publish.

## Related Issue

[SMR-761](https://sagebionetworks.jira.com/browse/SMR-761)

## Changelog

- Gate "Build and publish the images of the affected projects" in .github/workflows/ci.yml on github.event_name == 'push'

## Testing

- Merge a small follow-up PR (any change that touches a publishable project) via the merge queue and confirm:
 -- The merge_group CI run completes successfully but its log contains no `docker buildx build … --push` invocation for any image. Searching the run for naming to ghcr.io/sage-bionetworks/ should return zero hits.
 -- The post-merge push-event CI run does contain the `docker buildx build … --push` invocation.
 - After the post-merge run completes, verify GHCR state
 - On the infra repo, trigger `deploy-dev` and confirm the workflow's "synth" step prints Using images: model-ad-app:sha-<commit>, … (a real SHA, not the literal string edge). The dev footer should then read Site Version edge-<7-char-sha>.



[SMR-761]: https://sagebionetworks.jira.com/browse/SMR-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ