### PR TITLE
feat(bixarena): refine battle page and add mobile responsiveness (SMR-778)

### DIFF
--- a/apps/bixarena/app-angular/src/app/app.component.html
+++ b/apps/bixarena/app-angular/src/app/app.component.html
@@ -5,7 +5,9 @@
 <main>
   <router-outlet />
 </main>
-<bixarena-footer />
+@if (showFooter()) {
+  <bixarena-footer />
+}
 
 <bixarena-login-modal
   [(visible)]="gate.showLoginModal"

--- a/apps/bixarena/app-angular/src/app/app.component.ts
+++ b/apps/bixarena/app-angular/src/app/app.component.ts
@@ -1,5 +1,7 @@
-import { Component, inject } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { Component, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { NavigationEnd, Router, RouterModule } from '@angular/router';
+import { filter, map } from 'rxjs/operators';
 import { ConfigService } from '@sagebionetworks/bixarena/config';
 import { BattleGateService } from '@sagebionetworks/bixarena/services';
 import { NavComponent, FooterComponent, LoginModalComponent } from '@sagebionetworks/bixarena/ui';
@@ -14,4 +16,14 @@ import { GtmComponent } from '@sagebionetworks/web-shared/angular/analytics/gtm'
 export class AppComponent {
   readonly useGoogleTagManager = inject(ConfigService).config.analytics.googleTagManager.enabled;
   readonly gate = inject(BattleGateService);
+
+  private readonly router = inject(Router);
+  private readonly currentUrl = toSignal(
+    this.router.events.pipe(
+      filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+      map((e) => e.urlAfterRedirects),
+    ),
+    { initialValue: this.router.url },
+  );
+  readonly showFooter = computed(() => !this.currentUrl().startsWith('/battle'));
 }

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -60,26 +60,26 @@
           (continue)="state.continueRound('model2')"
         />
       </div>
-      <bixarena-voting-bar
-        [phase]="state.phase()"
-        [canVote]="state.canVote()"
-        [canReuse]="state.canReuse()"
-        (vote)="onVote($event)"
-        (hoverSide)="hoverSide.set($event)"
-        (newBattle)="onNewBattle()"
-        (samePrompt)="onSamePromptSubmit()"
-      />
-      <div class="btm">
+      <div class="composer-group">
+        <bixarena-voting-bar
+          [phase]="state.phase()"
+          [canVote]="state.canVote()"
+          [canReuse]="state.canReuse()"
+          (vote)="onVote($event)"
+          (hoverSide)="hoverSide.set($event)"
+          (newBattle)="onNewBattle()"
+          (samePrompt)="onSamePromptSubmit()"
+        />
         <bixarena-prompt-composer
           placeholder="Ask a follow-up..."
           [maxLength]="state.promptLengthLimit"
           [disabled]="state.phase() !== 'voting'"
           (promptSubmit)="onFollowUpSubmit($event)"
         />
+        <p class="disclaimer">
+          AI may make mistakes. Do not include sensitive or personal information.
+        </p>
       </div>
-      <p class="disclaimer">
-        AI may make mistakes. Do not include sensitive or personal information.
-      </p>
     </section>
   }
 </div>

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -39,12 +39,9 @@
             [class.fut]="i > state.currentMatch()"
           ></span>
         }
+        <span class="rl">Match {{ state.currentMatch() }} / {{ state.promptUseLimit }}</span>
         @if (state.allMatchesComplete()) {
-          <span class="rl complete"
-            >Nice work — {{ state.promptUseLimit }} matchups in. Battle a new question?</span
-          >
-        } @else {
-          <span class="rl">Match {{ state.currentMatch() }} / {{ state.promptUseLimit }}</span>
+          <span class="rl complete">Nice run! Start a new battle to continue.</span>
         }
       </div>
       <div class="panels">

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -26,7 +26,11 @@
   @if (state.phase() !== 'landing') {
     <section class="battle-view">
       <bixarena-blueprint-bg />
-      <div class="rail">
+      <div
+        class="rail"
+        pTooltip="Submit the same question against a fresh pair of models. The dots track your progress."
+        tooltipPosition="bottom"
+      >
         @for (i of state.promptUseDots; track i) {
           <span
             class="rd"
@@ -36,7 +40,9 @@
           ></span>
         }
         @if (state.allMatchesComplete()) {
-          <span class="rl complete">You've stress-tested this question! Try a new one.</span>
+          <span class="rl complete"
+            >Nice work — {{ state.promptUseLimit }} matchups in. Battle a new question?</span
+          >
         } @else {
           <span class="rl">Match {{ state.currentMatch() }} / {{ state.promptUseLimit }}</span>
         }

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -1,13 +1,10 @@
 <div class="page-content shell">
   @if (state.phase() === 'landing') {
     <section class="landing">
-      <div class="hero">
-        <h1 class="title">Bio<em>Arena</em></h1>
-        <p class="subtitle">
-          Discover how different AIs answer biomedical questions.<br />
-          No expertise needed — just vote for the response you trust.
-        </p>
-      </div>
+      <bixarena-hero
+        titleHtml="Bio<em>Arena</em>"
+        subtitleHtml="Discover how different AIs answer biomedical questions.<br>No expertise needed — just vote for the response you trust."
+      />
       <bixarena-example-prompts (promptSelect)="onExamplePromptSelect($event)" />
       <div class="composer-group">
         <bixarena-prompt-composer

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -25,6 +25,7 @@
 
   @if (state.phase() !== 'landing') {
     <section class="battle-view">
+      <bixarena-blueprint-bg />
       <div class="rail">
         @for (i of state.promptUseDots; track i) {
           <span

--- a/libs/bixarena/battle/src/lib/battle.component.scss
+++ b/libs/bixarena/battle/src/lib/battle.component.scss
@@ -32,14 +32,6 @@ bixarena-example-prompts {
   align-self: center;
 }
 
-// Pin composer to viewport bottom on landing's page-level scroll.
-.landing .composer-group {
-  position: sticky;
-  bottom: 1rem;
-  z-index: 5;
-  margin-top: auto;
-}
-
 // Fixed height so panels scroll internally instead of growing infinitely.
 .battle-view {
   position: relative;
@@ -129,13 +121,7 @@ bixarena-example-prompts {
   margin: 1rem 0 0;
 }
 
-// Mobile: page-level scroll, sticky composer/rail, stacked panels.
 @media (width < #{shared.$md-breakpoint}) {
-  .landing .composer-group {
-    position: static;
-    margin-top: auto;
-  }
-
   .battle-view {
     height: auto;
     min-height: calc(100dvh - var(--nav-height));

--- a/libs/bixarena/battle/src/lib/battle.component.scss
+++ b/libs/bixarena/battle/src/lib/battle.component.scss
@@ -15,8 +15,7 @@
   padding: 2.5rem 0 1rem;
 }
 
-.hero {
-  text-align: center;
+bixarena-hero {
   margin-bottom: 2.5rem;
 }
 
@@ -39,29 +38,6 @@ bixarena-example-prompts {
   bottom: 1rem;
   z-index: 5;
   margin-top: auto;
-}
-
-.title {
-  font-family: var(--font-serif);
-  font-size: 3rem;
-  font-weight: 400;
-  letter-spacing: -0.96px;
-  line-height: 1.08;
-  margin: 0 0 0.75rem;
-  color: var(--p-text-color);
-
-  em {
-    font-style: italic;
-    color: var(--p-primary-color);
-  }
-}
-
-.subtitle {
-  font-size: var(--text-lg);
-  color: var(--p-surface-600);
-  max-width: 37.5rem;
-  margin: 0 auto;
-  line-height: 1.55;
 }
 
 // Fixed height so panels scroll internally instead of growing infinitely.

--- a/libs/bixarena/battle/src/lib/battle.component.scss
+++ b/libs/bixarena/battle/src/lib/battle.component.scss
@@ -25,15 +25,22 @@ bixarena-example-prompts {
 }
 
 .composer-group {
-  position: sticky;
-  bottom: 1rem;
-  z-index: 5;
-  margin-top: auto;
   width: 100%;
   max-width: 40rem;
   display: flex;
   flex-direction: column;
+  gap: 0.5rem;
   align-self: center;
+}
+
+// Landing has page-level scroll, so pin the composer to the viewport bottom.
+// Battle-view is a fixed-height container with no scroll — flex layout already
+// puts the composer at the bottom; sticky there only creates z-index overlap.
+.landing .composer-group {
+  position: sticky;
+  bottom: 1rem;
+  z-index: 5;
+  margin-top: auto;
 }
 
 .title {
@@ -138,17 +145,9 @@ bixarena-example-prompts {
   }
 }
 
-.btm bixarena-prompt-composer {
-  max-width: 100%;
-}
-
 .disclaimer {
   text-align: center;
   font-size: var(--text-xs);
   color: var(--p-text-muted-color);
-  margin: 1.5rem 0 0;
-}
-
-.battle-view > .disclaimer {
-  margin-top: 1rem;
+  margin: 1rem 0 0;
 }

--- a/libs/bixarena/battle/src/lib/battle.component.scss
+++ b/libs/bixarena/battle/src/lib/battle.component.scss
@@ -33,9 +33,7 @@ bixarena-example-prompts {
   align-self: center;
 }
 
-// Landing has page-level scroll, so pin the composer to the viewport bottom.
-// Battle-view is a fixed-height container with no scroll — flex layout already
-// puts the composer at the bottom; sticky there only creates z-index overlap.
+// Pin composer to viewport bottom on landing's page-level scroll.
 .landing .composer-group {
   position: sticky;
   bottom: 1rem;
@@ -141,10 +139,6 @@ bixarena-example-prompts {
   gap: 0.75rem;
   flex: 1;
   min-height: 0;
-
-  @media (width < #{shared.$md-breakpoint}) {
-    grid-template-columns: 1fr;
-  }
 }
 
 .disclaimer {
@@ -152,4 +146,40 @@ bixarena-example-prompts {
   font-size: var(--text-xs);
   color: var(--p-text-muted-color);
   margin: 1rem 0 0;
+}
+
+// Mobile: page-level scroll, sticky composer/rail, stacked panels.
+@media (width < #{shared.$md-breakpoint}) {
+  .landing .composer-group {
+    position: static;
+    margin-top: auto;
+  }
+
+  .battle-view {
+    height: auto;
+    min-height: calc(100dvh - var(--nav-height));
+    overflow: visible;
+    padding-bottom: 0;
+  }
+
+  .battle-view .rail {
+    position: sticky;
+    top: var(--nav-height);
+    z-index: 4;
+    background: var(--p-surface-0);
+  }
+
+  .battle-view .composer-group {
+    position: sticky;
+    bottom: 0;
+    z-index: 5;
+    padding: 0.5rem var(--content-padding-x) calc(0.5rem + env(safe-area-inset-bottom));
+    background: linear-gradient(to top, var(--p-surface-0) 70%, transparent);
+  }
+
+  .panels {
+    display: flex;
+    flex-direction: column;
+    flex: none;
+  }
 }

--- a/libs/bixarena/battle/src/lib/battle.component.scss
+++ b/libs/bixarena/battle/src/lib/battle.component.scss
@@ -66,8 +66,10 @@ bixarena-example-prompts {
   line-height: 1.55;
 }
 
-// Fixed height so panels scroll internally instead of growing infinitely
+// Fixed height so panels scroll internally instead of growing infinitely.
 .battle-view {
+  position: relative;
+  isolation: isolate;
   height: calc(100dvh - var(--nav-height));
   display: flex;
   flex-direction: column;

--- a/libs/bixarena/battle/src/lib/battle.component.scss
+++ b/libs/bixarena/battle/src/lib/battle.component.scss
@@ -79,9 +79,10 @@ bixarena-example-prompts {
 
 .rail {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
+  gap: 0.25rem 0.5rem;
   padding: 0.625rem 0;
   flex-shrink: 0;
 }
@@ -116,6 +117,10 @@ bixarena-example-prompts {
   margin-left: 0.375rem;
 
   &.complete {
+    flex-basis: 100%;
+    margin-left: 0;
+    text-align: center;
+    line-height: 1.4;
     color: var(--p-primary-color);
     font-weight: 520;
   }

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -1,4 +1,5 @@
 import { Component, inject, OnDestroy, OnInit, signal } from '@angular/core';
+import { TooltipModule } from 'primeng/tooltip';
 import { BattleEvaluationOutcome } from '@sagebionetworks/bixarena/api-client';
 import { BattleGateService } from '@sagebionetworks/bixarena/services';
 import {
@@ -22,6 +23,7 @@ import { ExamplePromptsComponent } from './example-prompts/example-prompts.compo
     ExamplePromptsComponent,
     OnboardingModalComponent,
     BlueprintBgComponent,
+    TooltipModule,
   ],
   providers: [BattleStateService, BattleStreamService],
   templateUrl: './battle.component.html',

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -1,7 +1,11 @@
 import { Component, inject, OnDestroy, OnInit, signal } from '@angular/core';
 import { BattleEvaluationOutcome } from '@sagebionetworks/bixarena/api-client';
 import { BattleGateService } from '@sagebionetworks/bixarena/services';
-import { OnboardingModalComponent, PromptComposerComponent } from '@sagebionetworks/bixarena/ui';
+import {
+  BlueprintBgComponent,
+  OnboardingModalComponent,
+  PromptComposerComponent,
+} from '@sagebionetworks/bixarena/ui';
 import { ConfigService } from '@sagebionetworks/bixarena/config';
 import { BattleStateService } from './services/battle.service';
 import { BattleStreamService } from './services/battle-stream.service';
@@ -17,6 +21,7 @@ import { ExamplePromptsComponent } from './example-prompts/example-prompts.compo
     VotingBarComponent,
     ExamplePromptsComponent,
     OnboardingModalComponent,
+    BlueprintBgComponent,
   ],
   providers: [BattleStateService, BattleStreamService],
   templateUrl: './battle.component.html',

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -4,6 +4,7 @@ import { BattleEvaluationOutcome } from '@sagebionetworks/bixarena/api-client';
 import { BattleGateService } from '@sagebionetworks/bixarena/services';
 import {
   BlueprintBgComponent,
+  HeroComponent,
   OnboardingModalComponent,
   PromptComposerComponent,
 } from '@sagebionetworks/bixarena/ui';
@@ -23,6 +24,7 @@ import { ExamplePromptsComponent } from './example-prompts/example-prompts.compo
     ExamplePromptsComponent,
     OnboardingModalComponent,
     BlueprintBgComponent,
+    HeroComponent,
     TooltipModule,
   ],
   providers: [BattleStateService, BattleStreamService],

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
@@ -65,7 +65,7 @@
 .stage {
   position: relative;
   width: 100%;
-  padding: 2.8rem 0;
+  padding: 2rem 0;
 }
 
 .helix-bg {
@@ -112,6 +112,8 @@
   z-index: 1;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
+  align-content: center;
+  min-height: 14rem;
   gap: 0.75rem;
 
   &.swap-out {

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
@@ -157,7 +157,7 @@
   }
 }
 
-@media (width <= #{shared.$lg-breakpoint}) {
+@media (width < #{shared.$md-breakpoint}) {
   .prompt-cards {
     grid-template-columns: 1fr;
     max-width: 40rem;

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
@@ -50,13 +50,14 @@
   }
 
   &:hover:not(:disabled) {
-    color: var(--p-teal-400);
-    border-color: rgb(from var(--p-teal-400) r g b / 45%);
-    background: rgb(from var(--p-teal-400) r g b / 6%);
+    background: var(--p-surface-200);
+    border-color: var(--p-surface-300);
+    color: var(--p-text-color);
+    transform: translateY(-1px);
 
     .unwind-icon {
       transform: rotate(180deg);
-      color: var(--p-teal-400);
+      color: var(--p-text-color);
     }
   }
 }

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
@@ -169,7 +169,7 @@
   }
 
   .stage {
-    padding: 0;
+    padding: 1.25rem 0 0;
   }
 }
 

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.html
@@ -30,6 +30,29 @@
         <div class="content">
           <markdown [data]="msg.content" />
         </div>
+        <div class="action-line action-line--left">
+          <button
+            type="button"
+            class="copy-btn"
+            [pTooltip]="copiedIndex() === $index ? 'Copied!' : 'Copy'"
+            tooltipPosition="top"
+            aria-label="Copy response"
+            (click)="copy(msg.content, $index)"
+          >
+            <svg
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <rect x="5" y="5" width="9" height="9" rx="1.5" />
+              <path d="M11 5V3a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h2" />
+            </svg>
+          </button>
+        </div>
       }
     }
     <div

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
@@ -10,7 +10,8 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  background: var(--p-surface-100);
+  background: color-mix(in srgb, var(--p-surface-100) 70%, transparent);
+  backdrop-filter: blur(4px);
   height: 100%;
   max-height: 100%;
   transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
@@ -1,3 +1,5 @@
+@use 'shared/typescript/styles/src/shared-styles/variables' as shared;
+
 :host {
   display: block;
   min-width: 0;
@@ -285,11 +287,7 @@
   }
 }
 
-// Mobile: page-level scroll moves between rounds/panels, but each panel still
-// caps its own height so a long response doesn't dominate the page and the
-// next panel stays reachable. overscroll-behavior keeps inner scroll from
-// chaining into page scroll on touch.
-@media (width < 768px) {
+@media (width < #{shared.$md-breakpoint}) {
   .panel {
     height: auto;
     max-height: 38dvh;

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
@@ -39,6 +39,39 @@
   flex-shrink: 0;
 }
 
+.copy-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--p-text-muted-color);
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  &:disabled {
+    opacity: 0;
+    cursor: default;
+    pointer-events: none;
+  }
+
+  &:hover:not(:disabled) {
+    background: var(--p-surface-200);
+    color: var(--p-text-color);
+  }
+}
+
 .header-label {
   display: inline-flex;
   align-items: center;
@@ -196,6 +229,10 @@
   justify-content: flex-end;
   clear: both;
   margin-top: 0.5rem;
+
+  &--left {
+    justify-content: flex-start;
+  }
 }
 
 .action-btn {

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
@@ -17,7 +17,7 @@
   transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 
   &.selected {
-    border-color: var(--p-primary-color);
+    border-color: var(--p-surface-400);
   }
 
   &.unselected {
@@ -111,7 +111,7 @@
   min-height: 0;
   padding: 1rem 1.125rem;
   overflow-y: auto;
-  font-size: var(--text-md);
+  font-size: var(--panel-body-font-size, var(--text-md));
   line-height: 1.7;
   scroll-behavior: smooth;
   color: var(--p-surface-700);
@@ -282,5 +282,20 @@
 
   50% {
     opacity: 0.3;
+  }
+}
+
+// Mobile: page-level scroll moves between rounds/panels, but each panel still
+// caps its own height so a long response doesn't dominate the page and the
+// next panel stays reachable. overscroll-behavior keeps inner scroll from
+// chaining into page scroll on touch.
+@media (width < 768px) {
+  .panel {
+    height: auto;
+    max-height: 38dvh;
+  }
+
+  .body {
+    overscroll-behavior: contain;
   }
 }

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
@@ -7,22 +7,26 @@ import {
   input,
   output,
   PLATFORM_ID,
+  signal,
   viewChild,
 } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
+import { Clipboard } from '@angular/cdk/clipboard';
 import { MarkdownComponent } from 'ngx-markdown';
+import { TooltipModule } from 'primeng/tooltip';
 import { BattleEvaluationOutcome } from '@sagebionetworks/bixarena/api-client';
 import { ModelStreamState } from '../battle.types';
 import { CONTINUE_PROMPT, STREAM_CURSOR } from '../battle.constants';
 
 @Component({
   selector: 'bixarena-model-panel',
-  imports: [MarkdownComponent],
+  imports: [MarkdownComponent, TooltipModule],
   templateUrl: './model-panel.component.html',
   styleUrl: './model-panel.component.scss',
 })
 export class ModelPanelComponent {
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+  private readonly clipboard = inject(Clipboard);
 
   readonly modelId = input.required<'model1' | 'model2'>();
   readonly anonymousName = computed(() => (this.modelId() === 'model1' ? 'Model A' : 'Model B'));
@@ -34,6 +38,15 @@ export class ModelPanelComponent {
   readonly continue = output<void>();
 
   protected readonly continuePrompt = CONTINUE_PROMPT;
+
+  readonly copiedIndex = signal<number | null>(null);
+
+  copy(content: string, index: number): void {
+    if (!content) return;
+    this.clipboard.copy(content);
+    this.copiedIndex.set(index);
+    setTimeout(() => this.copiedIndex.set(null), 2000);
+  }
 
   readonly isSelected = computed(() => {
     const o = this.selectedOutcome();

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.ts
@@ -99,7 +99,8 @@ export class ModelPanelComponent {
 
   private scrollToBottom(): void {
     const el = this.bodyEl()?.nativeElement;
-    if (el) {
+    // Skip when content fits
+    if (el && el.scrollHeight > el.clientHeight) {
       // Flag prevents onScroll from treating our scrollTo as a user-initiated scroll
       this.isAutoScroll = true;
       el.scrollTop = el.scrollHeight;

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
@@ -23,7 +23,8 @@
           <path d="m8 16-4 4" />
           <path d="M9.5 17.5 21 6V3h-3L6.5 14.5" />
         </svg>
-        A is Better
+        <span class="vb-label">A is Better</span>
+        <span class="vb-label-short">A</span>
       </button>
       <button
         class="vb tie"
@@ -56,7 +57,8 @@
         (mouseleave)="hoverSide.emit(null)"
         aria-label="Vote Model B as better"
       >
-        B is Better
+        <span class="vb-label">B is Better</span>
+        <span class="vb-label-short">B</span>
         <svg
           class="vb-icon"
           viewBox="0 0 24 24"
@@ -94,7 +96,7 @@
   @if (phase() === 'reveal' || phase() === 'error') {
     <div class="nudge">
       @if (canReuse()) {
-        <p-button label="Same Question New Matchup" (onClick)="samePrompt.emit()" />
+        <p-button label="New Matchup" (onClick)="samePrompt.emit()" />
       }
       <p-button label="New Battle" severity="secondary" (onClick)="newBattle.emit()" />
     </div>

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
@@ -1,3 +1,5 @@
+@use 'shared/typescript/styles/src/shared-styles/variables' as shared;
+
 :host {
   display: block;
   flex-shrink: 0;
@@ -133,9 +135,7 @@
   }
 }
 
-// Mobile: shrink A/B labels to single letters so all three buttons fit one row.
-// Tie keeps its full label. min-height enforces a 44px tap target.
-@media (width < 768px) {
+@media (width < #{shared.$md-breakpoint}) {
   .vb {
     min-height: 2.75rem;
   }
@@ -147,5 +147,17 @@
   .vb.left .vb-label-short,
   .vb.right .vb-label-short {
     display: inline;
+  }
+
+  .validation-row {
+    flex-wrap: wrap;
+    justify-content: center;
+    row-gap: 0.5rem;
+  }
+
+  .validation-track {
+    flex-basis: 100%;
+    width: 100%;
+    max-width: 12rem;
   }
 }

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
@@ -59,6 +59,10 @@
   }
 }
 
+.vb-label-short {
+  display: none;
+}
+
 .nudge {
   display: flex;
   gap: 0.5rem;
@@ -126,5 +130,22 @@
   .validation-fill {
     animation: none;
     width: 100%;
+  }
+}
+
+// Mobile: shrink A/B labels to single letters so all three buttons fit one row.
+// Tie keeps its full label. min-height enforces a 44px tap target.
+@media (width < 768px) {
+  .vb {
+    min-height: 2.75rem;
+  }
+
+  .vb-label {
+    display: none;
+  }
+
+  .vb.left .vb-label-short,
+  .vb.right .vb-label-short {
+    display: inline;
   }
 }

--- a/libs/bixarena/home/src/lib/composer-section/composer-section.component.scss
+++ b/libs/bixarena/home/src/lib/composer-section/composer-section.component.scss
@@ -3,6 +3,8 @@
 }
 
 .composer-section {
+  --composer-input-min-height: 6rem;
+
   display: flex;
   justify-content: center;
   padding: 0 var(--content-padding-x);

--- a/libs/bixarena/home/src/lib/home.component.html
+++ b/libs/bixarena/home/src/lib/home.component.html
@@ -1,13 +1,10 @@
 <div class="page-content">
   <div class="landing-wrapper">
     <bixarena-blueprint-bg />
-    <header class="hero">
-      <h1 class="title">Your vote shapes the future of<br /><em>biomedical</em> AI</h1>
-      <p class="subtitle">
-        Every perspective matters — clinical expertise, research experience, and lived health
-        experience alike. Vote on which AI does better. Help us find out.
-      </p>
-    </header>
+    <bixarena-hero
+      titleHtml="Your vote shapes the future of<br><em>biomedical</em> AI"
+      subtitleHtml="Every perspective matters — clinical expertise, research experience, and lived health experience alike. Vote on which AI does better. Help us find out."
+    />
     <bixarena-composer-section />
     <bixarena-stats-section />
   </div>

--- a/libs/bixarena/home/src/lib/home.component.html
+++ b/libs/bixarena/home/src/lib/home.component.html
@@ -1,5 +1,6 @@
 <div class="page-content">
   <div class="landing-wrapper">
+    <bixarena-blueprint-bg />
     <header class="hero">
       <h1 class="title">Your vote shapes the future of<br /><em>biomedical</em> AI</h1>
       <p class="subtitle">

--- a/libs/bixarena/home/src/lib/home.component.scss
+++ b/libs/bixarena/home/src/lib/home.component.scss
@@ -24,36 +24,3 @@
   opacity: 0.35;
   mask-image: linear-gradient(to bottom, #000 70%, transparent 100%);
 }
-
-.hero {
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1.5rem;
-}
-
-.title {
-  font-family: var(--font-serif);
-  font-size: var(--hero-title-font-size);
-  font-weight: 400;
-  letter-spacing: -0.02em;
-  line-height: var(--hero-title-line-height);
-  text-wrap: balance;
-  margin: 0;
-  color: var(--p-text-color);
-
-  em {
-    font-style: italic;
-    color: var(--p-primary-color);
-  }
-}
-
-.subtitle {
-  font-size: var(--hero-subtitle-font-size);
-  color: var(--p-text-muted-color);
-  max-width: var(--hero-subtitle-max-width);
-  text-wrap: pretty;
-  margin: 0;
-  line-height: 1.55;
-}

--- a/libs/bixarena/home/src/lib/home.component.scss
+++ b/libs/bixarena/home/src/lib/home.component.scss
@@ -10,10 +10,19 @@
 }
 
 .landing-wrapper {
+  position: relative;
+  isolation: isolate;
   display: flex;
   flex-direction: column;
   gap: 3rem;
   padding: 6rem 0 3rem;
+}
+
+.landing-wrapper bixarena-blueprint-bg {
+  bottom: auto;
+  height: 70%;
+  opacity: 0.35;
+  mask-image: linear-gradient(to bottom, #000 70%, transparent 100%);
 }
 
 .hero {

--- a/libs/bixarena/home/src/lib/home.component.spec.ts
+++ b/libs/bixarena/home/src/lib/home.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { AuthService, BattleGateService } from '@sagebionetworks/bixarena/services';
+import { HeroComponent } from '@sagebionetworks/bixarena/ui';
 import { HomeComponent } from './home.component';
 
 describe('HomeComponent', () => {
@@ -9,7 +10,8 @@ describe('HomeComponent', () => {
 
   beforeEach(async () => {
     // Strip section imports so they don't mount real services (each child
-    // fires HTTP at construction). This spec only asserts layout shell.
+    // fires HTTP at construction). Keep HeroComponent so the hero markup
+    // actually renders for the title assertion.
     await TestBed.configureTestingModule({
       imports: [HomeComponent],
       providers: [
@@ -22,7 +24,7 @@ describe('HomeComponent', () => {
       ],
     })
       .overrideComponent(HomeComponent, {
-        set: { imports: [], schemas: [NO_ERRORS_SCHEMA] },
+        set: { imports: [HeroComponent], schemas: [NO_ERRORS_SCHEMA] },
       })
       .compileComponents();
     fixture = TestBed.createComponent(HomeComponent);

--- a/libs/bixarena/home/src/lib/home.component.ts
+++ b/libs/bixarena/home/src/lib/home.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, inject, OnInit, PLATFORM_ID } from 
 import { isPlatformBrowser } from '@angular/common';
 import { Router } from '@angular/router';
 import { AuthService, BattleGateService } from '@sagebionetworks/bixarena/services';
+import { BlueprintBgComponent } from '@sagebionetworks/bixarena/ui';
 import { ComposerSectionComponent } from './composer-section/composer-section.component';
 import { LeaderboardSectionComponent } from './leaderboard-section/leaderboard-section.component';
 import { StatsSectionComponent } from './stats-section/stats-section.component';
@@ -10,6 +11,7 @@ import { TrendingSectionComponent } from './trending-section/trending-section.co
 @Component({
   selector: 'bixarena-home',
   imports: [
+    BlueprintBgComponent,
     ComposerSectionComponent,
     StatsSectionComponent,
     TrendingSectionComponent,

--- a/libs/bixarena/home/src/lib/home.component.ts
+++ b/libs/bixarena/home/src/lib/home.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, inject, OnInit, PLATFORM_ID } from 
 import { isPlatformBrowser } from '@angular/common';
 import { Router } from '@angular/router';
 import { AuthService, BattleGateService } from '@sagebionetworks/bixarena/services';
-import { BlueprintBgComponent } from '@sagebionetworks/bixarena/ui';
+import { BlueprintBgComponent, HeroComponent } from '@sagebionetworks/bixarena/ui';
 import { ComposerSectionComponent } from './composer-section/composer-section.component';
 import { LeaderboardSectionComponent } from './leaderboard-section/leaderboard-section.component';
 import { StatsSectionComponent } from './stats-section/stats-section.component';
@@ -12,6 +12,7 @@ import { TrendingSectionComponent } from './trending-section/trending-section.co
   selector: 'bixarena-home',
   imports: [
     BlueprintBgComponent,
+    HeroComponent,
     ComposerSectionComponent,
     StatsSectionComponent,
     TrendingSectionComponent,

--- a/libs/bixarena/home/src/lib/leaderboard-section/leaderboard-section.component.scss
+++ b/libs/bixarena/home/src/lib/leaderboard-section/leaderboard-section.component.scss
@@ -72,6 +72,7 @@
   border: 1px solid var(--p-surface-200);
   border-radius: var(--p-border-radius-xl);
   overflow: hidden;
+  container-type: inline-size;
 }
 
 .col-head {
@@ -143,6 +144,8 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  word-break: break-word;
+  line-height: 1.3;
 }
 
 .row:first-of-type .row-name {
@@ -185,15 +188,30 @@
   display: none;
 }
 
-@media (width <= #{shared.$lg-breakpoint}) {
+@container (max-inline-size: 300px) {
+  .col-head {
+    padding: 0.75rem 0.875rem;
+  }
+
+  .row {
+    padding: 0.625rem 0.875rem;
+    gap: 0.375rem;
+  }
+
+  .row-name {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+  }
+}
+
+@media (width < #{shared.$md-breakpoint}) {
   .grid {
     grid-template-columns: 1fr;
     max-width: 40rem;
     margin: 0 auto;
   }
-}
 
-@media (width < #{shared.$md-breakpoint}) {
   .header {
     flex-direction: column;
     align-items: flex-start;

--- a/libs/bixarena/home/src/lib/trending-section/trending-section.component.scss
+++ b/libs/bixarena/home/src/lib/trending-section/trending-section.component.scss
@@ -75,15 +75,13 @@
   display: none;
 }
 
-@media (width <= #{shared.$lg-breakpoint}) {
+@media (width < #{shared.$md-breakpoint}) {
   .grid {
     grid-template-columns: 1fr;
     max-width: 40rem;
     margin: 0 auto;
   }
-}
 
-@media (width < #{shared.$md-breakpoint}) {
   .header {
     flex-direction: column;
     align-items: flex-start;

--- a/libs/bixarena/styles/src/lib/_layout.scss
+++ b/libs/bixarena/styles/src/lib/_layout.scss
@@ -15,6 +15,7 @@
   --hero-subtitle-max-width: 36rem;
   --composer-max-width: 48rem;
   --composer-input-min-height: 3.5rem;
+  --panel-body-font-size: var(--text-md);
 }
 
 // Tablet portrait and below (< lg)
@@ -26,6 +27,7 @@
     --section-gap: 3.5rem;
     --hero-title-font-size: 2.25rem;
     --composer-max-width: 36.25rem;
+    --panel-body-font-size: var(--text-sm);
   }
 }
 

--- a/libs/bixarena/styles/src/lib/_layout.scss
+++ b/libs/bixarena/styles/src/lib/_layout.scss
@@ -14,7 +14,7 @@
   --hero-subtitle-font-size: 1rem;
   --hero-subtitle-max-width: 36rem;
   --composer-max-width: 48rem;
-  --composer-input-min-height: 6rem;
+  --composer-input-min-height: 3.5rem;
 }
 
 // Tablet portrait and below (< lg)
@@ -40,6 +40,5 @@
     --hero-title-line-height: 1.15;
     --hero-subtitle-font-size: 0.875rem;
     --composer-max-width: 100%;
-    --composer-input-min-height: 4rem;
   }
 }

--- a/libs/bixarena/styles/src/lib/_overrides.scss
+++ b/libs/bixarena/styles/src/lib/_overrides.scss
@@ -262,8 +262,9 @@
   }
 
   .p-tooltip-text {
-    font-size: var(--text-xs);
-    padding: 0.4rem 0.6rem;
+    font-size: 0.6875rem;
+    padding: 0.3rem 0.5rem;
+    line-height: 1.4;
   }
 
   // Tighter selected-option emphasis in select dropdowns. Theme-aware bg

--- a/libs/bixarena/styles/src/lib/_variables.scss
+++ b/libs/bixarena/styles/src/lib/_variables.scss
@@ -19,6 +19,8 @@ html:not(.dark) {
   --hover-bg: rgb(0 0 0 / 4%);
   --grain-opacity: 0.06;
   --grain-blend: multiply;
+  --blueprint-stroke: #9a6f48;
+  --blueprint-opacity: 0.32;
 }
 
 html.dark {
@@ -26,4 +28,6 @@ html.dark {
   --hover-bg: rgb(253 252 251 / 4%);
   --grain-opacity: 0.15;
   --grain-blend: normal;
+  --blueprint-stroke: #e8c8a0;
+  --blueprint-opacity: 0.28;
 }

--- a/libs/bixarena/ui/src/index.ts
+++ b/libs/bixarena/ui/src/index.ts
@@ -1,6 +1,7 @@
 export * from './lib/avatar/avatar.component';
 export * from './lib/blueprint-bg/blueprint-bg.component';
 export * from './lib/footer/footer.component';
+export * from './lib/hero/hero.component';
 export * from './lib/login-modal/login-modal.component';
 export * from './lib/modal-dialog/modal-dialog.component';
 export * from './lib/nav/nav.component';

--- a/libs/bixarena/ui/src/index.ts
+++ b/libs/bixarena/ui/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/avatar/avatar.component';
+export * from './lib/blueprint-bg/blueprint-bg.component';
 export * from './lib/footer/footer.component';
 export * from './lib/login-modal/login-modal.component';
 export * from './lib/modal-dialog/modal-dialog.component';

--- a/libs/bixarena/ui/src/lib/blueprint-bg/blueprint-bg.component.html
+++ b/libs/bixarena/ui/src/lib/blueprint-bg/blueprint-bg.component.html
@@ -1,0 +1,82 @@
+<svg class="bp" viewBox="0 0 1200 700" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+  <defs>
+    <radialGradient id="ai-fade" cx="50%" cy="50%" r="65%">
+      <stop offset="0%" stop-color="#fff" stop-opacity="1" />
+      <stop offset="60%" stop-color="#fff" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#fff" stop-opacity="0" />
+    </radialGradient>
+    <mask id="ai-mask">
+      <rect width="1200" height="700" fill="url(#ai-fade)" />
+    </mask>
+
+    <radialGradient id="ai-sand" cx="50%" cy="50%" r="35%">
+      <stop offset="0%" stop-color="#e8723b" stop-opacity="0.06" />
+      <stop offset="70%" stop-color="#d4a574" stop-opacity="0.03" />
+      <stop offset="100%" stop-color="#d4a574" stop-opacity="0" />
+    </radialGradient>
+
+    <radialGradient id="ai-tier" cx="50%" cy="50%" r="55%">
+      <stop offset="0%" stop-color="#d4a574" stop-opacity="0" />
+      <stop offset="60%" stop-color="#d4a574" stop-opacity="0.04" />
+      <stop offset="100%" stop-color="#d4a574" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+
+  <g [attr.transform]="transform()">
+    <ellipse cx="600" cy="350" rx="280" ry="140" fill="url(#ai-sand)" />
+    <ellipse cx="600" cy="350" rx="700" ry="360" fill="url(#ai-tier)" />
+
+    <g mask="url(#ai-mask)" stroke="currentColor" fill="none">
+      <g opacity="0.5" stroke-width="1">
+        <ellipse cx="600" cy="350" rx="700" ry="360" />
+        <ellipse cx="600" cy="350" rx="660" ry="338" />
+      </g>
+
+      <g opacity="0.7" fill="currentColor" stroke="none">
+        @for (d of vomitoriums; track $index) {
+          <circle [attr.cx]="d.x" [attr.cy]="d.y" r="2.5" />
+        }
+      </g>
+
+      <g opacity="0.3" stroke-width="1">
+        <ellipse cx="600" cy="350" rx="560" ry="290" />
+        <ellipse cx="600" cy="350" rx="520" ry="270" />
+      </g>
+
+      <g opacity="0.32" stroke-width="1">
+        <ellipse cx="600" cy="350" rx="420" ry="220" />
+        <ellipse cx="600" cy="350" rx="380" ry="200" />
+      </g>
+
+      <g opacity="0.36" stroke-width="0.7">
+        @for (l of radials; track $index) {
+          <line [attr.x1]="l.x1" [attr.y1]="l.y1" [attr.x2]="l.x2" [attr.y2]="l.y2" />
+        }
+      </g>
+
+      <g opacity="0.75" fill="currentColor" stroke="none">
+        @for (s of seats; track $index) {
+          <circle [attr.cx]="s.x" [attr.cy]="s.y" [attr.r]="s.r" [attr.opacity]="s.o" />
+        }
+      </g>
+
+      <g opacity="0.35" stroke-width="0.9">
+        <ellipse cx="600" cy="350" rx="280" ry="140" />
+        <ellipse cx="600" cy="350" rx="240" ry="120" stroke-dasharray="2 5" opacity="0.7" />
+        <ellipse cx="600" cy="350" rx="195" ry="98" stroke-dasharray="1 4" opacity="0.5" />
+      </g>
+
+      <g opacity="0.4" stroke-width="0.7" stroke-dasharray="3 8">
+        <line x1="305" y1="350" x2="895" y2="350" />
+        <line x1="600" y1="200" x2="600" y2="500" />
+      </g>
+
+      <g fill="currentColor" stroke="none" opacity="0.85">
+        <circle cx="600" cy="210" r="2" />
+        <circle cx="600" cy="490" r="2" />
+        <circle cx="320" cy="350" r="2" />
+        <circle cx="880" cy="350" r="2" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/libs/bixarena/ui/src/lib/blueprint-bg/blueprint-bg.component.scss
+++ b/libs/bixarena/ui/src/lib/blueprint-bg/blueprint-bg.component.scss
@@ -1,0 +1,16 @@
+:host {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  overflow: hidden;
+
+  // The improved arena SVG has per-group opacities pre-tuned by the designer,
+  // so we rely on currentColor here and skip the host-level opacity multiplier.
+  color: var(--blueprint-stroke);
+}
+
+.bp {
+  width: 100%;
+  height: 100%;
+}

--- a/libs/bixarena/ui/src/lib/blueprint-bg/blueprint-bg.component.ts
+++ b/libs/bixarena/ui/src/lib/blueprint-bg/blueprint-bg.component.ts
@@ -1,0 +1,105 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+
+interface Dot {
+  x: number;
+  y: number;
+}
+
+interface Line {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+interface Seat {
+  x: number;
+  y: number;
+  r: number;
+  o: number;
+}
+
+const CX = 600;
+const CY = 350;
+
+function buildVomitoriums(): Dot[] {
+  const out: Dot[] = [];
+  for (let i = 0; i < 36; i++) {
+    const a = (i / 36) * Math.PI * 2;
+    out.push({ x: CX + Math.cos(a) * 680, y: CY + Math.sin(a) * 349 });
+  }
+  return out;
+}
+
+function buildRadials(): Line[] {
+  const out: Line[] = [];
+  for (let i = 0; i < 48; i++) {
+    const a = (i / 48) * Math.PI * 2;
+    out.push({
+      x1: CX + Math.cos(a) * 380,
+      y1: CY + Math.sin(a) * 200,
+      x2: CX + Math.cos(a) * 700,
+      y2: CY + Math.sin(a) * 360,
+    });
+  }
+  return out;
+}
+
+function buildSeats(): Seat[] {
+  const out: Seat[] = [];
+  for (let i = 0; i < 240; i++) {
+    const a = (i / 240) * Math.PI * 2 + (i % 3) * 0.018;
+    const ringT = (i % 4) / 4;
+    const r = 410 + ringT * 270;
+    const ry = 215 + ringT * 145;
+    out.push({
+      x: CX + Math.cos(a) * r,
+      y: CY + Math.sin(a) * ry,
+      r: 0.6 + ((i * 7) % 10) / 18,
+      o: 0.2 + ((i * 13) % 9) / 18,
+    });
+  }
+  return out;
+}
+
+/**
+ * Decorative amphitheatre-floorplan backdrop. Drop inside a wrapper that uses
+ * `position: relative` (anchors the absolute host) and `isolation: isolate`
+ * (creates a stacking context so the host's z-index: -1 sits cleanly behind
+ * siblings, no explicit z-index needed on each foreground element).
+ *
+ * Usage:
+ *   .wrapper { position: relative; isolation: isolate; }
+ *
+ *   <div class="wrapper">
+ *     <bixarena-blueprint-bg />
+ *     <!-- foreground content paints above in DOM order -->
+ *   </div>
+ *
+ * Inputs:
+ *   - `scale` — geometry size relative to the SVG viewBox. Default 0.85.
+ *
+ * CSS hooks (set on a `bixarena-blueprint-bg` selector in the parent):
+ *   - `opacity` — overall dimming.
+ *   - `mask-image` — gradient masks for edge fades.
+ *   - `height` / `inset` / `bottom` — restrict vertical coverage.
+ *   - `--blueprint-stroke` — stroke/fill color (theme-aware via tokens).
+ */
+@Component({
+  selector: 'bixarena-blueprint-bg',
+  imports: [],
+  templateUrl: './blueprint-bg.component.html',
+  styleUrl: './blueprint-bg.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BlueprintBgComponent {
+  readonly scale = input(0.85);
+
+  readonly vomitoriums = buildVomitoriums();
+  readonly radials = buildRadials();
+  readonly seats = buildSeats();
+
+  readonly transform = computed(
+    () => `translate(${CX} ${CY}) scale(${this.scale()}) translate(${-CX} ${-CY})`,
+  );
+}

--- a/libs/bixarena/ui/src/lib/hero/hero.component.html
+++ b/libs/bixarena/ui/src/lib/hero/hero.component.html
@@ -1,0 +1,4 @@
+<header class="hero">
+  <h1 class="title" [innerHTML]="titleHtml()"></h1>
+  <p class="subtitle" [innerHTML]="subtitleHtml()"></p>
+</header>

--- a/libs/bixarena/ui/src/lib/hero/hero.component.scss
+++ b/libs/bixarena/ui/src/lib/hero/hero.component.scss
@@ -1,0 +1,36 @@
+bixarena-hero {
+  display: block;
+
+  .hero {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+  }
+
+  .title {
+    font-family: var(--font-serif);
+    font-size: var(--hero-title-font-size);
+    font-weight: 400;
+    letter-spacing: -0.02em;
+    line-height: var(--hero-title-line-height);
+    text-wrap: balance;
+    margin: 0;
+    color: var(--p-text-color);
+
+    em {
+      font-style: italic;
+      color: var(--p-primary-color);
+    }
+  }
+
+  .subtitle {
+    font-size: var(--hero-subtitle-font-size);
+    color: var(--p-text-muted-color);
+    max-width: var(--hero-subtitle-max-width);
+    text-wrap: pretty;
+    margin: 0;
+    line-height: 1.55;
+  }
+}

--- a/libs/bixarena/ui/src/lib/hero/hero.component.ts
+++ b/libs/bixarena/ui/src/lib/hero/hero.component.ts
@@ -1,0 +1,12 @@
+import { Component, ViewEncapsulation, input } from '@angular/core';
+
+@Component({
+  selector: 'bixarena-hero',
+  templateUrl: './hero.component.html',
+  styleUrl: './hero.component.scss',
+  encapsulation: ViewEncapsulation.None,
+})
+export class HeroComponent {
+  readonly titleHtml = input.required<string>();
+  readonly subtitleHtml = input.required<string>();
+}

--- a/libs/bixarena/ui/src/lib/nav/nav.component.scss
+++ b/libs/bixarena/ui/src/lib/nav/nav.component.scss
@@ -1,11 +1,18 @@
 @use 'shared/typescript/styles/src/shared-styles/variables' as shared;
 
+:host {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
 .nav {
   display: flex;
   align-items: center;
   gap: 0;
   padding: 0 var(--content-padding-x);
   height: var(--nav-height);
+  background: var(--p-surface-0);
   color: var(--p-text-color);
   border-bottom: 1px solid var(--p-surface-200);
 }

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
@@ -1,5 +1,6 @@
 :host {
   display: block;
+  container-type: inline-size;
 }
 
 .question {
@@ -115,5 +116,28 @@
 
   .skeleton::after {
     animation: none;
+  }
+}
+
+@container (max-inline-size: 280px) {
+  .prompt-card {
+    padding: 0.875rem;
+  }
+
+  .question {
+    display: -webkit-box;
+    -webkit-line-clamp: 8;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .footer {
+    margin-top: 0.625rem;
+    padding-top: 0.625rem;
+    gap: 0.375rem;
+  }
+
+  .cta-text {
+    display: none;
   }
 }


### PR DESCRIPTION
## Description

Polish pass on the battle and home pages with focus on mobile/tablet responsiveness. The battle page gets a sticky nav, blueprint-amphitheatre backdrop, per-response copy buttons, and a unified composer/voting layout; mobile converts the fixed-height side-by-side panels into page-scrollable stacked panels with capped panel height so both responses stay reachable. Also extracts a shared `<bixarena-hero>` component used by home + battle so the title/subtitle treatment stays in sync.

## Related Issue

[SMR-778](https://sagebionetworks.jira.com/browse/SMR-778)

## Changelog

- Polish battle page with sticky nav, per-response copy button, blueprint-bg amphitheatre backdrop, and unified composer/voting layout
- Add mobile responsive layout: page-scrollable stacked panels, sticky rail/composer, capped model-panel height (38dvh) so both panels stay above the composer
- Compact voting buttons on mobile (single-letter A/Tie/B with 44px tap targets) and stack the validation status row vertically
- Refine match-progress rail: keep match counter visible at completion, append celebration row, fix centering
- Extract shared \`<bixarena-hero>\` component to \`libs/bixarena/ui\` and adopt on home + battle for consistent responsive hero scaling
- Adapt card grids for tablet widths: keep 3-column layout down to phone breakpoint with container-query-driven inner adjustments (line clamps, icon-only CTAs, wrapped leaderboard model names)
- Stabilize example-prompts height to prevent composer movement on prompt refresh

## Preview

| Phone | Tablet | Desktop |
|--------|--------|--------|
| <img width="324" height="701" alt="Screenshot 2026-05-01 at 5 13 17 PM" src="https://github.com/user-attachments/assets/5a8f1730-ff90-4c67-aa20-3a9ab9c94f80" /> | <img width="387" height="516" alt="Screenshot 2026-05-01 at 5 12 36 PM" src="https://github.com/user-attachments/assets/4fb35aa0-f3e4-40ae-9f46-25765147e24b" /> | <img width="862" height="540" alt="Screenshot 2026-05-01 at 5 13 28 PM" src="https://github.com/user-attachments/assets/ad766a04-16c4-4eb5-88e8-a649bd2c7146" /> |

For phone, if we want to be more user-friendly, we could consider using swipeable panels or cards in the future if needed.

[SMR-778]: https://sagebionetworks.jira.com/browse/SMR-778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ