### PR TITLE
feat(bixarena): rebuild onboarding modal as autoplay carousel with inline disclaimer (SMR-776)

### DIFF
--- a/apps/bixarena/app-angular/project.json
+++ b/apps/bixarena/app-angular/project.json
@@ -59,8 +59,8 @@
             },
             {
               "type": "anyComponentStyle",
-              "maximumWarning": "4kb",
-              "maximumError": "8kb"
+              "maximumWarning": "6kb",
+              "maximumError": "12kb"
             }
           ],
           "outputHashing": "all"

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -79,9 +79,4 @@
   }
 </div>
 
-<bixarena-onboarding-modal
-  [(visible)]="gate.showOnboardingModal"
-  [termsUrl]="termsUrl"
-  (agreed)="gate.onOnboardingComplete($event)"
-  (dismissed)="gate.onOnboardingDismiss()"
-/>
+<bixarena-onboarding-modal [(visible)]="showOnboardingModal" (closed)="onOnboardingClose()" />

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -80,3 +80,5 @@
 </div>
 
 <bixarena-onboarding-modal [(visible)]="showOnboardingModal" (closed)="onOnboardingClose()" />
+
+<bixarena-onboarding-fab (openRequested)="showOnboardingModal.set(true)" />

--- a/libs/bixarena/battle/src/lib/battle.component.html
+++ b/libs/bixarena/battle/src/lib/battle.component.html
@@ -13,9 +13,6 @@
           [disabled]="state.phase() === 'creating'"
           (promptSubmit)="onPromptSubmit($event)"
         />
-        <p class="disclaimer">
-          AI may make mistakes. Do not include sensitive or personal information.
-        </p>
       </div>
     </section>
   }
@@ -77,9 +74,6 @@
           [disabled]="state.phase() !== 'voting'"
           (promptSubmit)="onFollowUpSubmit($event)"
         />
-        <p class="disclaimer">
-          AI may make mistakes. Do not include sensitive or personal information.
-        </p>
       </div>
     </section>
   }

--- a/libs/bixarena/battle/src/lib/battle.component.scss
+++ b/libs/bixarena/battle/src/lib/battle.component.scss
@@ -114,13 +114,6 @@ bixarena-example-prompts {
   min-height: 0;
 }
 
-.disclaimer {
-  text-align: center;
-  font-size: var(--text-xs);
-  color: var(--p-text-muted-color);
-  margin: 1rem 0 0;
-}
-
 @media (width < #{shared.$md-breakpoint}) {
   .battle-view {
     height: auto;

--- a/libs/bixarena/battle/src/lib/battle.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.spec.ts
@@ -1,10 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PLATFORM_ID } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { EMPTY } from 'rxjs';
 import { BattleService as BattleApiService, BASE_PATH } from '@sagebionetworks/bixarena/api-client';
 import { ConfigService } from '@sagebionetworks/bixarena/config';
-import { BattleGateService } from '@sagebionetworks/bixarena/services';
+import { BattleGateService, OnboardingService } from '@sagebionetworks/bixarena/services';
 import { BattleComponent } from './battle.component';
 
 const mockConfig = {
@@ -17,16 +18,33 @@ const mockConfig = {
 describe('BattleComponent', () => {
   let component: BattleComponent;
   let fixture: ComponentFixture<BattleComponent>;
+  let onboarding: OnboardingService;
 
   beforeEach(async () => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     globalThis.fetch = jest.fn().mockReturnValue(new Promise(() => {}));
     sessionStorage.clear();
+    localStorage.clear();
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: jest.fn().mockReturnValue({
+        matches: false,
+        media: '',
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }),
+    });
 
     await TestBed.configureTestingModule({
       imports: [BattleComponent],
       providers: [
         provideHttpClient(),
+        provideNoopAnimations(),
         { provide: PLATFORM_ID, useValue: 'browser' },
         { provide: BASE_PATH, useValue: 'http://test/api/v1' },
         { provide: ConfigService, useValue: mockConfig },
@@ -41,6 +59,9 @@ describe('BattleComponent', () => {
         },
       ],
     }).compileComponents();
+
+    onboarding = TestBed.inject(OnboardingService);
+    onboarding.markSeen();
 
     fixture = TestBed.createComponent(BattleComponent);
     component = fixture.componentInstance;
@@ -63,10 +84,9 @@ describe('BattleComponent', () => {
     expect(consumeSpy.mock.results[0].value).toBeNull();
   });
 
-  it('auto-submits a saved pending prompt on init', async () => {
+  it('auto-submits a saved pending prompt on init when onboarding has been seen', async () => {
     const gate = TestBed.inject(BattleGateService);
     gate.savePendingPrompt('hello biomedical world');
-    jest.spyOn(BattleGateService.prototype, 'checkOnboarding').mockResolvedValue(true);
 
     fixture = TestBed.createComponent(BattleComponent);
     component = fixture.componentInstance;
@@ -81,7 +101,6 @@ describe('BattleComponent', () => {
   it('forwards a pending example_prompt id when present', async () => {
     const gate = TestBed.inject(BattleGateService);
     gate.savePendingPrompt('curated question', 'ep-99');
-    jest.spyOn(BattleGateService.prototype, 'checkOnboarding').mockResolvedValue(true);
 
     fixture = TestBed.createComponent(BattleComponent);
     component = fixture.componentInstance;
@@ -91,5 +110,44 @@ describe('BattleComponent', () => {
 
     expect(submitSpy).toHaveBeenCalledWith('curated question', 'ep-99');
     expect(gate.consumePendingPrompt()).toBeNull();
+  });
+
+  it('opens onboarding modal and defers pending prompt for first-time users', async () => {
+    localStorage.clear();
+    const gate = TestBed.inject(BattleGateService);
+    gate.savePendingPrompt('deferred prompt', 'ep-1');
+
+    fixture = TestBed.createComponent(BattleComponent);
+    component = fixture.componentInstance;
+    const submitSpy = jest.spyOn(component.state, 'submitPrompt').mockResolvedValue();
+    fixture.detectChanges();
+    await Promise.resolve();
+
+    expect(component.showOnboardingModal()).toBe(true);
+    expect(submitSpy).not.toHaveBeenCalled();
+
+    component.onOnboardingClose();
+    await Promise.resolve();
+
+    expect(component.showOnboardingModal()).toBe(false);
+    expect(submitSpy).toHaveBeenCalledWith('deferred prompt', 'ep-1');
+    expect(onboarding.hasSeen()).toBe(true);
+  });
+
+  it('opens onboarding without a pending prompt for first-time users with no submission', () => {
+    localStorage.clear();
+
+    fixture = TestBed.createComponent(BattleComponent);
+    component = fixture.componentInstance;
+    const submitSpy = jest.spyOn(component.state, 'submitPrompt').mockResolvedValue();
+    fixture.detectChanges();
+
+    expect(component.showOnboardingModal()).toBe(true);
+    expect(submitSpy).not.toHaveBeenCalled();
+
+    component.onOnboardingClose();
+
+    expect(component.showOnboardingModal()).toBe(false);
+    expect(submitSpy).not.toHaveBeenCalled();
   });
 });

--- a/libs/bixarena/battle/src/lib/battle.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PLATFORM_ID } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { EMPTY } from 'rxjs';
 import { BattleService as BattleApiService, BASE_PATH } from '@sagebionetworks/bixarena/api-client';
 import { ConfigService } from '@sagebionetworks/bixarena/config';
@@ -11,7 +11,6 @@ import { BattleComponent } from './battle.component';
 const mockConfig = {
   config: {
     battle: { promptLengthLimit: 5000, roundLimit: 20, promptUseLimit: 5 },
-    links: { termsOfService: 'https://example.com/terms' },
   },
 };
 
@@ -41,10 +40,9 @@ describe('BattleComponent', () => {
     });
 
     await TestBed.configureTestingModule({
-      imports: [BattleComponent],
+      imports: [BattleComponent, NoopAnimationsModule],
       providers: [
         provideHttpClient(),
-        provideNoopAnimations(),
         { provide: PLATFORM_ID, useValue: 'browser' },
         { provide: BASE_PATH, useValue: 'http://test/api/v1' },
         { provide: ConfigService, useValue: mockConfig },

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -9,6 +9,7 @@ import {
 import {
   BlueprintBgComponent,
   HeroComponent,
+  OnboardingFabComponent,
   OnboardingModalComponent,
   PromptComposerComponent,
 } from '@sagebionetworks/bixarena/ui';
@@ -26,6 +27,7 @@ import { ExamplePromptsComponent } from './example-prompts/example-prompts.compo
     VotingBarComponent,
     ExamplePromptsComponent,
     OnboardingModalComponent,
+    OnboardingFabComponent,
     BlueprintBgComponent,
     HeroComponent,
     TooltipModule,

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -1,14 +1,17 @@
 import { Component, inject, OnDestroy, OnInit, signal } from '@angular/core';
 import { TooltipModule } from 'primeng/tooltip';
 import { BattleEvaluationOutcome } from '@sagebionetworks/bixarena/api-client';
-import { BattleGateService } from '@sagebionetworks/bixarena/services';
+import {
+  BattleGateService,
+  OnboardingService,
+  PendingPrompt,
+} from '@sagebionetworks/bixarena/services';
 import {
   BlueprintBgComponent,
   HeroComponent,
   OnboardingModalComponent,
   PromptComposerComponent,
 } from '@sagebionetworks/bixarena/ui';
-import { ConfigService } from '@sagebionetworks/bixarena/config';
 import { BattleStateService } from './services/battle.service';
 import { BattleStreamService } from './services/battle-stream.service';
 import { ModelPanelComponent } from './model-panel/model-panel.component';
@@ -34,20 +37,32 @@ import { ExamplePromptsComponent } from './example-prompts/example-prompts.compo
 export class BattleComponent implements OnInit, OnDestroy {
   readonly state = inject(BattleStateService);
   readonly gate = inject(BattleGateService);
+  private readonly onboardingService = inject(OnboardingService);
   readonly hoverSide = signal<BattleEvaluationOutcome | null>(null);
-  readonly termsUrl = inject(ConfigService).config.links.termsOfService;
+
+  readonly showOnboardingModal = signal(false);
+  // Held while the onboarding modal is open so streaming doesn't start behind
+  // the explainer. Submitted on modal close.
+  private pendingPrompt: PendingPrompt | null = null;
 
   ngOnInit(): void {
     const pending = this.gate.consumePendingPrompt();
-    if (pending) void this.gatedSubmit(pending.prompt, pending.examplePromptId);
+    const firstTime = !this.onboardingService.hasSeen();
+
+    if (firstTime) {
+      this.pendingPrompt = pending;
+      this.showOnboardingModal.set(true);
+    } else if (pending) {
+      void this.state.submitPrompt(pending.prompt, pending.examplePromptId);
+    }
   }
 
   onPromptSubmit(prompt: string): void {
-    void this.gatedSubmit(prompt);
+    void this.state.submitPrompt(prompt);
   }
 
   onExamplePromptSelect(event: { question: string; examplePromptId: string }): void {
-    void this.gatedSubmit(event.question, event.examplePromptId);
+    void this.state.submitPrompt(event.question, event.examplePromptId);
   }
 
   onFollowUpSubmit(prompt: string): void {
@@ -66,14 +81,17 @@ export class BattleComponent implements OnInit, OnDestroy {
     void this.state.newMatchup();
   }
 
-  ngOnDestroy(): void {
-    this.state.reset();
+  onOnboardingClose(): void {
+    this.onboardingService.markSeen();
+    this.showOnboardingModal.set(false);
+    const pending = this.pendingPrompt;
+    this.pendingPrompt = null;
+    if (pending) {
+      void this.state.submitPrompt(pending.prompt, pending.examplePromptId);
+    }
   }
 
-  private async gatedSubmit(prompt: string, examplePromptId?: string | null): Promise<void> {
-    const passed = await this.gate.checkOnboarding();
-    if (passed) {
-      void this.state.submitPrompt(prompt, examplePromptId);
-    }
+  ngOnDestroy(): void {
+    this.state.reset();
   }
 }

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.html
@@ -96,9 +96,15 @@
   @if (phase() === 'reveal' || phase() === 'error') {
     <div class="nudge">
       @if (canReuse()) {
-        <p-button label="New Matchup" (onClick)="samePrompt.emit()" />
+        <div class="nudge-action">
+          <p-button label="New Matchup" (onClick)="samePrompt.emit()" />
+          <span class="nudge-caption">same question, new models</span>
+        </div>
       }
-      <p-button label="New Battle" severity="secondary" (onClick)="newBattle.emit()" />
+      <div class="nudge-action">
+        <p-button label="New Battle" severity="secondary" (onClick)="newBattle.emit()" />
+        <span class="nudge-caption">brand-new question</span>
+      </div>
     </div>
   }
 </div>

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
@@ -67,9 +67,23 @@
 
 .nudge {
   display: flex;
-  gap: 0.5rem;
+  gap: 1.25rem;
   flex-wrap: wrap;
   justify-content: center;
+  align-items: flex-start;
+}
+
+.nudge-action {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.nudge-caption {
+  font-size: 0.7rem;
+  color: var(--p-text-muted-color);
+  font-style: italic;
 }
 
 .validation-row {

--- a/libs/bixarena/services/src/lib/auth.guard.spec.ts
+++ b/libs/bixarena/services/src/lib/auth.guard.spec.ts
@@ -8,7 +8,6 @@ import { ConfigService } from '@sagebionetworks/bixarena/config';
 const mockConfig = {
   config: {
     auth: { baseUrls: { csr: 'http://127.0.0.1:8111' } },
-    links: { termsOfService: '' },
   },
 };
 

--- a/libs/bixarena/services/src/lib/battle-gate.service.spec.ts
+++ b/libs/bixarena/services/src/lib/battle-gate.service.spec.ts
@@ -7,7 +7,6 @@ import { BattleGateService } from './battle-gate.service';
 const mockConfig = {
   config: {
     auth: { baseUrls: { csr: 'http://127.0.0.1:8111' } },
-    links: { termsOfService: '' },
   },
 };
 

--- a/libs/bixarena/services/src/lib/battle-gate.service.spec.ts
+++ b/libs/bixarena/services/src/lib/battle-gate.service.spec.ts
@@ -1,9 +1,8 @@
 import { TestBed } from '@angular/core/testing';
-import { PLATFORM_ID, signal } from '@angular/core';
+import { PLATFORM_ID } from '@angular/core';
 import { ConfigService } from '@sagebionetworks/bixarena/config';
 import { AuthService } from './auth.service';
 import { BattleGateService } from './battle-gate.service';
-import { OnboardingService } from './onboarding.service';
 
 const mockConfig = {
   config: {
@@ -15,74 +14,20 @@ const mockConfig = {
 describe('BattleGateService', () => {
   let service: BattleGateService;
   let authService: AuthService;
-  const hasCompleted = signal(false);
-  const mockOnboardingService = {
-    hasCompleted,
-    markComplete: jest.fn(),
-  };
 
   beforeEach(() => {
-    hasCompleted.set(false);
-    mockOnboardingService.markComplete.mockReset();
     sessionStorage.clear();
 
     TestBed.configureTestingModule({
       providers: [
         BattleGateService,
         AuthService,
-        { provide: OnboardingService, useValue: mockOnboardingService },
         { provide: PLATFORM_ID, useValue: 'browser' },
         { provide: ConfigService, useValue: mockConfig },
       ],
     });
     service = TestBed.inject(BattleGateService);
     authService = TestBed.inject(AuthService);
-  });
-
-  describe('checkOnboarding()', () => {
-    it('resolves true immediately when onboarding is already completed', async () => {
-      hasCompleted.set(true);
-      expect(await service.checkOnboarding()).toBe(true);
-    });
-
-    it('shows onboarding modal when not completed', () => {
-      void service.checkOnboarding();
-      expect(service.showOnboardingModal()).toBe(true);
-    });
-
-    it('resolves true when completed via onOnboardingComplete', async () => {
-      const promise = service.checkOnboarding();
-      service.onOnboardingComplete(false);
-      expect(await promise).toBe(true);
-    });
-
-    it('resolves false when dismissed via onOnboardingDismiss', async () => {
-      const promise = service.checkOnboarding();
-      service.onOnboardingDismiss();
-      expect(await promise).toBe(false);
-    });
-  });
-
-  describe('onOnboardingComplete()', () => {
-    it('hides onboarding modal', () => {
-      void service.checkOnboarding();
-      service.onOnboardingComplete(false);
-      expect(service.showOnboardingModal()).toBe(false);
-    });
-
-    it('calls markComplete with dontShowAgain flag', () => {
-      void service.checkOnboarding();
-      service.onOnboardingComplete(true);
-      expect(mockOnboardingService.markComplete).toHaveBeenCalledWith(true);
-    });
-  });
-
-  describe('onOnboardingDismiss()', () => {
-    it('hides onboarding modal', () => {
-      void service.checkOnboarding();
-      service.onOnboardingDismiss();
-      expect(service.showOnboardingModal()).toBe(false);
-    });
   });
 
   describe('onLoginComplete()', () => {

--- a/libs/bixarena/services/src/lib/battle-gate.service.ts
+++ b/libs/bixarena/services/src/lib/battle-gate.service.ts
@@ -1,7 +1,6 @@
 import { inject, Injectable, PLATFORM_ID, signal } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { AuthService } from './auth.service';
-import { OnboardingService } from './onboarding.service';
 
 const PENDING_PROMPT_KEY = 'bixarena.pendingPrompt';
 const PENDING_EXAMPLE_PROMPT_ID_KEY = 'bixarena.pendingExamplePromptId';
@@ -9,6 +8,11 @@ const PENDING_PROMPT_TS_KEY = 'bixarena.pendingPromptTs';
 const PENDING_PROMPT_OWNER_KEY = 'bixarena.pendingPromptOwner';
 const PENDING_PROMPT_TTL_MS = 15 * 60 * 1000;
 const PENDING_PROMPT_MAX_LENGTH = 5000;
+
+export interface PendingPrompt {
+  prompt: string;
+  examplePromptId: string | null;
+}
 
 // Module-level helper so AuthService.logout can clear pending without
 // importing the service class (would create a circular dep).
@@ -27,37 +31,9 @@ export function clearPendingPromptStorage(): void {
 @Injectable({ providedIn: 'root' })
 export class BattleGateService {
   readonly authService = inject(AuthService);
-  private readonly onboardingService = inject(OnboardingService);
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   readonly showLoginModal = signal(false);
-  readonly showOnboardingModal = signal(false);
-
-  private pendingResolver: ((passed: boolean) => void) | null = null;
-
-  // TODO: if concurrent calls become an issue, cache the pending Promise so all callers share it
-  async checkOnboarding(): Promise<boolean> {
-    if (!this.onboardingService.hasCompleted()) {
-      this.showOnboardingModal.set(true);
-      return new Promise((resolve) => {
-        this.pendingResolver = resolve;
-      });
-    }
-    return true;
-  }
-
-  onOnboardingComplete(dontShowAgain: boolean): void {
-    this.onboardingService.markComplete(dontShowAgain);
-    this.showOnboardingModal.set(false);
-    this.pendingResolver?.(true);
-    this.pendingResolver = null;
-  }
-
-  onOnboardingDismiss(): void {
-    this.showOnboardingModal.set(false);
-    this.pendingResolver?.(false);
-    this.pendingResolver = null;
-  }
 
   // The home route guard picks up pending and routes to /battle after OIDC
   // returns to /. If auth-service ever supports a dynamic post-login URL,
@@ -102,7 +78,7 @@ export class BattleGateService {
     return this.peekValidPrompt() !== null;
   }
 
-  consumePendingPrompt(): { prompt: string; examplePromptId: string | null } | null {
+  consumePendingPrompt(): PendingPrompt | null {
     if (!this.isBrowser) return null;
     const valid = this.peekValidPrompt();
     if (!valid) {

--- a/libs/bixarena/services/src/lib/onboarding.service.ts
+++ b/libs/bixarena/services/src/lib/onboarding.service.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable, signal } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { LocalStorageService } from '@sagebionetworks/web-shared/angular/storage';
 
 const ONBOARDING_KEY = 'ba-onboarding-done';
@@ -7,12 +7,11 @@ const ONBOARDING_KEY = 'ba-onboarding-done';
 export class OnboardingService {
   private readonly storage = inject(LocalStorageService);
 
-  readonly hasCompleted = signal<boolean>(this.storage.getItem(ONBOARDING_KEY) === 'true');
+  hasSeen(): boolean {
+    return this.storage.getItem(ONBOARDING_KEY) === 'true';
+  }
 
-  markComplete(dontShowAgain: boolean): void {
-    this.hasCompleted.set(true);
-    if (dontShowAgain) {
-      this.storage.setItem(ONBOARDING_KEY, 'true');
-    }
+  markSeen(): void {
+    this.storage.setItem(ONBOARDING_KEY, 'true');
   }
 }

--- a/libs/bixarena/styles/src/lib/_overrides.scss
+++ b/libs/bixarena/styles/src/lib/_overrides.scss
@@ -168,7 +168,12 @@
   }
 
   .bixarena-modal.onboarding-modal.p-dialog {
-    max-width: 520px;
+    max-width: 760px;
+    background: var(--p-surface-0);
+
+    .p-dialog-content {
+      padding: 1.75rem;
+    }
 
     .p-button {
       height: 36px;

--- a/libs/bixarena/ui/src/index.ts
+++ b/libs/bixarena/ui/src/index.ts
@@ -5,6 +5,7 @@ export * from './lib/hero/hero.component';
 export * from './lib/login-modal/login-modal.component';
 export * from './lib/modal-dialog/modal-dialog.component';
 export * from './lib/nav/nav.component';
+export * from './lib/onboarding-fab/onboarding-fab.component';
 export * from './lib/onboarding-modal/onboarding-modal.component';
 export * from './lib/prompt-card/prompt-card.component';
 export * from './lib/prompt-composer/prompt-composer.component';

--- a/libs/bixarena/ui/src/lib/onboarding-fab/onboarding-fab.component.html
+++ b/libs/bixarena/ui/src/lib/onboarding-fab/onboarding-fab.component.html
@@ -1,0 +1,17 @@
+<button type="button" class="fab" aria-label="How it works" (click)="open()">
+  <svg
+    class="icon"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2.2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+    <path d="M12 17h.01" />
+  </svg>
+  <span class="label">How it works</span>
+</button>

--- a/libs/bixarena/ui/src/lib/onboarding-fab/onboarding-fab.component.scss
+++ b/libs/bixarena/ui/src/lib/onboarding-fab/onboarding-fab.component.scss
@@ -1,0 +1,88 @@
+@use 'shared/typescript/styles/src/shared-styles/variables' as shared;
+
+:host {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 50;
+}
+
+.fab {
+  --fab-bg: var(--p-surface-100);
+  --fab-bg-hover: var(--p-surface-200);
+  --fab-fg: var(--p-text-color);
+  --fab-border: var(--p-surface-200);
+
+  display: inline-flex;
+  align-items: center;
+  height: 40px;
+  padding: 0 0.85rem;
+  border-radius: 999px;
+  background: var(--fab-bg);
+  border: 1px solid var(--fab-border);
+  box-shadow: 0 6px 20px rgb(0 0 0 / 12%);
+  color: var(--fab-fg);
+  font: inherit;
+  font-size: var(--text-sm);
+  cursor: pointer;
+  overflow: hidden;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    box-shadow 0.2s;
+}
+
+.fab:focus-visible {
+  outline: 2px solid var(--p-primary-color);
+  outline-offset: 2px;
+}
+
+.icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+.label {
+  display: inline-block;
+  white-space: nowrap;
+  max-width: 0;
+  padding-left: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition:
+    max-width 0.25s ease,
+    opacity 0.2s ease,
+    padding-left 0.25s ease;
+}
+
+.fab:hover,
+.fab:focus-visible {
+  background: var(--fab-bg-hover);
+  border-color: var(--p-surface-300);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 16%);
+}
+
+.fab:hover .label,
+.fab:focus-visible .label {
+  max-width: 12rem;
+  opacity: 1;
+  padding-left: 0.5rem;
+}
+
+// Touch / no-hover devices: keep the label visible so the affordance is
+// discoverable without hover.
+@media (hover: none) {
+  .label {
+    max-width: 12rem;
+    opacity: 1;
+    padding-left: 0.5rem;
+  }
+}
+
+@media (width < #{shared.$md-breakpoint}) {
+  :host {
+    bottom: 1rem;
+    right: 1rem;
+  }
+}

--- a/libs/bixarena/ui/src/lib/onboarding-fab/onboarding-fab.component.ts
+++ b/libs/bixarena/ui/src/lib/onboarding-fab/onboarding-fab.component.ts
@@ -1,0 +1,14 @@
+import { Component, output } from '@angular/core';
+
+@Component({
+  selector: 'bixarena-onboarding-fab',
+  templateUrl: './onboarding-fab.component.html',
+  styleUrl: './onboarding-fab.component.scss',
+})
+export class OnboardingFabComponent {
+  readonly openRequested = output<void>();
+
+  open(): void {
+    this.openRequested.emit();
+  }
+}

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.html
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.html
@@ -14,6 +14,10 @@
     (focusin)="autoplayPaused.set(true)"
     (focusout)="autoplayPaused.set(false)"
   >
+    <div class="header">
+      <h2 class="header-title">How It Works</h2>
+    </div>
+
     <div class="viewport">
       <div class="track" [style.transform]="'translateX(' + -currentFrame() * 100 + '%)'">
         @for (frame of frames; track frame.id; let i = $index) {
@@ -24,64 +28,84 @@
             [attr.aria-label]="i + 1 + ' of ' + frames.length"
             [attr.aria-hidden]="i !== currentFrame()"
           >
-            <div class="art" aria-hidden="true">{{ frame.art }}</div>
-            <h2 class="title">{{ frame.title }}</h2>
-            <p class="description">{{ frame.description }}</p>
+            <div class="art" aria-hidden="true">
+              @switch (frame.id) {
+                @case ('start') {
+                  <div class="battle-mock">
+                    <div class="prompt-bubble">
+                      <span class="q-badge">Q</span>
+                      <span class="prompt-text">{{ samplePrompt }}</span>
+                    </div>
+                    <div class="panels">
+                      <div class="panel">
+                        <div class="panel-header">
+                          <span class="panel-name">Model A</span>
+                        </div>
+                        <div class="panel-body">
+                          <span class="line w-100"></span>
+                          <span class="line w-85"></span>
+                          <span class="line w-90"></span>
+                          <span class="line w-70"></span>
+                          <span class="line w-50"></span>
+                          <span class="cursor"></span>
+                        </div>
+                      </div>
+                      <div class="panel">
+                        <div class="panel-header">
+                          <span class="panel-name">Model B</span>
+                        </div>
+                        <div class="panel-body">
+                          <span class="line w-95"></span>
+                          <span class="line w-75"></span>
+                          <span class="line w-90"></span>
+                          <span class="line w-60"></span>
+                          <span class="cursor"></span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                }
+                @default {
+                  <div class="art-placeholder">{{ i + 1 }}</div>
+                }
+              }
+            </div>
+
+            <div class="copy">
+              <h3 class="title">{{ frame.title }}</h3>
+              <p class="description">{{ frame.description }}</p>
+            </div>
           </section>
         }
       </div>
     </div>
 
-    <div class="controls">
-      <button type="button" class="nav-btn" aria-label="Previous slide" (click)="prev()">
-        <svg
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-        >
-          <path d="m15 18-6-6 6-6" />
-        </svg>
-      </button>
-      <div class="dots" role="tablist" aria-label="Slide selection">
-        @for (frame of frames; track frame.id; let i = $index) {
-          <button
-            type="button"
-            class="dot"
-            role="tab"
-            [class.active]="i === currentFrame()"
-            [attr.aria-selected]="i === currentFrame()"
-            [attr.aria-label]="'Go to slide ' + (i + 1)"
-            (click)="goTo(i)"
-          ></button>
-        }
-      </div>
-      <button type="button" class="nav-btn" aria-label="Next slide" (click)="next()">
-        <svg
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-        >
-          <path d="m9 18 6-6-6-6" />
-        </svg>
-      </button>
+    <div class="dots" role="tablist" aria-label="Slide selection">
+      @for (frame of frames; track frame.id; let i = $index) {
+        <button
+          type="button"
+          class="dot"
+          role="tab"
+          [class.active]="i === currentFrame()"
+          [attr.aria-selected]="i === currentFrame()"
+          [attr.aria-label]="'Go to slide ' + (i + 1)"
+          (click)="goTo(i)"
+        ></button>
+      }
     </div>
 
     <div class="footer">
-      @if (!isLastFrame()) {
-        <button type="button" class="skip" (click)="done()">Skip</button>
-      }
-      <p-button
-        [label]="isLastFrame() ? 'Get started' : 'Next'"
-        (onClick)="isLastFrame() ? done() : next()"
-      />
+      <button type="button" class="skip" (click)="done()">Skip</button>
+      <div class="nav-actions">
+        @if (!isFirstFrame()) {
+          <p-button label="Back" styleClass="secondary-btn" (onClick)="prev()" />
+        }
+        @if (isLastFrame()) {
+          <p-button label="Get started" (onClick)="done()" />
+        } @else {
+          <p-button label="Next" (onClick)="next()" />
+        }
+      </div>
     </div>
   </div>
 </bixarena-modal-dialog>

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.html
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.html
@@ -65,6 +65,106 @@
                     </div>
                   </div>
                 }
+                @case ('select') {
+                  <div class="battle-mock">
+                    <div class="panels">
+                      <div class="panel selected">
+                        <div class="panel-header">
+                          <span class="panel-name">
+                            <span class="name-generic">Model A</span>
+                            <span class="name-real">Claude Opus 4.7</span>
+                          </span>
+                          <span class="pick-badge">YOUR PICK</span>
+                        </div>
+                        <div class="panel-body">
+                          <span class="line w-100"></span>
+                          <span class="line w-85"></span>
+                          <span class="line w-90"></span>
+                          <span class="line w-70"></span>
+                          <span class="line w-50"></span>
+                        </div>
+                      </div>
+                      <div class="panel">
+                        <div class="panel-header">
+                          <span class="panel-name">
+                            <span class="name-generic">Model B</span>
+                            <span class="name-real">GPT-5</span>
+                          </span>
+                        </div>
+                        <div class="panel-body">
+                          <span class="line w-95"></span>
+                          <span class="line w-75"></span>
+                          <span class="line w-90"></span>
+                          <span class="line w-60"></span>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="vote-bar">
+                      <button type="button" class="vb left active" tabindex="-1">
+                        <svg
+                          class="vb-icon flip"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          aria-hidden="true"
+                        >
+                          <path d="m11 19-6-6" />
+                          <path d="m5 21-2-2" />
+                          <path d="m8 16-4 4" />
+                          <path d="M9.5 17.5 21 6V3h-3L6.5 14.5" />
+                        </svg>
+                        <span>A is Better</span>
+                      </button>
+                      <button type="button" class="vb" tabindex="-1">
+                        <svg
+                          class="vb-icon"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          aria-hidden="true"
+                        >
+                          <path
+                            d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+                          />
+                        </svg>
+                        Tie
+                      </button>
+                      <button type="button" class="vb right" tabindex="-1">
+                        <span>B is Better</span>
+                        <svg
+                          class="vb-icon"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          aria-hidden="true"
+                        >
+                          <path d="m11 19-6-6" />
+                          <path d="m5 21-2-2" />
+                          <path d="m8 16-4 4" />
+                          <path d="M9.5 17.5 21 6V3h-3L6.5 14.5" />
+                        </svg>
+                      </button>
+                      <svg class="cursor-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path
+                          d="M3 2.5 L3 19.5 L8 14.5 L11 21.5 L13.5 20.5 L10.5 13.5 L17 13.5 Z"
+                          fill="currentColor"
+                          stroke="#fff"
+                          stroke-width="1.4"
+                          stroke-linejoin="round"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                }
                 @default {
                   <div class="art-placeholder">{{ i + 1 }}</div>
                 }

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.html
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.html
@@ -11,8 +11,6 @@
     aria-label="How BixArena works"
     (mouseenter)="autoplayPaused.set(true)"
     (mouseleave)="autoplayPaused.set(false)"
-    (focusin)="autoplayPaused.set(true)"
-    (focusout)="autoplayPaused.set(false)"
   >
     <div class="header">
       <h2 class="header-title">How It Works</h2>
@@ -219,14 +217,13 @@
       </div>
     </div>
 
-    <div class="dots" role="tablist" aria-label="Slide selection">
+    <div class="dots" aria-label="Slide selection">
       @for (frame of frames; track frame.id; let i = $index) {
         <button
           type="button"
           class="dot"
-          role="tab"
           [class.active]="i === currentFrame()"
-          [attr.aria-selected]="i === currentFrame()"
+          [attr.aria-current]="i === currentFrame() ? 'true' : null"
           [attr.aria-label]="'Go to slide ' + (i + 1)"
           (click)="goTo(i)"
         ></button>

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.html
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.html
@@ -40,11 +40,11 @@
                           <span class="panel-name">Model A</span>
                         </div>
                         <div class="panel-body">
-                          <span class="line w-100"></span>
-                          <span class="line w-85"></span>
-                          <span class="line w-90"></span>
-                          <span class="line w-70"></span>
-                          <span class="line w-50"></span>
+                          <span class="line" style="width: 100%"></span>
+                          <span class="line" style="width: 85%"></span>
+                          <span class="line" style="width: 90%"></span>
+                          <span class="line" style="width: 70%"></span>
+                          <span class="line" style="width: 50%"></span>
                           <span class="cursor"></span>
                         </div>
                       </div>
@@ -53,10 +53,10 @@
                           <span class="panel-name">Model B</span>
                         </div>
                         <div class="panel-body">
-                          <span class="line w-95"></span>
-                          <span class="line w-75"></span>
-                          <span class="line w-90"></span>
-                          <span class="line w-60"></span>
+                          <span class="line" style="width: 95%"></span>
+                          <span class="line" style="width: 75%"></span>
+                          <span class="line" style="width: 90%"></span>
+                          <span class="line" style="width: 60%"></span>
                           <span class="cursor"></span>
                         </div>
                       </div>
@@ -75,11 +75,11 @@
                           <span class="pick-badge">YOUR PICK</span>
                         </div>
                         <div class="panel-body">
-                          <span class="line w-100"></span>
-                          <span class="line w-85"></span>
-                          <span class="line w-90"></span>
-                          <span class="line w-70"></span>
-                          <span class="line w-50"></span>
+                          <span class="line" style="width: 100%"></span>
+                          <span class="line" style="width: 85%"></span>
+                          <span class="line" style="width: 90%"></span>
+                          <span class="line" style="width: 70%"></span>
+                          <span class="line" style="width: 50%"></span>
                         </div>
                       </div>
                       <div class="panel">
@@ -90,10 +90,10 @@
                           </span>
                         </div>
                         <div class="panel-body">
-                          <span class="line w-95"></span>
-                          <span class="line w-75"></span>
-                          <span class="line w-90"></span>
-                          <span class="line w-60"></span>
+                          <span class="line" style="width: 95%"></span>
+                          <span class="line" style="width: 75%"></span>
+                          <span class="line" style="width: 90%"></span>
+                          <span class="line" style="width: 60%"></span>
                         </div>
                       </div>
                     </div>
@@ -201,9 +201,6 @@
 
                     <p class="lb-disclaimer">Example only — not live data</p>
                   </div>
-                }
-                @default {
-                  <div class="art-placeholder">{{ i + 1 }}</div>
                 }
               }
             </div>

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.html
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.html
@@ -116,7 +116,8 @@
                           <path d="m8 16-4 4" />
                           <path d="M9.5 17.5 21 6V3h-3L6.5 14.5" />
                         </svg>
-                        <span>A is Better</span>
+                        <span class="vb-label">A is Better</span>
+                        <span class="vb-label-short">A</span>
                       </button>
                       <button type="button" class="vb" tabindex="-1">
                         <svg
@@ -136,7 +137,8 @@
                         Tie
                       </button>
                       <button type="button" class="vb right" tabindex="-1">
-                        <span>B is Better</span>
+                        <span class="vb-label">B is Better</span>
+                        <span class="vb-label-short">B</span>
                         <svg
                           class="vb-icon"
                           viewBox="0 0 24 24"

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.html
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.html
@@ -165,6 +165,43 @@
                     </div>
                   </div>
                 }
+                @case ('reveal') {
+                  <div class="lb-mock">
+                    <div class="lb-header">Daily Leaderboard</div>
+
+                    <div class="lb-rows">
+                      <div class="lb-row claude-row">
+                        <span class="lb-rank">
+                          <span class="rank-old">2</span>
+                          <span class="rank-new">1</span>
+                        </span>
+                        <span class="lb-name">Claude Opus 4.7</span>
+                        <span class="lb-score">
+                          <span class="score-old">1542</span>
+                          <span class="score-new">1551</span>
+                        </span>
+                      </div>
+                      <div class="lb-row gpt-row">
+                        <span class="lb-rank">
+                          <span class="rank-old">1</span>
+                          <span class="rank-new">2</span>
+                        </span>
+                        <span class="lb-name">GPT-5</span>
+                        <span class="lb-score">
+                          <span class="score-old">1547</span>
+                          <span class="score-new">1538</span>
+                        </span>
+                      </div>
+                      <div class="lb-row">
+                        <span class="lb-rank">3</span>
+                        <span class="lb-name">Gemini 2.5 Pro</span>
+                        <span class="lb-score static-score">1518</span>
+                      </div>
+                    </div>
+
+                    <p class="lb-disclaimer">Example only — not live data</p>
+                  </div>
+                }
                 @default {
                   <div class="art-placeholder">{{ i + 1 }}</div>
                 }

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.html
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.html
@@ -1,76 +1,87 @@
 <bixarena-modal-dialog
-  [heading]="showAgreement() ? 'Before You Start' : 'How it works'"
   styleClass="onboarding-modal"
   [closable]="true"
   [(visible)]="visible"
-  (closed)="onDismiss()"
+  (closed)="onModalClosed()"
 >
-  @if (!showAgreement()) {
-    <div class="step-list">
-      @for (step of steps; track $index) {
-        <div class="step-item">
-          <div class="step-num">{{ $index + 1 }}</div>
-          <div class="step-content">
-            <div class="step-label">{{ step.title }}</div>
-            <div class="step-desc">{{ step.description }}</div>
-          </div>
-        </div>
-      }
+  <div
+    class="carousel"
+    role="group"
+    aria-roledescription="carousel"
+    aria-label="How BixArena works"
+    (mouseenter)="autoplayPaused.set(true)"
+    (mouseleave)="autoplayPaused.set(false)"
+    (focusin)="autoplayPaused.set(true)"
+    (focusout)="autoplayPaused.set(false)"
+  >
+    <div class="viewport">
+      <div class="track" [style.transform]="'translateX(' + -currentFrame() * 100 + '%)'">
+        @for (frame of frames; track frame.id; let i = $index) {
+          <section
+            class="frame"
+            role="group"
+            aria-roledescription="slide"
+            [attr.aria-label]="i + 1 + ' of ' + frames.length"
+            [attr.aria-hidden]="i !== currentFrame()"
+          >
+            <div class="art" aria-hidden="true">{{ frame.art }}</div>
+            <h2 class="title">{{ frame.title }}</h2>
+            <p class="description">{{ frame.description }}</p>
+          </section>
+        }
+      </div>
     </div>
-  } @else {
-    <div class="agreement-text">
-      <p>
-        We process your prompts to ensure they are relevant to biomedical research. Your prompts are
-        also sent to third-party LLM proxies and AI model providers who may store and use them for
-        training and service improvement.
-      </p>
-      <p>
-        <strong
-          >Do not include private, sensitive, confidential, or personally identifiable information
-          in your prompts.</strong
+
+    <div class="controls">
+      <button type="button" class="nav-btn" aria-label="Previous slide" (click)="prev()">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
         >
-      </p>
-      <p>
-        AI responses may contain errors. Verify all AI responses independently. By continuing, you
-        agree to our
-        <a [href]="termsUrl()" target="_blank" rel="noopener noreferrer">Terms of Service</a>.
-      </p>
+          <path d="m15 18-6-6 6-6" />
+        </svg>
+      </button>
+      <div class="dots" role="tablist" aria-label="Slide selection">
+        @for (frame of frames; track frame.id; let i = $index) {
+          <button
+            type="button"
+            class="dot"
+            role="tab"
+            [class.active]="i === currentFrame()"
+            [attr.aria-selected]="i === currentFrame()"
+            [attr.aria-label]="'Go to slide ' + (i + 1)"
+            (click)="goTo(i)"
+          ></button>
+        }
+      </div>
+      <button type="button" class="nav-btn" aria-label="Next slide" (click)="next()">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="m9 18 6-6-6-6" />
+        </svg>
+      </button>
     </div>
-  }
 
-  <div class="modal-dots">
-    <button
-      type="button"
-      class="dot"
-      [class.active]="!showAgreement()"
-      aria-label="Go to How it works"
-      (click)="showAgreement.set(false)"
-    ></button>
-    <button
-      type="button"
-      class="dot"
-      [class.active]="showAgreement()"
-      aria-label="Go to Before You Start"
-      (click)="showAgreement.set(true)"
-    ></button>
-  </div>
-
-  <div class="modal-footer">
-    <label class="dont-show">
-      <input
-        type="checkbox"
-        [checked]="dontShowChecked()"
-        (change)="dontShowChecked.set($any($event.target).checked)"
-      />
-      Don't show again
-    </label>
-    <div class="btns">
-      @if (showAgreement()) {
-        <button class="secondary-btn" (click)="back()">Back</button>
-        <p-button label="Accept & Battle" (onClick)="agree()" />
-      } @else {
-        <p-button label="Next" (onClick)="next()" />
+    <div class="footer">
+      @if (!isLastFrame()) {
+        <button type="button" class="skip" (click)="done()">Skip</button>
       }
+      <p-button
+        [label]="isLastFrame() ? 'Get started' : 'Next'"
+        (onClick)="isLastFrame() ? done() : next()"
+      />
     </div>
   </div>
 </bixarena-modal-dialog>

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
@@ -83,8 +83,8 @@
   align-items: center;
   gap: 0.6rem;
   padding: 0.6rem 0.85rem;
-  background: color-mix(in srgb, var(--p-primary-color) 6%, var(--p-surface-0));
-  border: 1px solid color-mix(in srgb, var(--p-primary-color) 18%, transparent);
+  background: var(--p-surface-0);
+  border: 1px solid var(--p-surface-200);
   border-radius: 10px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.85rem;

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
@@ -1,14 +1,30 @@
 .carousel {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.25rem;
   min-width: 0;
+  width: 100%;
+  max-width: 46rem;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.header-title {
+  font-size: 1.375rem;
+  font-weight: 600;
+  color: var(--p-text-color);
+  margin: 0;
+  line-height: 1.2;
 }
 
 .viewport {
   overflow: hidden;
-  border-radius: 12px;
-  background: var(--p-surface-100);
+  border-radius: 14px;
 }
 
 .track {
@@ -20,19 +36,24 @@
 .frame {
   flex: 0 0 100%;
   min-width: 0;
-  padding: 2rem 1.5rem;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  text-align: center;
-  gap: 1rem;
+  gap: 1.25rem;
 }
 
-// Placeholder art block; replaced once the design lands.
 .art {
   width: 100%;
-  aspect-ratio: 16 / 10;
-  max-width: 24rem;
+  border-radius: 14px;
+  background: var(--p-surface-100);
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.art-placeholder {
+  width: 100%;
+  height: 15rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -45,7 +66,164 @@
   font-size: 3rem;
   font-weight: 700;
   color: var(--p-primary-color);
-  letter-spacing: 0.05em;
+}
+
+// Frame 1 — battle illustration mock.
+.battle-mock {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  width: 100%;
+}
+
+.prompt-bubble {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 0.85rem;
+  background: color-mix(in srgb, var(--p-primary-color) 6%, var(--p-surface-0));
+  border: 1px solid color-mix(in srgb, var(--p-primary-color) 18%, transparent);
+  border-radius: 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85rem;
+  color: var(--p-text-color);
+  align-self: stretch;
+}
+
+.q-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  background: var(--p-primary-color);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.75rem;
+  flex-shrink: 0;
+}
+
+.prompt-text {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.panel {
+  background: var(--p-surface-0);
+  border: 1px solid var(--p-surface-200);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.75rem;
+  border-bottom: 1px solid var(--p-surface-200);
+}
+
+.panel-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--p-text-color);
+}
+
+.panel-body {
+  padding: 0.85rem 0.75rem 0.65rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-height: 7rem;
+  position: relative;
+}
+
+.line {
+  display: block;
+  height: 6px;
+  border-radius: 4px;
+  background: var(--p-surface-200);
+}
+
+.line.w-100 {
+  width: 100%;
+}
+
+.line.w-95 {
+  width: 95%;
+}
+
+.line.w-90 {
+  width: 90%;
+}
+
+.line.w-85 {
+  width: 85%;
+}
+
+.line.w-75 {
+  width: 75%;
+}
+
+.line.w-70 {
+  width: 70%;
+}
+
+.line.w-60 {
+  width: 60%;
+}
+
+.line.w-50 {
+  width: 50%;
+}
+
+.cursor {
+  position: absolute;
+  bottom: 0.5rem;
+  right: 0.65rem;
+  width: 4px;
+  height: 14px;
+  background: var(--p-text-muted-color);
+  border-radius: 1px;
+  opacity: 0.7;
+  animation: cursor-blink 1.1s ease-in-out infinite;
+}
+
+@keyframes cursor-blink {
+  0%,
+  100% {
+    opacity: 0.7;
+  }
+
+  50% {
+    opacity: 0.15;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cursor {
+    animation: none;
+  }
+}
+
+.copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  text-align: left;
 }
 
 .title {
@@ -62,88 +240,56 @@
   color: var(--p-text-muted-color);
   line-height: 1.55;
   margin: 0;
-  max-width: 28rem;
   text-wrap: pretty;
-}
-
-.controls {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
-}
-
-.nav-btn {
-  width: 32px;
-  height: 32px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  border: 1px solid var(--p-surface-200);
-  background: transparent;
-  color: var(--p-text-muted-color);
-  cursor: pointer;
-  transition:
-    background 0.15s,
-    color 0.15s,
-    border-color 0.15s;
-
-  &:hover {
-    background: var(--p-surface-100);
-    color: var(--p-text-color);
-    border-color: var(--p-surface-300);
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--p-primary-color);
-    outline-offset: 2px;
-  }
-
-  svg {
-    width: 16px;
-    height: 16px;
-  }
 }
 
 .dots {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  justify-content: center;
+  gap: 0.4rem;
+  align-self: center;
 }
 
 .dot {
   width: 8px;
   height: 8px;
-  border-radius: 50%;
+  border-radius: 999px;
   border: none;
   background: var(--p-surface-300);
   cursor: pointer;
   padding: 0;
   transition:
-    background 0.15s,
-    transform 0.15s;
+    background 0.18s,
+    width 0.18s;
+}
 
-  &:hover {
-    background: var(--p-surface-400);
-  }
+.dot:hover {
+  background: var(--p-surface-400);
+}
 
-  &.active {
-    background: var(--p-primary-color);
-    transform: scale(1.2);
-  }
+.dot.active {
+  background: var(--p-primary-color);
+  width: 22px;
+}
 
-  &:focus-visible {
-    outline: 2px solid var(--p-primary-color);
-    outline-offset: 3px;
-  }
+.dot:focus-visible {
+  outline: 2px solid var(--p-primary-color);
+  outline-offset: 3px;
 }
 
 .footer {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: space-between;
   gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.nav-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .skip {
@@ -152,17 +298,17 @@
   color: var(--p-text-muted-color);
   font: inherit;
   font-size: var(--text-sm);
-  padding: 0.5rem 0.75rem;
+  padding: 0.5rem;
   cursor: pointer;
   border-radius: 6px;
+}
 
-  &:hover {
-    color: var(--p-text-color);
-    background: var(--p-surface-100);
-  }
+.skip:hover {
+  color: var(--p-text-color);
+  background: var(--p-surface-100);
+}
 
-  &:focus-visible {
-    outline: 2px solid var(--p-primary-color);
-    outline-offset: 2px;
-  }
+.skip:focus-visible {
+  outline: 2px solid var(--p-primary-color);
+  outline-offset: 2px;
 }

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
@@ -102,7 +102,7 @@
   background: var(--p-primary-color);
   color: #fff;
   font-weight: 700;
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   flex-shrink: 0;
 }
 
@@ -313,31 +313,6 @@
   flex-direction: column;
   gap: 0.85rem;
   width: 100%;
-}
-
-.action-row {
-  display: flex;
-  gap: 1.25rem;
-  justify-content: center;
-}
-
-.action {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-.action-caption {
-  font-size: 0.7rem;
-  color: var(--p-text-muted-color);
-  font-style: italic;
-}
-
-.lb-divider {
-  height: 1px;
-  background: var(--p-surface-200);
-  margin: 0.15rem 0;
 }
 
 .lb-header {

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
@@ -1,3 +1,5 @@
+@use 'shared/typescript/styles/src/shared-styles/variables' as shared;
+
 .carousel {
   display: flex;
   flex-direction: column;
@@ -266,6 +268,10 @@
   transform: scaleX(-1);
 }
 
+.vb-label-short {
+  display: none;
+}
+
 .cursor-icon {
   position: absolute;
   width: 18px;
@@ -514,27 +520,6 @@
   }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .cursor-icon,
-  .vb.active,
-  .panel.selected,
-  .pick-badge,
-  .name-generic,
-  .name-real,
-  .claude-row,
-  .gpt-row,
-  .rank-old,
-  .rank-new {
-    animation: none;
-  }
-
-  .name-real,
-  .rank-new,
-  .score-new {
-    opacity: 0;
-  }
-}
-
 .panel-name {
   position: relative;
   display: inline-flex;
@@ -663,12 +648,6 @@
   }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .cursor {
-    animation: none;
-  }
-}
-
 .copy {
   display: flex;
   flex-direction: column;
@@ -761,4 +740,43 @@
 .skip:focus-visible {
   outline: 2px solid var(--p-primary-color);
   outline-offset: 2px;
+}
+
+@media (width < #{shared.$md-breakpoint}) {
+  .vb-label {
+    display: none;
+  }
+
+  .vb.left .vb-label-short,
+  .vb.right .vb-label-short {
+    display: inline;
+  }
+
+  .pick-badge {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cursor,
+  .cursor-icon,
+  .vb.active,
+  .panel.selected,
+  .pick-badge,
+  .name-generic,
+  .name-real,
+  .claude-row,
+  .gpt-row,
+  .rank-old,
+  .rank-new,
+  .score-old,
+  .score-new {
+    animation: none;
+  }
+
+  .name-real,
+  .rank-new,
+  .score-new {
+    opacity: 0;
+  }
 }

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
@@ -301,17 +301,236 @@
   }
 }
 
+// Frame 3 — leaderboard mock with rank-jump animation.
+.lb-mock {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  width: 100%;
+}
+
+.action-row {
+  display: flex;
+  gap: 1.25rem;
+  justify-content: center;
+}
+
+.action {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.action-caption {
+  font-size: 0.7rem;
+  color: var(--p-text-muted-color);
+  font-style: italic;
+}
+
+.lb-divider {
+  height: 1px;
+  background: var(--p-surface-200);
+  margin: 0.15rem 0;
+}
+
+.lb-header {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--p-text-muted-color);
+  text-align: center;
+}
+
+.lb-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.lb-row {
+  display: grid;
+  grid-template-columns: 28px 1fr auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.45rem 0.85rem;
+  background: var(--p-surface-0);
+  border: 1px solid var(--p-surface-200);
+  border-radius: 8px;
+  font-size: 0.85rem;
+}
+
+.lb-rank {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: var(--p-text-muted-color);
+  font-variant-numeric: tabular-nums;
+  min-height: 1em;
+}
+
+.rank-old,
+.rank-new {
+  display: inline-block;
+}
+
+.rank-new {
+  position: absolute;
+  inset: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+}
+
+.lb-name {
+  font-weight: 500;
+  color: var(--p-text-color);
+}
+
+.lb-score {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.8rem;
+  color: var(--p-text-muted-color);
+  min-width: 2.6rem;
+}
+
+.score-old,
+.score-new {
+  display: inline-block;
+}
+
+.score-new {
+  position: absolute;
+  inset: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  opacity: 0;
+}
+
+.lb-disclaimer {
+  text-align: center;
+  font-size: 0.65rem;
+  color: var(--p-text-muted-color);
+  font-style: italic;
+  margin: 0;
+}
+
+.claude-row {
+  animation: claude-rise 5s ease-in-out infinite;
+}
+
+.gpt-row {
+  animation: gpt-fall 5s ease-in-out infinite;
+}
+
+.claude-row .rank-old,
+.gpt-row .rank-old,
+.claude-row .score-old,
+.gpt-row .score-old {
+  animation: rank-fade-out 5s ease-in-out infinite;
+}
+
+.claude-row .rank-new,
+.gpt-row .rank-new,
+.claude-row .score-new,
+.gpt-row .score-new {
+  animation: rank-fade-in 5s ease-in-out infinite;
+}
+
+@keyframes claude-rise {
+  0%,
+  30% {
+    transform: translateY(calc(100% + 0.25rem));
+  }
+
+  42%,
+  88% {
+    transform: translateY(0);
+  }
+
+  96%,
+  100% {
+    transform: translateY(calc(100% + 0.25rem));
+  }
+}
+
+@keyframes gpt-fall {
+  0%,
+  30% {
+    transform: translateY(calc(-100% - 0.25rem));
+  }
+
+  42%,
+  88% {
+    transform: translateY(0);
+  }
+
+  96%,
+  100% {
+    transform: translateY(calc(-100% - 0.25rem));
+  }
+}
+
+@keyframes rank-fade-out {
+  0%,
+  35% {
+    opacity: 1;
+  }
+
+  42%,
+  88% {
+    opacity: 0;
+  }
+
+  95%,
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes rank-fade-in {
+  0%,
+  35% {
+    opacity: 0;
+  }
+
+  42%,
+  88% {
+    opacity: 1;
+  }
+
+  95%,
+  100% {
+    opacity: 0;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .cursor-icon,
   .vb.active,
   .panel.selected,
   .pick-badge,
   .name-generic,
-  .name-real {
+  .name-real,
+  .claude-row,
+  .gpt-row,
+  .rank-old,
+  .rank-new {
     animation: none;
   }
 
-  .name-real {
+  .name-real,
+  .rank-new,
+  .score-new {
     opacity: 0;
   }
 }

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
@@ -131,15 +131,246 @@
 .panel-header {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 0.5rem;
   padding: 0.55rem 0.75rem;
   border-bottom: 1px solid var(--p-surface-200);
 }
 
+.panel.selected {
+  border-color: var(--p-surface-500);
+  box-shadow: 0 0 0 1px var(--p-surface-500);
+  animation: panel-select 4s ease-in-out infinite;
+}
+
+@keyframes panel-select {
+  0%,
+  25% {
+    border-color: var(--p-surface-200);
+    box-shadow: none;
+  }
+
+  35%,
+  78% {
+    border-color: var(--p-surface-500);
+    box-shadow: 0 0 0 1px var(--p-surface-500);
+  }
+
+  100% {
+    border-color: var(--p-surface-200);
+    box-shadow: none;
+  }
+}
+
+.pick-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.18rem 0.5rem;
+  border-radius: 4px;
+  background: var(--p-text-color);
+  color: var(--p-surface-0);
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  animation: pick-badge-in 4s ease-in-out infinite;
+  transform-origin: right center;
+}
+
+@keyframes pick-badge-in {
+  0%,
+  25% {
+    opacity: 0;
+    transform: scale(0.85);
+  }
+
+  35%,
+  78% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  100% {
+    opacity: 0;
+    transform: scale(0.85);
+  }
+}
+
+.vote-bar {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 0.85rem;
+}
+
+.vb {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 1.25rem;
+  border: 1px solid var(--p-surface-200);
+  border-radius: 100px;
+  background: var(--p-surface-100);
+  color: var(--p-surface-600);
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 520;
+  cursor: default;
+  letter-spacing: -0.01em;
+  pointer-events: none;
+}
+
+.vb.active {
+  background: var(--p-surface-200);
+  border-color: var(--p-surface-300);
+  color: var(--p-text-color);
+  transform: translateY(-1px);
+  animation: vb-activate 4s ease-in-out infinite;
+}
+
+@keyframes vb-activate {
+  0%,
+  20% {
+    background: var(--p-surface-100);
+    border-color: var(--p-surface-200);
+    color: var(--p-surface-600);
+    transform: translateY(0);
+  }
+
+  30%,
+  78% {
+    background: var(--p-surface-200);
+    border-color: var(--p-surface-300);
+    color: var(--p-text-color);
+    transform: translateY(-1px);
+  }
+
+  100% {
+    background: var(--p-surface-100);
+    border-color: var(--p-surface-200);
+    color: var(--p-surface-600);
+    transform: translateY(0);
+  }
+}
+
+.vb-icon {
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+}
+
+.vb-icon.flip {
+  transform: scaleX(-1);
+}
+
+.cursor-icon {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  left: calc(50% - 5.4rem);
+  top: 0.95rem;
+  color: var(--p-text-color);
+  filter: drop-shadow(0 1px 2px rgb(0 0 0 / 25%));
+  pointer-events: none;
+  animation: cursor-glide 4s ease-in-out infinite;
+}
+
+@keyframes cursor-glide {
+  0% {
+    transform: translate(2.8rem, -1.4rem) scale(1);
+  }
+
+  20% {
+    transform: translate(0, 0) scale(1);
+  }
+
+  25% {
+    transform: translate(0, 0) scale(0.82);
+  }
+
+  30%,
+  78% {
+    transform: translate(0, 0) scale(1);
+  }
+
+  100% {
+    transform: translate(2.8rem, -1.4rem) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cursor-icon,
+  .vb.active,
+  .panel.selected,
+  .pick-badge,
+  .name-generic,
+  .name-real {
+    animation: none;
+  }
+
+  .name-real {
+    opacity: 0;
+  }
+}
+
 .panel-name {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
   font-size: 0.85rem;
   font-weight: 600;
   color: var(--p-text-color);
+}
+
+.name-generic {
+  display: inline-block;
+  animation: name-generic-out 4s ease-in-out infinite;
+}
+
+.name-real {
+  position: absolute;
+  inset: 0;
+  display: inline-block;
+  white-space: nowrap;
+  opacity: 0;
+  animation: name-real-in 4s ease-in-out infinite;
+}
+
+@keyframes name-generic-out {
+  0%,
+  45% {
+    opacity: 1;
+  }
+
+  55%,
+  78% {
+    opacity: 0;
+  }
+
+  90%,
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes name-real-in {
+  0%,
+  45% {
+    opacity: 0;
+  }
+
+  55%,
+  78% {
+    opacity: 1;
+  }
+
+  90%,
+  100% {
+    opacity: 0;
+  }
 }
 
 .panel-body {

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
@@ -53,23 +53,6 @@
   justify-content: center;
 }
 
-.art-placeholder {
-  width: 100%;
-  height: 15rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 12px;
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--p-primary-color) 14%, transparent),
-    color-mix(in srgb, var(--p-primary-color) 4%, transparent)
-  );
-  font-size: 3rem;
-  font-weight: 700;
-  color: var(--p-primary-color);
-}
-
 // Frame 1 — battle illustration mock.
 .battle-mock {
   display: flex;
@@ -566,38 +549,6 @@
   height: 6px;
   border-radius: 4px;
   background: var(--p-surface-200);
-}
-
-.line.w-100 {
-  width: 100%;
-}
-
-.line.w-95 {
-  width: 95%;
-}
-
-.line.w-90 {
-  width: 90%;
-}
-
-.line.w-85 {
-  width: 85%;
-}
-
-.line.w-75 {
-  width: 75%;
-}
-
-.line.w-70 {
-  width: 70%;
-}
-
-.line.w-60 {
-  width: 60%;
-}
-
-.line.w-50 {
-  width: 50%;
 }
 
 .cursor {

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
@@ -1,68 +1,168 @@
-.step-list {
+.carousel {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-}
-
-.step-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.875rem;
-  padding: 0.75rem;
-}
-
-.step-num {
-  flex-shrink: 0;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background: rgb(249 115 22 / 10%);
-  color: var(--p-primary-color);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 13px;
-  font-weight: 600;
-}
-
-.step-content {
-  flex: 1;
+  gap: 1.5rem;
   min-width: 0;
 }
 
-.step-label {
-  font-size: var(--text-sm);
+.viewport {
+  overflow: hidden;
+  border-radius: 12px;
+  background: var(--p-surface-100);
+}
+
+.track {
+  display: flex;
+  transition: transform 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  will-change: transform;
+}
+
+.frame {
+  flex: 0 0 100%;
+  min-width: 0;
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1rem;
+}
+
+// Placeholder art block; replaced once the design lands.
+.art {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  max-width: 24rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--p-primary-color) 14%, transparent),
+    color-mix(in srgb, var(--p-primary-color) 4%, transparent)
+  );
+  font-size: 3rem;
+  font-weight: 700;
+  color: var(--p-primary-color);
+  letter-spacing: 0.05em;
+}
+
+.title {
+  font-size: var(--text-lg);
   font-weight: 600;
   color: var(--p-text-color);
-  margin-bottom: 0.2rem;
+  margin: 0;
+  line-height: 1.3;
+  text-wrap: balance;
 }
 
-.step-desc {
-  font-size: var(--text-xs);
+.description {
+  font-size: var(--text-sm);
   color: var(--p-text-muted-color);
   line-height: 1.55;
+  margin: 0;
+  max-width: 28rem;
+  text-wrap: pretty;
 }
 
-.agreement-text {
-  font-size: var(--text-xs);
-  color: var(--p-text-color);
-  line-height: 1.6;
-
-  p {
-    margin: 0 0 0.5rem;
-  }
-
-  a {
-    color: var(--p-primary-color);
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-}
-
-.btns {
+.controls {
   display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.nav-btn {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid var(--p-surface-200);
+  background: transparent;
+  color: var(--p-text-muted-color);
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s,
+    border-color 0.15s;
+
+  &:hover {
+    background: var(--p-surface-100);
+    color: var(--p-text-color);
+    border-color: var(--p-surface-300);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--p-primary-color);
+    outline-offset: 2px;
+  }
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.dots {
+  display: inline-flex;
+  align-items: center;
   gap: 0.5rem;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  background: var(--p-surface-300);
+  cursor: pointer;
+  padding: 0;
+  transition:
+    background 0.15s,
+    transform 0.15s;
+
+  &:hover {
+    background: var(--p-surface-400);
+  }
+
+  &.active {
+    background: var(--p-primary-color);
+    transform: scale(1.2);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--p-primary-color);
+    outline-offset: 3px;
+  }
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.skip {
+  border: none;
+  background: transparent;
+  color: var(--p-text-muted-color);
+  font: inherit;
+  font-size: var(--text-sm);
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  border-radius: 6px;
+
+  &:hover {
+    color: var(--p-text-color);
+    background: var(--p-surface-100);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--p-primary-color);
+    outline-offset: 2px;
+  }
 }

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
@@ -49,7 +49,7 @@ export class OnboardingModalComponent {
       id: 'select',
       title: 'Select the Better',
       description:
-        'Review the two AI-generated answers side by side and decide which model demonstrates clearer reasoning or insight. Your choice directly shapes model performance metrics.',
+        'Review the two AI-generated answers side by side and pick the one with clearer reasoning or sharper insight. After you vote, both models are revealed.',
     },
     {
       id: 'reveal',

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
@@ -1,11 +1,29 @@
-import { Component, input, model, output, signal } from '@angular/core';
+import {
+  Component,
+  computed,
+  DestroyRef,
+  effect,
+  inject,
+  isDevMode,
+  model,
+  OnDestroy,
+  output,
+  PLATFORM_ID,
+  signal,
+} from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { ButtonModule } from 'primeng/button';
 import { ModalDialogComponent } from '../modal-dialog/modal-dialog.component';
 
-interface OnboardingStep {
-  title: string;
-  description: string;
+interface OnboardingFrame {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  // Placeholder illustration; replaced once design lands.
+  readonly art: string;
 }
+
+const AUTOPLAY_INTERVAL_MS = 2500;
 
 @Component({
   selector: 'bixarena-onboarding-modal',
@@ -13,51 +31,103 @@ interface OnboardingStep {
   templateUrl: './onboarding-modal.component.html',
   styleUrl: './onboarding-modal.component.scss',
 })
-export class OnboardingModalComponent {
+export class OnboardingModalComponent implements OnDestroy {
   readonly visible = model(false);
-  readonly termsUrl = input('');
-  readonly agreed = output<boolean>();
-  readonly dismissed = output<void>();
+  readonly closed = output<void>();
 
-  readonly steps: OnboardingStep[] = [
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly frames: OnboardingFrame[] = [
     {
-      title: 'Start a Battle',
+      id: 'stream',
+      title: 'Two anonymous models answer',
       description:
-        'Pick a curated biomedical question or submit your own prompt. Two AI models are randomly chosen to face off, and their identities stay anonymous so you can focus purely on the response quality.',
+        'You ask a biomedical question. Two AI models respond side-by-side, identities hidden so you compare answers, not brands.',
+      art: 'A',
     },
     {
-      title: 'Select the Better',
+      id: 'vote',
+      title: 'You pick the winner',
       description:
-        'Review the two AI-generated answers side by side and decide which model demonstrates clearer reasoning or insight. Your choice directly shapes model performance metrics.',
+        'Read both answers. Vote for the one with clearer reasoning, better evidence, or sharper insight.',
+      art: 'B',
     },
     {
-      title: 'Reveal & Impact',
+      id: 'reveal',
+      title: 'Models revealed, leaderboard updates',
       description:
-        "Once you've made your choice, the models are revealed. Only biomedical battles count toward the daily leaderboard. Ready for another round? Jump into your next battle.",
+        'The reveal shows which models you compared. Your vote feeds the live daily leaderboard ranking biomedical AI performance.',
+      art: 'C',
     },
   ];
 
-  readonly showAgreement = signal(false);
-  readonly dontShowChecked = signal(false);
+  readonly currentFrame = signal(0);
+  readonly autoplayPaused = signal(false);
+  readonly isLastFrame = computed(() => this.currentFrame() === this.frames.length - 1);
+
+  private readonly reducedMotion = this.isBrowser
+    ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    : false;
+
+  private autoplayTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    // Reset to first frame whenever the modal is opened so re-entry starts fresh.
+    effect(() => {
+      if (this.visible()) this.currentFrame.set(0);
+    });
+
+    effect(() => {
+      const shouldRun =
+        this.visible() && !this.autoplayPaused() && !this.reducedMotion && this.isBrowser;
+      if (shouldRun) {
+        this.startAutoplay();
+      } else {
+        this.stopAutoplay();
+      }
+    });
+
+    this.destroyRef.onDestroy(() => this.stopAutoplay());
+  }
 
   next(): void {
-    this.showAgreement.set(true);
+    this.currentFrame.update((i) => (i + 1) % this.frames.length);
   }
 
-  back(): void {
-    this.showAgreement.set(false);
+  prev(): void {
+    this.currentFrame.update((i) => (i - 1 + this.frames.length) % this.frames.length);
   }
 
-  agree(): void {
+  goTo(index: number): void {
+    if (index < 0 || index >= this.frames.length) {
+      if (isDevMode()) console.warn('OnboardingModal: invalid frame index', index);
+      return;
+    }
+    this.currentFrame.set(index);
+  }
+
+  done(): void {
     this.visible.set(false);
-    this.showAgreement.set(false);
-    this.agreed.emit(this.dontShowChecked());
+    this.closed.emit();
   }
 
-  onDismiss(): void {
-    this.visible.set(false);
-    this.showAgreement.set(false);
-    this.dontShowChecked.set(false);
-    this.dismissed.emit();
+  onModalClosed(): void {
+    this.closed.emit();
+  }
+
+  ngOnDestroy(): void {
+    this.stopAutoplay();
+  }
+
+  private startAutoplay(): void {
+    if (this.autoplayTimer !== null) return;
+    this.autoplayTimer = setInterval(() => this.next(), AUTOPLAY_INTERVAL_MS);
+  }
+
+  private stopAutoplay(): void {
+    if (this.autoplayTimer === null) return;
+    clearInterval(this.autoplayTimer);
+    this.autoplayTimer = null;
   }
 }

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
@@ -6,7 +6,6 @@ import {
   inject,
   isDevMode,
   model,
-  OnDestroy,
   output,
   PLATFORM_ID,
   signal,
@@ -31,7 +30,7 @@ const AUTOPLAY_INTERVAL_MS = 2500;
   templateUrl: './onboarding-modal.component.html',
   styleUrl: './onboarding-modal.component.scss',
 })
-export class OnboardingModalComponent implements OnDestroy {
+export class OnboardingModalComponent {
   readonly visible = model(false);
   readonly closed = output<void>();
 
@@ -114,10 +113,6 @@ export class OnboardingModalComponent implements OnDestroy {
 
   onModalClosed(): void {
     this.closed.emit();
-  }
-
-  ngOnDestroy(): void {
-    this.stopAutoplay();
   }
 
   private startAutoplay(): void {

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
@@ -18,11 +18,10 @@ interface OnboardingFrame {
   readonly id: string;
   readonly title: string;
   readonly description: string;
-  // Placeholder illustration; replaced once design lands.
-  readonly art: string;
 }
 
-const AUTOPLAY_INTERVAL_MS = 2500;
+const AUTOPLAY_INTERVAL_MS = 7000;
+const SAMPLE_PROMPT = 'How does sleep affect the immune system?';
 
 @Component({
   selector: 'bixarena-onboarding-modal',
@@ -37,32 +36,32 @@ export class OnboardingModalComponent {
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
   private readonly destroyRef = inject(DestroyRef);
 
+  readonly samplePrompt = SAMPLE_PROMPT;
+
   readonly frames: OnboardingFrame[] = [
     {
-      id: 'stream',
-      title: 'Two anonymous models answer',
+      id: 'start',
+      title: 'Start a Battle',
       description:
-        'You ask a biomedical question. Two AI models respond side-by-side, identities hidden so you compare answers, not brands.',
-      art: 'A',
+        'Pick a curated example or ask your own biomedical question. Two AI models are randomly chosen to face off, and their identities stay anonymous so you can focus purely on the response quality.',
     },
     {
-      id: 'vote',
-      title: 'You pick the winner',
+      id: 'select',
+      title: 'Select the Better',
       description:
-        'Read both answers. Vote for the one with clearer reasoning, better evidence, or sharper insight.',
-      art: 'B',
+        'Review the two AI-generated answers side by side and decide which model demonstrates clearer reasoning or insight. Your choice directly shapes model performance metrics.',
     },
     {
       id: 'reveal',
-      title: 'Models revealed, leaderboard updates',
+      title: 'Reveal & Impact',
       description:
-        'The reveal shows which models you compared. Your vote feeds the live daily leaderboard ranking biomedical AI performance.',
-      art: 'C',
+        "Once you've made your choice, the models are revealed. Only biomedical battles count toward the daily leaderboard. Ready for another round? Jump into your next battle.",
     },
   ];
 
   readonly currentFrame = signal(0);
   readonly autoplayPaused = signal(false);
+  readonly isFirstFrame = computed(() => this.currentFrame() === 0);
   readonly isLastFrame = computed(() => this.currentFrame() === this.frames.length - 1);
 
   private readonly reducedMotion = this.isBrowser

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
@@ -53,7 +53,7 @@ export class OnboardingModalComponent {
     },
     {
       id: 'reveal',
-      title: 'Battles Drive Impact',
+      title: 'Make Your Impact',
       description:
         'Only biomedical battles count toward the daily leaderboard. Ready for another round? Jump into your next battle with the same question against new models, or start a fresh battle.',
     },

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
@@ -53,9 +53,9 @@ export class OnboardingModalComponent {
     },
     {
       id: 'reveal',
-      title: 'Reveal & Impact',
+      title: 'Battles Drive Impact',
       description:
-        "Once you've made your choice, the models are revealed. Only biomedical battles count toward the daily leaderboard. Ready for another round? Jump into your next battle.",
+        'Only biomedical battles count toward the daily leaderboard. Ready for another round? Jump into your next battle with the same question against new models, or start a fresh battle.',
     },
   ];
 

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
@@ -77,8 +77,13 @@ export class OnboardingModalComponent {
     });
 
     effect(() => {
+      // No autoplay on last frame: wrap would scroll backward through prior slides.
       const shouldRun =
-        this.visible() && !this.autoplayPaused() && !this.reducedMotion && this.isBrowser;
+        this.visible() &&
+        !this.autoplayPaused() &&
+        !this.reducedMotion &&
+        this.isBrowser &&
+        !this.isLastFrame();
       if (shouldRun) {
         this.startAutoplay();
       } else {
@@ -90,11 +95,13 @@ export class OnboardingModalComponent {
   }
 
   next(): void {
-    this.currentFrame.update((i) => (i + 1) % this.frames.length);
+    if (this.isLastFrame()) return;
+    this.currentFrame.update((i) => i + 1);
   }
 
   prev(): void {
-    this.currentFrame.update((i) => (i - 1 + this.frames.length) % this.frames.length);
+    if (this.isFirstFrame()) return;
+    this.currentFrame.update((i) => i - 1);
   }
 
   goTo(index: number): void {

--- a/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.html
+++ b/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.html
@@ -32,3 +32,52 @@
     </button>
   </div>
 </div>
+<p class="disclaimer">
+  <span class="disclaimer-text"
+    >AI may make mistakes. Do not include sensitive or personal information.</span
+  >
+  <button
+    type="button"
+    class="more-info"
+    [attr.aria-expanded]="disclaimerOpen()"
+    aria-label="More info about how prompts are handled"
+    (click)="toggleDisclaimer($event)"
+  >
+    <svg
+      class="more-info-icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 16v-4M12 8h.01" />
+    </svg>
+    <span>More info</span>
+  </button>
+</p>
+
+<p-popover
+  #disclaimerPopover
+  styleClass="prompt-disclaimer-popover"
+  (onShow)="disclaimerOpen.set(true)"
+  (onHide)="disclaimerOpen.set(false)"
+>
+  <div class="disclaimer-content">
+    <div class="eyebrow">About your prompts</div>
+    <p>
+      Prompts are checked for biomedical relevance and sent to third-party LLM providers, who may
+      store and use them for training and service improvement.
+    </p>
+    <p class="warn">
+      <strong
+        >Don't include private, sensitive, confidential, or personally identifiable
+        information.</strong
+      >
+    </p>
+    <p>AI responses may contain errors. Verify all AI responses independently.</p>
+  </div>
+</p-popover>

--- a/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.scss
+++ b/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.scss
@@ -128,31 +128,25 @@
 .more-info {
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
-  padding: 0.2rem 0.6rem;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  background: color-mix(in srgb, var(--p-primary-color) 10%, transparent);
-  color: var(--p-primary-color);
+  gap: 0.25rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--p-text-muted-color);
   font: inherit;
   font-size: inherit;
   font-weight: 500;
+  text-decoration: underline;
+  text-underline-offset: 2px;
   cursor: pointer;
-  transition:
-    background 0.15s,
-    border-color 0.15s;
+  transition: color 0.15s;
 
   &:hover {
-    background: color-mix(in srgb, var(--p-primary-color) 18%, transparent);
-  }
-
-  &:focus-visible {
-    outline: none;
-    border-color: var(--p-primary-color);
+    color: var(--p-text-color);
   }
 
   &[aria-expanded='true'] {
-    background: color-mix(in srgb, var(--p-primary-color) 22%, transparent);
+    color: var(--p-text-color);
   }
 }
 

--- a/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.scss
+++ b/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.scss
@@ -109,3 +109,83 @@
     height: 14px;
   }
 }
+
+.disclaimer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.5rem;
+  font-size: var(--text-xs);
+  color: var(--p-text-muted-color);
+  margin: 0.75rem 0 0;
+}
+
+.disclaimer-text {
+  line-height: 1.5;
+}
+
+.more-info {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: color-mix(in srgb, var(--p-primary-color) 10%, transparent);
+  color: var(--p-primary-color);
+  font: inherit;
+  font-size: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
+
+  &:hover {
+    background: color-mix(in srgb, var(--p-primary-color) 18%, transparent);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--p-primary-color);
+  }
+
+  &[aria-expanded='true'] {
+    background: color-mix(in srgb, var(--p-primary-color) 22%, transparent);
+  }
+}
+
+.more-info-icon {
+  width: 13px;
+  height: 13px;
+}
+
+.disclaimer-content {
+  max-width: 22rem;
+  font-size: var(--text-sm);
+  line-height: 1.55;
+  color: var(--p-text-color);
+
+  p {
+    margin: 0 0 0.75rem;
+  }
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+
+  .warn {
+    color: var(--p-text-color);
+    font-weight: 500;
+  }
+}
+
+.eyebrow {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--p-text-muted-color);
+  margin-bottom: 0.65rem;
+}

--- a/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.ts
+++ b/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.ts
@@ -1,7 +1,9 @@
 import { Component, computed, ElementRef, input, output, signal, viewChild } from '@angular/core';
+import { Popover, PopoverModule } from 'primeng/popover';
 
 @Component({
   selector: 'bixarena-prompt-composer',
+  imports: [PopoverModule],
   templateUrl: './prompt-composer.component.html',
   styleUrl: './prompt-composer.component.scss',
 })
@@ -14,6 +16,12 @@ export class PromptComposerComponent {
 
   readonly text = signal('');
   readonly textareaEl = viewChild<ElementRef<HTMLTextAreaElement>>('textarea');
+  private readonly disclaimerPopover = viewChild.required<Popover>('disclaimerPopover');
+  readonly disclaimerOpen = signal(false);
+
+  toggleDisclaimer(event: Event): void {
+    this.disclaimerPopover().toggle(event);
+  }
 
   readonly isHot = computed(() => this.text().trim().length > 0 && !this.disabled());
 


### PR DESCRIPTION
## Description

Replaces the blocking onboarding modal (triggered after first prompt submit) with a smoother, less intrusive UX: a 3-frame autoplay carousel that opens on first `/battle` entry before any action is required, an inline disclaimer below the prompt composer, and a persistent floating FAB so users can re-open the explainer anytime. This eliminates the double-interruption flow (sign-in → submit → onboarding modal).

## Related Issue

[SMR-776](https://sagebionetworks.jira.com/browse/SMR-776)

## Changelog

- Rebuild onboarding modal as a 3-frame autoplay carousel with CSS-only animated illustrations (battle, vote+reveal, leaderboard rank-jump)
- Move onboarding trigger to first `/battle` entry; pending prompt is deferred and submitted on modal close
- Add floating help FAB (bottom-right of `/battle`) so users can reopen the carousel at any time
- Replace disclaimer modal with an always-visible inline notice below the composer, using a PrimeNG Popover for the full text
- Simplify `BattleGateService` by removing the onboarding gate; `OnboardingService` API simplified to `hasSeen`/`markSeen`
- Add descriptive captions under voting-bar action buttons ("same question, new models" / "brand-new question")

## Preview

*Short inline disclaimer*

<img width="1038" height="620" alt="Screenshot 2026-05-04 at 1 26 06 PM" src="https://github.com/user-attachments/assets/568286a2-6667-416b-b48c-d4e949b583ef" />

<br><br>*Onboarding carousel auto-opens on first `/battle` visit, autoplays through three illustrated steps, and closes to reveal the battle — floating FAB stays visible for later reference.*

https://github.com/user-attachments/assets/1d4711c5-fa58-48b0-a490-2d34459d680f



[SMR-776]: https://sagebionetworks.jira.com/browse/SMR-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ