### PR TITLE
feat(bixarena): refine leaderboard page and polish bar chart (SMR-779)

### DIFF
--- a/libs/bixarena/home/src/lib/leaderboard-section/leaderboard-section.component.html
+++ b/libs/bixarena/home/src/lib/leaderboard-section/leaderboard-section.component.html
@@ -20,7 +20,7 @@
               class="metric"
               pTooltip="Bradley-Terry score on an Elo scale"
               tooltipPosition="top"
-              >Elo</span
+              >Score</span
             >
           </div>
           @for (entry of col.entries; track entry.id) {

--- a/libs/bixarena/home/src/lib/stats-section/stats-section.component.scss
+++ b/libs/bixarena/home/src/lib/stats-section/stats-section.component.scss
@@ -45,18 +45,19 @@
   color: var(--p-primary-color);
 }
 
-@media (width < #{shared.$md-breakpoint}) {
+// Drop the divider + tighten gap for mobile views
+@media (width < #{shared.$lg-breakpoint}) {
   .stats {
     gap: 1.5rem;
   }
 
-  // Drop the divider on mobile: when stats wrap to multiple rows the left
-  // border on the wrapped row's first item reads as a stray vertical line.
   .stat + .stat {
     border-left: none;
     padding-left: 0;
   }
+}
 
+@media (width < #{shared.$md-breakpoint}) {
   .stat-val {
     font-size: var(--text-xl);
   }

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.scss
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.scss
@@ -1,12 +1,24 @@
 :host {
   display: block;
+
+  --bar-podium-from: var(--p-primary-300);
+  --bar-podium-to: var(--p-primary-100);
+  --bar-rest-from: var(--p-surface-300);
+  --bar-rest-to: var(--p-surface-200);
+}
+
+:host-context(.dark) {
+  --bar-podium-from: var(--p-primary-300);
+  --bar-podium-to: var(--p-primary-500);
+  --bar-rest-from: var(--p-slate-300);
+  --bar-rest-to: var(--p-slate-500);
 }
 
 // Horizontal row of bars. Centers when content fits, scrolls horizontally otherwise.
 // Top padding leaves room for the score labels that float above the tallest bar.
 .chart-row {
   display: flex;
-  gap: 1.25rem;
+  gap: 1rem;
   padding: 3rem 1rem 1.5rem;
   margin: 0;
   list-style: none;
@@ -28,7 +40,7 @@
 // from the template: --bar-final-height (target % of track) and --bar-index (for stagger).
 .bar-track {
   position: relative;
-  width: 3.5rem;
+  width: 4rem;
   height: 16rem;
 }
 

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.spec.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.spec.ts
@@ -67,14 +67,14 @@ describe('LeaderboardBarChartComponent', () => {
     expect(bars[1].heightPct).toBeLessThan(100);
   });
 
-  it('uses brand gradient for top three and silver gradient for the rest', () => {
+  it('uses podium gradient for top three and rest gradient for the others', () => {
     fixture.componentRef.setInput('entries', buildEntries(5));
     fixture.detectChanges();
     const bars = fixture.componentInstance.bars();
-    expect(bars[0].barGradient).toContain('--p-primary-300');
-    expect(bars[2].barGradient).toContain('--p-primary-500');
-    expect(bars[3].barGradient).toContain('--p-slate-300');
-    expect(bars[4].barGradient).toContain('--p-slate-500');
+    expect(bars[0].barGradient).toContain('--bar-podium-from');
+    expect(bars[2].barGradient).toContain('--bar-podium-to');
+    expect(bars[3].barGradient).toContain('--bar-rest-from');
+    expect(bars[4].barGradient).toContain('--bar-rest-to');
   });
 
   it('exposes rank, model name, and score via aria-label', () => {

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-bar-chart/leaderboard-bar-chart.component.ts
@@ -36,9 +36,10 @@ export class LeaderboardBarChartComponent {
     const MIN_HEIGHT_PCT = 32;
     const scoreRange = maxScore - minScore;
 
-    // Top 3 ranks get the warm brand gradient (podium); the rest get a neutral silver.
-    const podiumGradient = 'linear-gradient(to bottom, var(--p-primary-300), var(--p-primary-500))';
-    const silverGradient = 'linear-gradient(to bottom, var(--p-slate-300), var(--p-slate-500))';
+    // Top 3 ranks get the warm brand gradient (podium); the rest get a neutral.
+    const podiumGradient =
+      'linear-gradient(to bottom, var(--bar-podium-from), var(--bar-podium-to))';
+    const restGradient = 'linear-gradient(to bottom, var(--bar-rest-from), var(--bar-rest-to))';
     return visible.map((entry) => {
       // When all visible entries share the same score, render at full height instead of the floor.
       const heightPct =
@@ -53,7 +54,7 @@ export class LeaderboardBarChartComponent {
         modelOrganization: entry.modelOrganization ?? null,
         score: Math.round(entry.btScore),
         heightPct,
-        barGradient: entry.rank <= 3 ? podiumGradient : silverGradient,
+        barGradient: entry.rank <= 3 ? podiumGradient : restGradient,
         orgLogoUrl: this.orgLogoService.getLogoUrl(entry.modelOrganization),
         orgLogoMono: this.orgLogoService.isMonoLogo(entry.modelOrganization),
       };

--- a/libs/bixarena/leaderboard/src/lib/leaderboard.component.html
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard.component.html
@@ -1,10 +1,8 @@
 <div class="page-content">
-  <header class="hero">
-    <h1 class="title">Leader<em>board</em></h1>
-    <p class="subtitle">
-      Community-driven evaluation of AI models on biomedical topics. Every battle counts toward the
-      daily ranking.
-    </p>
+  <bixarena-hero
+    titleHtml="Leader<em>board</em>"
+    subtitleHtml="Community-driven evaluation of AI models on biomedical topics. Every battle counts toward the daily ranking."
+  >
     <div class="stats-strip">
       <div class="stat">
         <span class="stat-value">{{ facade.entryCount() | number }}</span>
@@ -21,7 +19,7 @@
         </div>
       }
     </div>
-  </header>
+  </bixarena-hero>
 
   <bixarena-leaderboard-toolbar
     [categories]="categoryOptions()"

--- a/libs/bixarena/leaderboard/src/lib/leaderboard.component.html
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard.component.html
@@ -1,7 +1,7 @@
 <div class="page-content">
   <bixarena-hero
     titleHtml="Leader<em>board</em>"
-    subtitleHtml="Community-driven evaluation of AI models on biomedical topics. Every battle counts toward the daily ranking."
+    subtitleHtml="Community-driven evaluation of AI models on biomedical topics.<br>Every battle counts toward the daily ranking."
   >
     <div class="stats-strip">
       <div class="stat">

--- a/libs/bixarena/leaderboard/src/lib/leaderboard.component.scss
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard.component.scss
@@ -2,36 +2,8 @@
   display: block;
 }
 
-.hero {
-  text-align: center;
+bixarena-hero {
   margin-bottom: 2.5rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1rem;
-}
-
-.title {
-  font-family: var(--font-serif);
-  font-size: 3rem;
-  font-weight: 400;
-  letter-spacing: -0.96px;
-  line-height: 1.08;
-  margin: 0;
-  color: var(--p-text-color);
-
-  em {
-    font-style: italic;
-    color: var(--p-primary-color);
-  }
-}
-
-.subtitle {
-  font-size: var(--text-lg);
-  color: var(--p-surface-600);
-  max-width: 37.5rem;
-  margin: 0;
-  line-height: 1.55;
 }
 
 .methodology-note {

--- a/libs/bixarena/leaderboard/src/lib/leaderboard.component.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard.component.ts
@@ -6,6 +6,7 @@ import {
   LeaderboardSort,
   SortDirection,
 } from '@sagebionetworks/bixarena/api-client';
+import { HeroComponent } from '@sagebionetworks/bixarena/ui';
 import { LeaderboardFacadeService } from './services/leaderboard.service';
 import {
   LeaderboardSortChange,
@@ -40,6 +41,7 @@ const SORT_FIELD_MAP: Record<LeaderboardSortField, LeaderboardSort> = {
     LeaderboardTableComponent,
     LeaderboardToolbarComponent,
     LeaderboardBarChartComponent,
+    HeroComponent,
     PaginatorModule,
     DatePipe,
     DecimalPipe,

--- a/libs/bixarena/ui/src/lib/hero/hero.component.html
+++ b/libs/bixarena/ui/src/lib/hero/hero.component.html
@@ -1,4 +1,5 @@
 <header class="hero">
   <h1 class="title" [innerHTML]="titleHtml()"></h1>
   <p class="subtitle" [innerHTML]="subtitleHtml()"></p>
+  <ng-content></ng-content>
 </header>


### PR DESCRIPTION
## Description

Polish pass on the leaderboard page focused on bar chart visual treatment and shared-component adoption. The bar chart now uses theme-aware CSS custom properties so light theme can show warm beige/orange tones drawn from existing design system tokens while dark theme preserves its current bright-orange feel. The page hero migrates to the shared `<bixarena-hero>` component with a new content-projection slot for the stats strip. Also includes a small fix for the home stats row wrapping at iPad mini width.

## Related Issue

[SMR-779](https://sagebionetworks.jira.com/browse/SMR-779)

## Changelog

- Adopt shared `<bixarena-hero>` component on the leaderboard page and add an `<ng-content>` slot to the hero for the projected stats strip
- Switch bar chart to theme-aware CSS custom properties: light uses `--p-primary-100/300` for podium and `--p-surface-200/300` for rest; dark keeps existing `--p-primary-300/500` and `--p-slate-300/500`
- Reverse light-theme bar gradient direction so the deeper color anchors the bottom edge, matching the dark-theme reading
- Widen bar tracks (3.5rem -> 4rem) and tighten chart row gap (1.25rem -> 1rem)
- Drop home page stats dividers and tighten gap at \`< lg\` so 5 stats fit on a single row at iPad mini portrait (768px)

## Preview

The bar colors are improved on light theme (previous used the same colors from dark theme)

<img width="1348" height="691" alt="Screenshot 2026-05-01 at 9 02 38 PM" src="https://github.com/user-attachments/assets/d0e5364b-c177-43a6-bc74-267219a3adf0" />


[SMR-779]: https://sagebionetworks.jira.com/browse/SMR-779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ