### PR TITLE
fix(sage-monorepo): run ghp-import on host to restore gh-pages deploy auth (SMR-773)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -47,9 +47,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Deploy to GitHub Pages
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-              && uv run ghp-import -n -p -f -m 'Deploy full site (docs + all storybooks)' site"
+        run: pipx run ghp-import -n -p -f -m 'Deploy full site (docs + all storybooks)' site
 
       - name: Remove the dev container
         if: always()

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -49,6 +49,9 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
+      - name: Install ghp-import
+        run: pipx install ghp-import
+
       - name: Deploy storybooks
         env:
           STORYBOOKS: ${{ inputs.storybooks }}
@@ -57,8 +60,7 @@ jobs:
 
           for storybook in $STORYBOOKS; do
             echo "Deploying storybook/${storybook}"
-            devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-                && uv run ghp-import -p -f -m 'Deploy storybook/${storybook}' -x storybook/${storybook} dist/storybook/storybook/${storybook}"
+            ghp-import -p -f -m "Deploy storybook/${storybook}" -x "storybook/${storybook}" "dist/storybook/storybook/${storybook}"
           done
 
           echo ""


### PR DESCRIPTION
## Description

The `actions/checkout` bump to v6.0.2 in #4020 broke gh-pages deploys. [v6](https://github.com/actions/checkout/releases/tag/v6.0.0) changed `persist-credentials: true` to write the GitHub token to a file under `$RUNNER_TEMP` instead of into `.git/config`. The deploy-docs and deploy-storybook workflows ran `ghp-import` inside the devcontainer, which only sees the bind-mounted repo (not `$RUNNER_TEMP`) so `git push origin gh-pages` fell through to interactive auth and failed with `could not read Username for 'https://github.com'`. This moves the publish step to the host, where the credential file lives.

## Related Issue

- [SMR-773](https://sagebionetworks.jira.com/browse/SMR-773)

## Changelog

- Run `ghp-import` on the host (via `pipx`) in `deploy-docs.yml` and `deploy-storybook.yml` so it picks up the v6 credential file
- Keep `mkdocs build` and `nx build-storybook` inside the devcontainer; only the publish step moved


[SMR-773]: https://sagebionetworks.jira.com/browse/SMR-773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ