### PR TITLE
fix(model-ad): fix alignment of significance controls (MG-893)

### DIFF
--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-controls/significance-controls/significance-controls.component.scss
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-controls/significance-controls/significance-controls.component.scss
@@ -19,11 +19,6 @@
     align-items: center;
     padding-left: 10px;
   }
-
-  .toggle-switch {
-    display: flex;
-    align-items: end;
-  }
 }
 
 .significance-control-panel {


### PR DESCRIPTION
## Description

Fix alignment of significance control toggle.

## Related Issue

[MG-893](https://sagebionetworks.jira.com/browse/MG-893)

## Changelog

- Updated css to fix alignment issue

## Testing

See below for preview of fix:

| Before                   | After                   |
|--------------------------|-------------------------|
| <img width="259" height="73" alt="image" src="https://github.com/user-attachments/assets/e63b53d4-835f-4827-8b63-782da68ec945" /> | <img width="242" height="49" alt="image" src="https://github.com/user-attachments/assets/a56f327d-b489-481e-b0f9-45e1b7b2bdf2" /> |


[MG-893]: https://sagebionetworks.jira.com/browse/MG-893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ