### PR TITLE
feat(bixarena): implement post-login redirect via return_to param

### DIFF
--- a/apps/bixarena/auth-service/src/main/java/org/sagebionetworks/bixarena/auth/service/api/AuthApi.java
+++ b/apps/bixarena/auth-service/src/main/java/org/sagebionetworks/bixarena/auth/service/api/AuthApi.java
@@ -197,6 +197,7 @@ public interface AuthApi {
      * GET /auth/login : Start Synapse OIDC authorization code flow
      * Initiates the OIDC login by redirecting the user to Synapse with state and nonce.
      *
+     * @param returnTo Relative path to redirect to after login (e.g. /battle). (optional)
      * @return Flow started (no content; clients should follow redirect) (status code 204)
      *         or Redirect to Synapse login (status code 302)
      *         or Invalid request (status code 400)
@@ -232,9 +233,9 @@ public interface AuthApi {
     )
     
     default ResponseEntity<Void> login(
-        
+        @Size(max = 500) @Parameter(name = "return_to", description = "Relative path to redirect to after login (e.g. /battle).", in = ParameterIn.QUERY) @Valid @RequestParam(value = "return_to", required = false) @Nullable String returnTo
     ) {
-        return getDelegate().login();
+        return getDelegate().login(returnTo);
     }
 
 

--- a/apps/bixarena/auth-service/src/main/java/org/sagebionetworks/bixarena/auth/service/api/AuthApiDelegate.java
+++ b/apps/bixarena/auth-service/src/main/java/org/sagebionetworks/bixarena/auth/service/api/AuthApiDelegate.java
@@ -161,6 +161,7 @@ public interface AuthApiDelegate {
      * GET /auth/login : Start Synapse OIDC authorization code flow
      * Initiates the OIDC login by redirecting the user to Synapse with state and nonce.
      *
+     * @param returnTo Relative path to redirect to after login (e.g. /battle). (optional)
      * @return Flow started (no content; clients should follow redirect) (status code 204)
      *         or Redirect to Synapse login (status code 302)
      *         or Invalid request (status code 400)
@@ -168,7 +169,7 @@ public interface AuthApiDelegate {
      *         or The request cannot be fulfilled due to an unexpected server error (status code 500)
      * @see AuthApi#login
      */
-    default ResponseEntity<Void> login() {
+    default ResponseEntity<Void> login(String returnTo) {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/problem+json"))) {

--- a/apps/bixarena/auth-service/src/main/java/org/sagebionetworks/bixarena/auth/service/api/AuthApiDelegateImpl.java
+++ b/apps/bixarena/auth-service/src/main/java/org/sagebionetworks/bixarena/auth/service/api/AuthApiDelegateImpl.java
@@ -202,8 +202,7 @@ public class AuthApiDelegateImpl implements AuthApiDelegate {
   }
 
   @Override
-  public ResponseEntity<Void> login() {
-    // Generate state & nonce (TODO: persist securely in session)
+  public ResponseEntity<Void> login(String returnTo) {
     String state = java.util.UUID.randomUUID().toString();
     String nonce = java.util.UUID.randomUUID().toString();
     HttpServletRequest req =
@@ -211,12 +210,16 @@ public class AuthApiDelegateImpl implements AuthApiDelegate {
     HttpSession session = req.getSession(true);
     session.setAttribute("OIDC_STATE", state);
     session.setAttribute("OIDC_NONCE", nonce);
+    if (returnTo != null && isSafeReturnTo(returnTo)) {
+      session.setAttribute("OIDC_RETURN_TO", returnTo);
+    }
     if (log.isInfoEnabled()) {
       log.info(
-        "OIDC start: sessionId={} assigned state={} nonce={} host={} port={}",
+        "OIDC start: sessionId={} assigned state={} nonce={} returnTo={} host={} port={}",
         session.getId(),
         state,
         nonce,
+        returnTo,
         req.getServerName(),
         req.getServerPort()
       );
@@ -367,11 +370,14 @@ public class AuthApiDelegateImpl implements AuthApiDelegate {
       session.setAttribute("AUTH_AVATAR_URL", persistedUser.getAvatarUrl());
       session.removeAttribute("OIDC_STATE");
       session.removeAttribute("OIDC_NONCE");
-      // If browser navigation (prefers HTML) redirect to root instead of showing JSON
+      String returnTo = (String) session.getAttribute("OIDC_RETURN_TO");
+      session.removeAttribute("OIDC_RETURN_TO");
+      // If browser navigation (prefers HTML) redirect to app instead of showing JSON
       String accept = req.getHeader("Accept");
       if (accept != null && accept.contains("text/html")) {
         String uiBase = appProperties.uiBaseUrl();
-        return ResponseEntity.status(302).header("Location", uiBase).build();
+        String location = (returnTo != null) ? uiBase + returnTo : uiBase;
+        return ResponseEntity.status(302).header("Location", location).build();
       }
       var body = Callback200ResponseDto.builder().status("ok").build();
       return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(body);
@@ -381,6 +387,11 @@ public class AuthApiDelegateImpl implements AuthApiDelegate {
         .contentType(MediaType.APPLICATION_JSON)
         .body(Callback200ResponseDto.builder().status("error:exception").build());
     }
+  }
+
+  private boolean isSafeReturnTo(String returnTo) {
+    // Accept only relative paths — reject absolute URLs and protocol-relative URLs
+    return returnTo.startsWith("/") && !returnTo.startsWith("//") && !returnTo.contains("://");
   }
 
   private Map<String, Object> exchangeCodeForTokens(String code) {

--- a/apps/bixarena/auth-service/src/main/java/org/sagebionetworks/bixarena/auth/service/api/AuthApiDelegateImpl.java
+++ b/apps/bixarena/auth-service/src/main/java/org/sagebionetworks/bixarena/auth/service/api/AuthApiDelegateImpl.java
@@ -383,6 +383,9 @@ public class AuthApiDelegateImpl implements AuthApiDelegate {
       return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(body);
     } catch (Exception e) {
       log.info("OIDC callback: exception {}", e.getMessage());
+      if (session != null) {
+        session.removeAttribute("OIDC_RETURN_TO");
+      }
       return ResponseEntity.status(400)
         .contentType(MediaType.APPLICATION_JSON)
         .body(Callback200ResponseDto.builder().status("error:exception").build());

--- a/apps/bixarena/auth-service/src/main/resources/openapi.yaml
+++ b/apps/bixarena/auth-service/src/main/resources/openapi.yaml
@@ -22,6 +22,16 @@ paths:
       description: Initiates the OIDC login by redirecting the user to Synapse with
         state and nonce.
       operationId: login
+      parameters:
+        - description: Relative path to redirect to after login (e.g. /battle).
+          explode: true
+          in: query
+          name: return_to
+          required: false
+          schema:
+            maxLength: 500
+            type: string
+          style: form
       responses:
         '204':
           description: Flow started (no content; clients should follow redirect)

--- a/apps/bixarena/auth-service/src/test/java/org/sagebionetworks/bixarena/auth/service/api/AuthApiDelegateImplTest.java
+++ b/apps/bixarena/auth-service/src/test/java/org/sagebionetworks/bixarena/auth/service/api/AuthApiDelegateImplTest.java
@@ -1,0 +1,141 @@
+package org.sagebionetworks.bixarena.auth.service.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sagebionetworks.bixarena.auth.service.configuration.AppProperties;
+import org.sagebionetworks.bixarena.auth.service.security.key.JwkKeyStore;
+import org.sagebionetworks.bixarena.auth.service.service.InternalJwtService;
+import org.sagebionetworks.bixarena.auth.service.service.UserService;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@ExtendWith(MockitoExtension.class)
+class AuthApiDelegateImplTest {
+
+  @Mock
+  private JwkKeyStore keyStore;
+
+  @Mock
+  private InternalJwtService jwtService;
+
+  @Mock
+  private AppProperties appProperties;
+
+  @Mock
+  private UserService userService;
+
+  @InjectMocks
+  private AuthApiDelegateImpl delegate;
+
+  private MockHttpServletRequest request;
+  private MockHttpSession session;
+
+  @BeforeEach
+  void setUp() {
+    request = new MockHttpServletRequest();
+    session = new MockHttpSession();
+    request.setSession(session);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+    AppProperties.Auth auth = new AppProperties.Auth(
+      "https://signin.synapse.org",
+      "https://repo-prod.prod.sagebase.org/auth/v1/oauth2/token",
+      "https://repo-prod.prod.sagebase.org/auth/v1/openid/jwks",
+      "test-client-id",
+      "test-client-secret",
+      URI.create("http://localhost:8000/auth/callback"),
+      "urn:bixarena:auth",
+      "urn:bixarena:auth",
+      600L,
+      "service-client",
+      "service-secret",
+      300L
+    );
+    when(appProperties.auth()).thenReturn(auth);
+  }
+
+  @AfterEach
+  void tearDown() {
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  // --- login() return_to session storage ---
+
+  @Test
+  @DisplayName("should store return_to in session when path is a valid relative path")
+  void shouldStoreReturnToInSessionWhenPathIsValidRelativePath() {
+    delegate.login("/battle");
+
+    assertThat(session.getAttribute("OIDC_RETURN_TO")).isEqualTo("/battle");
+  }
+
+  @Test
+  @DisplayName("should store return_to for nested relative path")
+  void shouldStoreReturnToForNestedRelativePath() {
+    delegate.login("/leaderboard/cancer-biology");
+
+    assertThat(session.getAttribute("OIDC_RETURN_TO")).isEqualTo("/leaderboard/cancer-biology");
+  }
+
+  @Test
+  @DisplayName("should not store return_to when return_to is null")
+  void shouldNotStoreReturnToWhenReturnToIsNull() {
+    delegate.login(null);
+
+    assertThat(session.getAttribute("OIDC_RETURN_TO")).isNull();
+  }
+
+  @Test
+  @DisplayName("should not store return_to when path is an absolute URL")
+  void shouldNotStoreReturnToWhenPathIsAbsoluteUrl() {
+    delegate.login("http://evil.com/steal");
+
+    assertThat(session.getAttribute("OIDC_RETURN_TO")).isNull();
+  }
+
+  @Test
+  @DisplayName("should not store return_to when path is a protocol-relative URL")
+  void shouldNotStoreReturnToWhenPathIsProtocolRelativeUrl() {
+    delegate.login("//evil.com/steal");
+
+    assertThat(session.getAttribute("OIDC_RETURN_TO")).isNull();
+  }
+
+  @Test
+  @DisplayName("should not store return_to when path uses javascript scheme")
+  void shouldNotStoreReturnToWhenPathUsesJavascriptScheme() {
+    delegate.login("javascript:alert(1)");
+
+    assertThat(session.getAttribute("OIDC_RETURN_TO")).isNull();
+  }
+
+  @Test
+  @DisplayName("should not store return_to when path has no leading slash")
+  void shouldNotStoreReturnToWhenPathHasNoLeadingSlash() {
+    delegate.login("evil.com");
+
+    assertThat(session.getAttribute("OIDC_RETURN_TO")).isNull();
+  }
+
+  @Test
+  @DisplayName("should always store OIDC_STATE and OIDC_NONCE regardless of return_to")
+  void shouldAlwaysStoreOidcStateAndNonce() {
+    delegate.login("/battle");
+
+    assertThat(session.getAttribute("OIDC_STATE")).isNotNull();
+    assertThat(session.getAttribute("OIDC_NONCE")).isNotNull();
+  }
+}

--- a/libs/bixarena/api-client-angular/src/lib/api/auth.service.ts
+++ b/libs/bixarena/api-client-angular/src/lib/api/auth.service.ts
@@ -423,10 +423,12 @@ export class AuthService {
   /**
    * Start Synapse OIDC authorization code flow
    * Initiates the OIDC login by redirecting the user to Synapse with state and nonce.
+   * @param returnTo Relative path to redirect to after login (e.g. /battle).
    * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
    * @param reportProgress flag to report request and response progress.
    */
   public login(
+    returnTo?: string,
     observe?: 'body',
     reportProgress?: boolean,
     options?: {
@@ -436,6 +438,7 @@ export class AuthService {
     },
   ): Observable<any>;
   public login(
+    returnTo?: string,
     observe?: 'response',
     reportProgress?: boolean,
     options?: {
@@ -445,6 +448,7 @@ export class AuthService {
     },
   ): Observable<HttpResponse<any>>;
   public login(
+    returnTo?: string,
     observe?: 'events',
     reportProgress?: boolean,
     options?: {
@@ -454,6 +458,7 @@ export class AuthService {
     },
   ): Observable<HttpEvent<any>>;
   public login(
+    returnTo?: string,
     observe: any = 'body',
     reportProgress: boolean = false,
     options?: {
@@ -462,6 +467,15 @@ export class AuthService {
       transferCache?: boolean;
     },
   ): Observable<any> {
+    let localVarQueryParameters = new HttpParams({ encoder: this.encoder });
+    if (returnTo !== undefined && returnTo !== null) {
+      localVarQueryParameters = this.addToHttpParams(
+        localVarQueryParameters,
+        <any>returnTo,
+        'return_to',
+      );
+    }
+
     let localVarHeaders = this.defaultHeaders;
 
     let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
@@ -498,6 +512,7 @@ export class AuthService {
     let localVarPath = `/auth/login`;
     return this.httpClient.request<any>('get', `${this.configuration.basePath}${localVarPath}`, {
       context: localVarHttpContext,
+      params: localVarQueryParameters,
       responseType: <any>responseType_,
       withCredentials: this.configuration.withCredentials,
       headers: localVarHeaders,

--- a/libs/bixarena/api-client-python/bixarena_api_client/api/admin_api.py
+++ b/libs/bixarena/api-client-python/bixarena_api_client/api/admin_api.py
@@ -261,6 +261,7 @@ class AdminApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -501,6 +502,7 @@ class AdminApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -758,6 +760,7 @@ class AdminApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1046,6 +1049,7 @@ class AdminApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1320,6 +1324,7 @@ class AdminApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1616,6 +1621,7 @@ class AdminApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1896,6 +1902,7 @@ class AdminApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -2186,6 +2193,7 @@ class AdminApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -2510,6 +2518,7 @@ class AdminApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}

--- a/libs/bixarena/api-client-python/bixarena_api_client/api/auth_api.py
+++ b/libs/bixarena/api-client-python/bixarena_api_client/api/auth_api.py
@@ -262,6 +262,7 @@ class AuthApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -503,6 +504,7 @@ class AuthApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -738,6 +740,7 @@ class AuthApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -784,6 +787,12 @@ class AuthApi:
     @validate_call
     def login(
         self,
+        return_to: Annotated[
+            Optional[Annotated[str, Field(strict=True, max_length=500)]],
+            Field(
+                description="Relative path to redirect to after login (e.g. /battle)."
+            ),
+        ] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -800,6 +809,8 @@ class AuthApi:
 
         Initiates the OIDC login by redirecting the user to Synapse with state and nonce.
 
+        :param return_to: Relative path to redirect to after login (e.g. /battle).
+        :type return_to: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -823,6 +834,7 @@ class AuthApi:
         """  # noqa: E501
 
         _param = self._login_serialize(
+            return_to=return_to,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -848,6 +860,12 @@ class AuthApi:
     @validate_call
     def login_with_http_info(
         self,
+        return_to: Annotated[
+            Optional[Annotated[str, Field(strict=True, max_length=500)]],
+            Field(
+                description="Relative path to redirect to after login (e.g. /battle)."
+            ),
+        ] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -864,6 +882,8 @@ class AuthApi:
 
         Initiates the OIDC login by redirecting the user to Synapse with state and nonce.
 
+        :param return_to: Relative path to redirect to after login (e.g. /battle).
+        :type return_to: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -887,6 +907,7 @@ class AuthApi:
         """  # noqa: E501
 
         _param = self._login_serialize(
+            return_to=return_to,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -912,6 +933,12 @@ class AuthApi:
     @validate_call
     def login_without_preload_content(
         self,
+        return_to: Annotated[
+            Optional[Annotated[str, Field(strict=True, max_length=500)]],
+            Field(
+                description="Relative path to redirect to after login (e.g. /battle)."
+            ),
+        ] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -928,6 +955,8 @@ class AuthApi:
 
         Initiates the OIDC login by redirecting the user to Synapse with state and nonce.
 
+        :param return_to: Relative path to redirect to after login (e.g. /battle).
+        :type return_to: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -951,6 +980,7 @@ class AuthApi:
         """  # noqa: E501
 
         _param = self._login_serialize(
+            return_to=return_to,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -971,11 +1001,13 @@ class AuthApi:
 
     def _login_serialize(
         self,
+        return_to,
         _request_auth,
         _content_type,
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -991,6 +1023,9 @@ class AuthApi:
 
         # process the path parameters
         # process the query parameters
+        if return_to is not None:
+            _query_params.append(("return_to", return_to))
+
         # process the header parameters
         # process the form parameters
         # process the body parameter
@@ -1211,6 +1246,7 @@ class AuthApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1465,6 +1501,7 @@ class AuthApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1725,6 +1762,7 @@ class AuthApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}

--- a/libs/bixarena/api-client-python/bixarena_api_client/api/battle_api.py
+++ b/libs/bixarena/api-client-python/bixarena_api_client/api/battle_api.py
@@ -293,6 +293,7 @@ class BattleApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -581,6 +582,7 @@ class BattleApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -871,6 +873,7 @@ class BattleApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1161,6 +1164,7 @@ class BattleApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1470,6 +1474,7 @@ class BattleApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1753,6 +1758,7 @@ class BattleApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -2027,6 +2033,7 @@ class BattleApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -2286,6 +2293,7 @@ class BattleApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -2545,6 +2553,7 @@ class BattleApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -2804,6 +2813,7 @@ class BattleApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -3066,6 +3076,7 @@ class BattleApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -3335,6 +3346,7 @@ class BattleApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -3600,6 +3612,7 @@ class BattleApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -3878,6 +3891,7 @@ class BattleApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -4165,6 +4179,7 @@ class BattleApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -4455,6 +4470,7 @@ class BattleApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -4764,6 +4780,7 @@ class BattleApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}

--- a/libs/bixarena/api-client-python/bixarena_api_client/api/chat_api.py
+++ b/libs/bixarena/api-client-python/bixarena_api_client/api/chat_api.py
@@ -246,6 +246,7 @@ class ChatApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}

--- a/libs/bixarena/api-client-python/bixarena_api_client/api/example_prompt_api.py
+++ b/libs/bixarena/api-client-python/bixarena_api_client/api/example_prompt_api.py
@@ -266,6 +266,7 @@ class ExamplePromptApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -551,6 +552,7 @@ class ExamplePromptApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -822,6 +824,7 @@ class ExamplePromptApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1078,6 +1081,7 @@ class ExamplePromptApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1337,6 +1341,7 @@ class ExamplePromptApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1602,6 +1607,7 @@ class ExamplePromptApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1868,6 +1874,7 @@ class ExamplePromptApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -2143,6 +2150,7 @@ class ExamplePromptApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -2433,6 +2441,7 @@ class ExamplePromptApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}

--- a/libs/bixarena/api-client-python/bixarena_api_client/api/leaderboard_api.py
+++ b/libs/bixarena/api-client-python/bixarena_api_client/api/leaderboard_api.py
@@ -292,6 +292,7 @@ class LeaderboardApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -585,6 +586,7 @@ class LeaderboardApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -897,6 +899,7 @@ class LeaderboardApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1142,6 +1145,7 @@ class LeaderboardApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}

--- a/libs/bixarena/api-client-python/bixarena_api_client/api/model_api.py
+++ b/libs/bixarena/api-client-python/bixarena_api_client/api/model_api.py
@@ -273,6 +273,7 @@ class ModelApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -544,6 +545,7 @@ class ModelApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}

--- a/libs/bixarena/api-client-python/bixarena_api_client/api/quest_api.py
+++ b/libs/bixarena/api-client-python/bixarena_api_client/api/quest_api.py
@@ -259,6 +259,7 @@ class QuestApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -547,6 +548,7 @@ class QuestApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -821,6 +823,7 @@ class QuestApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1117,6 +1120,7 @@ class QuestApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1375,6 +1379,7 @@ class QuestApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1675,6 +1680,7 @@ class QuestApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -1959,6 +1965,7 @@ class QuestApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -2249,6 +2256,7 @@ class QuestApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}
@@ -2573,6 +2581,7 @@ class QuestApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}

--- a/libs/bixarena/api-client-python/bixarena_api_client/api/stats_api.py
+++ b/libs/bixarena/api-client-python/bixarena_api_client/api/stats_api.py
@@ -224,6 +224,7 @@ class StatsApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}

--- a/libs/bixarena/api-client-python/bixarena_api_client/api/user_api.py
+++ b/libs/bixarena/api-client-python/bixarena_api_client/api/user_api.py
@@ -227,6 +227,7 @@ class UserApi:
         _headers,
         _host_index,
     ) -> RequestSerialized:
+
         _host = None
 
         _collection_formats: Dict[str, str] = {}

--- a/libs/bixarena/api-client-python/docs/AuthApi.md
+++ b/libs/bixarena/api-client-python/docs/AuthApi.md
@@ -229,7 +229,7 @@ This endpoint does not need any parameter.
 
 # **login**
 
-> login()
+> login(return_to=return_to)
 
 Start Synapse OIDC authorization code flow
 
@@ -253,17 +253,20 @@ configuration = bixarena_api_client.Configuration(
 with bixarena_api_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = bixarena_api_client.AuthApi(api_client)
+    return_to = 'return_to_example' # str | Relative path to redirect to after login (e.g. /battle). (optional)
 
     try:
         # Start Synapse OIDC authorization code flow
-        api_instance.login()
+        api_instance.login(return_to=return_to)
     except Exception as e:
         print("Exception when calling AuthApi->login: %s\n" % e)
 ```
 
 ### Parameters
 
-This endpoint does not need any parameter.
+| Name          | Type    | Description                                              | Notes      |
+| ------------- | ------- | -------------------------------------------------------- | ---------- |
+| **return_to** | **str** | Relative path to redirect to after login (e.g. /battle). | [optional] |
 
 ### Return type
 

--- a/libs/bixarena/api-description/openapi/auth-public.openapi.yaml
+++ b/libs/bixarena/api-description/openapi/auth-public.openapi.yaml
@@ -27,6 +27,14 @@ paths:
       description: Initiates the OIDC login by redirecting the user to Synapse with state and nonce.
       operationId: login
       security: []
+      parameters:
+        - name: return_to
+          in: query
+          required: false
+          description: Relative path to redirect to after login (e.g. /battle).
+          schema:
+            type: string
+            maxLength: 500
       responses:
         '204':
           description: Flow started (no content; clients should follow redirect)

--- a/libs/bixarena/api-description/openapi/auth-service.openapi.yaml
+++ b/libs/bixarena/api-description/openapi/auth-service.openapi.yaml
@@ -27,6 +27,14 @@ paths:
       description: Initiates the OIDC login by redirecting the user to Synapse with state and nonce.
       operationId: login
       security: []
+      parameters:
+        - name: return_to
+          in: query
+          required: false
+          description: Relative path to redirect to after login (e.g. /battle).
+          schema:
+            type: string
+            maxLength: 500
       responses:
         '204':
           description: Flow started (no content; clients should follow redirect)

--- a/libs/bixarena/api-description/openapi/openapi.yaml
+++ b/libs/bixarena/api-description/openapi/openapi.yaml
@@ -1523,6 +1523,14 @@ paths:
       description: Initiates the OIDC login by redirecting the user to Synapse with state and nonce.
       operationId: login
       security: []
+      parameters:
+        - name: return_to
+          in: query
+          required: false
+          description: Relative path to redirect to after login (e.g. /battle).
+          schema:
+            type: string
+            maxLength: 500
       responses:
         '204':
           description: Flow started (no content; clients should follow redirect)

--- a/libs/bixarena/api-description/src/paths/auth-login.yaml
+++ b/libs/bixarena/api-description/src/paths/auth-login.yaml
@@ -7,6 +7,14 @@ get:
   description: Initiates the OIDC login by redirecting the user to Synapse with state and nonce.
   operationId: login
   security: []
+  parameters:
+    - name: return_to
+      in: query
+      required: false
+      description: Relative path to redirect to after login (e.g. /battle).
+      schema:
+        type: string
+        maxLength: 500
   responses:
     '204':
       description: Flow started (no content; clients should follow redirect)

--- a/libs/bixarena/home/src/lib/home.component.ts
+++ b/libs/bixarena/home/src/lib/home.component.ts
@@ -1,7 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, OnInit, PLATFORM_ID } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
-import { Router } from '@angular/router';
-import { AuthService, BattleGateService } from '@sagebionetworks/bixarena/services';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { BlueprintBgComponent, HeroComponent } from '@sagebionetworks/bixarena/ui';
 import { ComposerSectionComponent } from './composer-section/composer-section.component';
 import { LeaderboardSectionComponent } from './leaderboard-section/leaderboard-section.component';
@@ -22,21 +19,4 @@ import { TrendingSectionComponent } from './trending-section/trending-section.co
   styleUrl: './home.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class HomeComponent implements OnInit {
-  private readonly auth = inject(AuthService);
-  private readonly gate = inject(BattleGateService);
-  private readonly router = inject(Router);
-  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
-
-  // OIDC always lands users back on /. Resume the round-trip when a pending
-  // prompt is waiting; drop stale pending if they came back unauthenticated
-  // (failed/abandoned login) so the next sign-in won't surprise-redirect.
-  ngOnInit(): void {
-    if (!this.isBrowser || !this.gate.hasPendingPrompt()) return;
-    if (this.auth.isAuthenticated()) {
-      void this.router.navigate(['/battle']);
-    } else {
-      this.gate.clearPending();
-    }
-  }
-}
+export class HomeComponent {}

--- a/libs/bixarena/services/src/lib/auth.service.ts
+++ b/libs/bixarena/services/src/lib/auth.service.ts
@@ -42,9 +42,10 @@ export class AuthService {
     }
   }
 
-  login(): void {
+  login(returnTo?: string): void {
     if (!this.isBrowser) return;
-    window.location.href = `${this.authUrl}/auth/login`;
+    const base = `${this.authUrl}/auth/login`;
+    window.location.href = returnTo ? `${base}?return_to=${encodeURIComponent(returnTo)}` : base;
   }
 
   // Only clears local state after server confirms session invalidation.

--- a/libs/bixarena/services/src/lib/battle-gate.service.spec.ts
+++ b/libs/bixarena/services/src/lib/battle-gate.service.spec.ts
@@ -36,7 +36,7 @@ describe('BattleGateService', () => {
       service.showLoginModal.set(true);
       service.onLoginComplete();
       expect(service.showLoginModal()).toBe(false);
-      expect(authService.login).toHaveBeenCalled();
+      expect(authService.login).toHaveBeenCalledWith('/battle');
     });
   });
 

--- a/libs/bixarena/services/src/lib/battle-gate.service.ts
+++ b/libs/bixarena/services/src/lib/battle-gate.service.ts
@@ -35,12 +35,9 @@ export class BattleGateService {
 
   readonly showLoginModal = signal(false);
 
-  // The home route guard picks up pending and routes to /battle after OIDC
-  // returns to /. If auth-service ever supports a dynamic post-login URL,
-  // we can route from here directly and skip the / hop.
   onLoginComplete(): void {
     this.showLoginModal.set(false);
-    this.authService.login();
+    this.authService.login('/battle');
   }
 
   onLoginCancel(): void {


### PR DESCRIPTION
## Description

After a successful OIDC login, users were always redirected to the root (`/`), requiring a client-side hop from home to `/battle` to resume an in-progress action. This PR implements server-side post-login redirect by adding an optional `return_to` query parameter to `GET /auth/login`. The auth service stores the validated relative path in the OIDC session and redirects directly to it after the OAuth callback, eliminating the round-trip through `/` and the brittle `HomeComponent.ngOnInit` workaround it required.

## Changelog

- Add optional `return_to` query param to `GET /auth/login` OpenAPI spec and regenerate clients
- Implement server-side post-login redirect via `OIDC_RETURN_TO` session attribute in the Java auth service
- Validate `return_to` to reject absolute URLs and open-redirect attack vectors (relative paths only)
- Wire `return_to` through Angular `AuthService.login()` and `BattleGateService`, passing `/battle` as the post-login destination
- Clear `OIDC_RETURN_TO` in both the success and error callback paths
- Remove `HomeComponent.ngOnInit` workaround that performed a client-side `/` → `/battle` hop post-login
- Add unit tests for `isSafeReturnTo()` covering valid paths, absolute URLs, protocol-relative URLs, and scheme injection