### PR TITLE
fix(sage-monorepo): sentry uploads not gated to push events (SMR-762)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
             && nx affected --target=build-image --configuration=edge'
 
       - name: Upload Sentry sourcemaps for the affected projects
+        if: github.event_name == 'push'
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo \
             --remote-env SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN" \


### PR DESCRIPTION
## Description

Gates the Sentry sourcemaps upload step in CI to `push` events only, preventing duplicate uploads from the same commit. Previously, the step ran for both `merge_group` and `push` events, causing the same release sourcemaps to be uploaded twice when a PR merged through the merge queue.

## Related Issue

Fixes [SMR-762](https://sagebionetworks.jira.com/browse/SMR-762)

## Changelog

- Restrict the Sentry sourcemaps upload step in `.github/workflows/ci.yml` to `push` events

## Testing

The CI workflow now has:

- Single Sentry sourcemap upload per merged commit instead of duplicate uploads
- Cleaner Sentry release artifacts with no redundant uploads from merge_group runs


[SMR-762]: https://sagebionetworks.jira.com/browse/SMR-762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ