### PR TITLE
feat(bixarena): add GA4 analytics event tracking (SMR-774)

### DIFF
--- a/libs/bixarena/battle/src/lib/battle.component.spec.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.spec.ts
@@ -92,7 +92,7 @@ describe('BattleComponent', () => {
     fixture.detectChanges();
     await Promise.resolve();
 
-    expect(submitSpy).toHaveBeenCalledWith('hello biomedical world', null);
+    expect(submitSpy).toHaveBeenCalledWith('hello biomedical world', null, undefined);
     expect(gate.consumePendingPrompt()).toBeNull();
   });
 
@@ -106,7 +106,7 @@ describe('BattleComponent', () => {
     fixture.detectChanges();
     await Promise.resolve();
 
-    expect(submitSpy).toHaveBeenCalledWith('curated question', 'ep-99');
+    expect(submitSpy).toHaveBeenCalledWith('curated question', 'ep-99', undefined);
     expect(gate.consumePendingPrompt()).toBeNull();
   });
 
@@ -128,7 +128,7 @@ describe('BattleComponent', () => {
     await Promise.resolve();
 
     expect(component.showOnboardingModal()).toBe(false);
-    expect(submitSpy).toHaveBeenCalledWith('deferred prompt', 'ep-1');
+    expect(submitSpy).toHaveBeenCalledWith('deferred prompt', 'ep-1', undefined);
     expect(onboarding.hasSeen()).toBe(true);
   });
 

--- a/libs/bixarena/battle/src/lib/battle.component.ts
+++ b/libs/bixarena/battle/src/lib/battle.component.ts
@@ -55,16 +55,20 @@ export class BattleComponent implements OnInit, OnDestroy {
       this.pendingPrompt = pending;
       this.showOnboardingModal.set(true);
     } else if (pending) {
-      void this.state.submitPrompt(pending.prompt, pending.examplePromptId);
+      void this.state.submitPrompt(
+        pending.prompt,
+        pending.examplePromptId,
+        pending.entryPoint ?? undefined,
+      );
     }
   }
 
   onPromptSubmit(prompt: string): void {
-    void this.state.submitPrompt(prompt);
+    void this.state.submitPrompt(prompt, null, 'battle_composer');
   }
 
   onExamplePromptSelect(event: { question: string; examplePromptId: string }): void {
-    void this.state.submitPrompt(event.question, event.examplePromptId);
+    void this.state.submitPrompt(event.question, event.examplePromptId, 'battle_example_card');
   }
 
   onFollowUpSubmit(prompt: string): void {
@@ -89,7 +93,11 @@ export class BattleComponent implements OnInit, OnDestroy {
     const pending = this.pendingPrompt;
     this.pendingPrompt = null;
     if (pending) {
-      void this.state.submitPrompt(pending.prompt, pending.examplePromptId);
+      void this.state.submitPrompt(
+        pending.prompt,
+        pending.examplePromptId,
+        pending.entryPoint ?? undefined,
+      );
     }
   }
 

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -7,6 +7,7 @@ import {
   Model,
 } from '@sagebionetworks/bixarena/api-client';
 import { ConfigService } from '@sagebionetworks/bixarena/config';
+import { AnalyticsService, BattleEntryPoint } from '@sagebionetworks/bixarena/services';
 import { BattlePhase, INITIAL_STREAM_STATE, ModelStreamState } from '../battle.types';
 import {
   CONTINUE_PROMPT,
@@ -23,6 +24,7 @@ export class BattleStateService {
   private readonly battleApi = inject(BattleApiService);
   private readonly streamService = inject(BattleStreamService);
   private readonly config = inject(ConfigService).config;
+  private readonly analytics = inject(AnalyticsService);
 
   constructor() {
     inject(DestroyRef).onDestroy(() => {
@@ -98,7 +100,11 @@ export class BattleStateService {
   private isVoting = false;
   private examplePromptId: string | null = null;
 
-  async submitPrompt(prompt: string, examplePromptId?: string | null): Promise<void> {
+  async submitPrompt(
+    prompt: string,
+    examplePromptId?: string | null,
+    entryPoint?: BattleEntryPoint,
+  ): Promise<void> {
     if (!this.isBrowser) return;
     this.initialPrompt.set(prompt);
     this.lastPrompt.set(prompt);
@@ -126,6 +132,11 @@ export class BattleStateService {
     this.battleId.set(battle.id);
     this.model1.set(battle.model1);
     this.model2.set(battle.model2);
+    this.analytics.trackBattleStarted(
+      battle.id,
+      entryPoint ?? 'battle_composer',
+      !!examplePromptId,
+    );
     try {
       await this.createRoundAndStream(battle.id, battle.model1.id, battle.model2.id, prompt);
     } catch (err) {
@@ -203,6 +214,7 @@ export class BattleStateService {
     );
     try {
       await this.createRoundAndStream(battleId, model1.id, model2.id, prompt);
+      this.analytics.trackFollowupQuestionSubmitted(battleId, this.completedRounds + 1);
     } catch (err) {
       console.error('Failed to create follow-up round', err);
       this.setStreamError('Something went wrong', true);
@@ -241,6 +253,7 @@ export class BattleStateService {
     this.battleId.set(battle.id);
     this.model1.set(battle.model1);
     this.model2.set(battle.model2);
+    this.analytics.trackBattleStarted(battle.id, 'new_matchup_button', !!this.examplePromptId);
     try {
       await this.createRoundAndStream(battle.id, battle.model1.id, battle.model2.id, prompt);
     } catch (err) {
@@ -277,6 +290,7 @@ export class BattleStateService {
       return;
     }
 
+    this.analytics.trackVoteSubmitted(battleId, outcome, this.completedRounds);
     this.selectedOutcome.set(outcome);
     this.promptUsesRemaining.update((n) => Math.max(0, n - 1));
     this.phase.set('validating');

--- a/libs/bixarena/home/src/lib/composer-section/composer-section.component.ts
+++ b/libs/bixarena/home/src/lib/composer-section/composer-section.component.ts
@@ -106,7 +106,7 @@ export class ComposerSectionComponent implements OnInit {
   }
 
   onPromptSubmit(prompt: string): void {
-    this.gate.savePendingPrompt(prompt);
+    this.gate.savePendingPrompt(prompt, null, 'home_composer');
     if (this.auth.isAuthenticated()) {
       void this.router.navigate(['/battle']);
     } else {

--- a/libs/bixarena/home/src/lib/composer-section/composer-section.component.ts
+++ b/libs/bixarena/home/src/lib/composer-section/composer-section.component.ts
@@ -110,6 +110,7 @@ export class ComposerSectionComponent implements OnInit {
     if (this.auth.isAuthenticated()) {
       void this.router.navigate(['/battle']);
     } else {
+      this.gate.setLoginEntryPoint('home_composer');
       this.gate.showLoginModal.set(true);
     }
   }

--- a/libs/bixarena/home/src/lib/leaderboard-section/leaderboard-section.component.ts
+++ b/libs/bixarena/home/src/lib/leaderboard-section/leaderboard-section.component.ts
@@ -18,7 +18,7 @@ import {
   LeaderboardListInner,
   LeaderboardService,
 } from '@sagebionetworks/bixarena/api-client';
-import { ModelOrgLogoService } from '@sagebionetworks/bixarena/services';
+import { AnalyticsService, ModelOrgLogoService } from '@sagebionetworks/bixarena/services';
 import { AvatarComponent } from '@sagebionetworks/bixarena/ui';
 import { TooltipModule } from 'primeng/tooltip';
 import { LEADERBOARD_COLUMN_COUNT, LOOKBACK_DAYS } from '../home.constants';
@@ -53,6 +53,7 @@ interface RenderedEntry {
 export class LeaderboardSectionComponent implements OnInit {
   private readonly leaderboardApi = inject(LeaderboardService);
   private readonly orgLogo = inject(ModelOrgLogoService);
+  private readonly analytics = inject(AnalyticsService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
@@ -110,6 +111,8 @@ export class LeaderboardSectionComponent implements OnInit {
             if (columns.length < LEADERBOARD_COLUMN_COUNT) return;
             this.columnsSignal.set(columns);
             this.hidden.set(false);
+            const totalEntries = columns.reduce((sum, c) => sum + c.entries.length, 0);
+            this.analytics.trackLeaderboardViewed('home_preview', totalEntries, 'home_section');
           });
       });
   }

--- a/libs/bixarena/home/src/lib/trending-section/trending-section.component.ts
+++ b/libs/bixarena/home/src/lib/trending-section/trending-section.component.ts
@@ -97,6 +97,7 @@ export class TrendingSectionComponent implements OnInit {
     if (this.auth.isAuthenticated()) {
       void this.router.navigate(['/battle']);
     } else {
+      this.gate.setLoginEntryPoint('home_trending_card');
       this.gate.showLoginModal.set(true);
     }
   }
@@ -105,6 +106,7 @@ export class TrendingSectionComponent implements OnInit {
     if (this.auth.isAuthenticated()) {
       void this.router.navigate(['/battle']);
     } else {
+      this.gate.setLoginEntryPoint('home_ask_own_button');
       this.gate.showLoginModal.set(true);
     }
   }

--- a/libs/bixarena/home/src/lib/trending-section/trending-section.component.ts
+++ b/libs/bixarena/home/src/lib/trending-section/trending-section.component.ts
@@ -93,7 +93,7 @@ export class TrendingSectionComponent implements OnInit {
   }
 
   onCardClick(p: ExamplePrompt): void {
-    this.gate.savePendingPrompt(p.question, p.id);
+    this.gate.savePendingPrompt(p.question, p.id, 'home_trending_card');
     if (this.auth.isAuthenticated()) {
       void this.router.navigate(['/battle']);
     } else {

--- a/libs/bixarena/leaderboard/src/lib/leaderboard.component.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard.component.ts
@@ -6,6 +6,7 @@ import {
   LeaderboardSort,
   SortDirection,
 } from '@sagebionetworks/bixarena/api-client';
+import { AnalyticsService } from '@sagebionetworks/bixarena/services';
 import { HeroComponent } from '@sagebionetworks/bixarena/ui';
 import { LeaderboardFacadeService } from './services/leaderboard.service';
 import {
@@ -52,6 +53,7 @@ const SORT_FIELD_MAP: Record<LeaderboardSortField, LeaderboardSort> = {
 })
 export class LeaderboardComponent {
   readonly facade = inject(LeaderboardFacadeService);
+  private readonly analytics = inject(AnalyticsService);
 
   readonly activeCategoryId = signal<string>(DEFAULT_CATEGORY_SLUG);
   readonly searchTerm = signal('');
@@ -98,7 +100,16 @@ export class LeaderboardComponent {
     void this.facade.loadLeaderboards();
 
     effect(() => {
-      void this.facade.load(this.activeCategoryId(), this.query());
+      const categoryId = this.activeCategoryId();
+      const q = this.query();
+      this.facade
+        .load(categoryId, q)
+        .then(() => {
+          if (!this.facade.error()) {
+            this.analytics.trackLeaderboardViewed(categoryId, this.facade.entryCount());
+          }
+        })
+        .catch(() => undefined);
     });
 
     inject(DestroyRef).onDestroy(() => {
@@ -116,11 +127,16 @@ export class LeaderboardComponent {
   }
 
   onFiltersChange(filters: LeaderboardFilters): void {
+    const old = this.filters();
+    if (filters.license !== old.license) {
+      this.analytics.trackLeaderboardFilterChanged('license', String(filters.license ?? 'all'));
+    }
     this.filters.set(filters);
     this.pageFirst.set(0);
   }
 
   onCategoryChange(id: string): void {
+    this.analytics.trackLeaderboardFilterChanged('category', id);
     this.activeCategoryId.set(id);
     this.pageFirst.set(0);
   }
@@ -141,6 +157,7 @@ export class LeaderboardComponent {
   }
 
   onViewChange(next: LeaderboardView): void {
+    this.analytics.trackLeaderboardFilterChanged('view', next);
     this.view.set(next);
   }
 }

--- a/libs/bixarena/leaderboard/src/lib/leaderboard.component.ts
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard.component.ts
@@ -54,6 +54,7 @@ const SORT_FIELD_MAP: Record<LeaderboardSortField, LeaderboardSort> = {
 export class LeaderboardComponent {
   readonly facade = inject(LeaderboardFacadeService);
   private readonly analytics = inject(AnalyticsService);
+  private hasTrackedView = false;
 
   readonly activeCategoryId = signal<string>(DEFAULT_CATEGORY_SLUG);
   readonly searchTerm = signal('');
@@ -105,7 +106,8 @@ export class LeaderboardComponent {
       this.facade
         .load(categoryId, q)
         .then(() => {
-          if (!this.facade.error()) {
+          if (!this.facade.error() && !this.hasTrackedView) {
+            this.hasTrackedView = true;
             this.analytics.trackLeaderboardViewed(categoryId, this.facade.entryCount());
           }
         })
@@ -127,10 +129,6 @@ export class LeaderboardComponent {
   }
 
   onFiltersChange(filters: LeaderboardFilters): void {
-    const old = this.filters();
-    if (filters.license !== old.license) {
-      this.analytics.trackLeaderboardFilterChanged('license', String(filters.license ?? 'all'));
-    }
     this.filters.set(filters);
     this.pageFirst.set(0);
   }

--- a/libs/bixarena/services/src/index.ts
+++ b/libs/bixarena/services/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/analytics.service';
 export * from './lib/auth.guard';
 export * from './lib/auth.service';
 export * from './lib/battle-gate.service';

--- a/libs/bixarena/services/src/lib/analytics.service.ts
+++ b/libs/bixarena/services/src/lib/analytics.service.ts
@@ -126,10 +126,7 @@ export class AnalyticsService {
     });
   }
 
-  trackLeaderboardFilterChanged(
-    filterType: 'category' | 'license' | 'view',
-    filterValue: string,
-  ): void {
+  trackLeaderboardFilterChanged(filterType: 'category' | 'view', filterValue: string): void {
     this.push('leaderboard_filter_changed', {
       filter_type: filterType,
       filter_value: filterValue,

--- a/libs/bixarena/services/src/lib/analytics.service.ts
+++ b/libs/bixarena/services/src/lib/analytics.service.ts
@@ -1,0 +1,125 @@
+import { Injectable, inject } from '@angular/core';
+import { GoogleTagManagerService } from 'angular-google-tag-manager';
+import { BattleEvaluationOutcome } from '@sagebionetworks/bixarena/api-client';
+
+export type LoginEntryPoint =
+  | 'nav_login_button'
+  | 'home_composer'
+  | 'home_trending_card'
+  | 'home_ask_own_button'
+  | 'nav_battle_link';
+
+export type BattleEntryPoint =
+  | 'home_composer'
+  | 'home_trending_card'
+  | 'battle_composer'
+  | 'battle_example_card'
+  | 'new_matchup_button';
+
+const OUTCOME_MAP: Record<BattleEvaluationOutcome, string> = {
+  model1: 'model_a',
+  model2: 'model_b',
+  tie: 'tie',
+};
+
+@Injectable({ providedIn: 'root' })
+export class AnalyticsService {
+  private readonly gtm = inject(GoogleTagManagerService, { optional: true });
+
+  private push(event: string, params?: Record<string, unknown>): void {
+    this.gtm?.pushTag({ event, ...params }).catch(() => undefined);
+  }
+
+  trackLoginInitiated(entryPoint: LoginEntryPoint): void {
+    this.push('login_initiated', { entry_point: entryPoint });
+  }
+
+  trackLogin(entryPoint?: string): void {
+    this.push('login', {
+      method: 'synapse_oauth',
+      ...(entryPoint ? { entry_point: entryPoint } : {}),
+    });
+  }
+
+  trackLogout(): void {
+    this.push('logout');
+  }
+
+  trackOnboardingViewed(): void {
+    this.push('onboarding_viewed');
+  }
+
+  trackOnboardingCompleted(): void {
+    this.push('onboarding_completed');
+  }
+
+  trackOnboardingDismissed(stepIndex: number): void {
+    this.push('onboarding_dismissed', { step_index: stepIndex });
+  }
+
+  trackOnboardingReopened(): void {
+    this.push('onboarding_reopened');
+  }
+
+  trackBattleStarted(
+    battleId: string,
+    entryPoint: BattleEntryPoint,
+    useExamplePrompt: boolean,
+  ): void {
+    this.push('battle_started', {
+      battle_id: battleId,
+      entry_point: entryPoint,
+      use_example_prompt: useExamplePrompt,
+    });
+  }
+
+  trackSelectContent(contentType: 'trending_prompt' | 'example_prompt', itemId: string): void {
+    this.push('select_content', { content_type: contentType, item_id: itemId });
+  }
+
+  trackVoteSubmitted(
+    battleId: string,
+    outcome: BattleEvaluationOutcome,
+    roundNumber: number,
+  ): void {
+    this.push('vote_submitted', {
+      battle_id: battleId,
+      vote_choice: OUTCOME_MAP[outcome],
+      round_number: roundNumber,
+    });
+  }
+
+  trackFollowupQuestionSubmitted(
+    battleId: string,
+    roundNumber: number,
+    questionLengthChars: number,
+  ): void {
+    this.push('followup_question_submitted', {
+      battle_id: battleId,
+      round_number: roundNumber,
+      question_length_chars: questionLengthChars,
+    });
+  }
+
+  trackLeaderboardViewed(
+    activeCategory: string,
+    modelCount: number,
+    entryPoint?: 'home_section',
+  ): void {
+    this.push('leaderboard_viewed', {
+      active_category: activeCategory,
+      model_count: modelCount,
+      ...(entryPoint ? { entry_point: entryPoint } : {}),
+    });
+  }
+
+  trackLeaderboardFilterChanged(
+    filterType: 'category' | 'license' | 'view',
+    filterValue: string,
+  ): void {
+    this.push('leaderboard_filter_changed', {
+      filter_type: filterType,
+      filter_value: filterValue,
+    });
+  }
+}

--- a/libs/bixarena/services/src/lib/analytics.service.ts
+++ b/libs/bixarena/services/src/lib/analytics.service.ts
@@ -22,6 +22,8 @@ const OUTCOME_MAP: Record<BattleEvaluationOutcome, string> = {
   tie: 'tie',
 };
 
+const LOGIN_ENTRY_POINT_KEY = 'bixarena.loginEntryPoint';
+
 @Injectable({ providedIn: 'root' })
 export class AnalyticsService {
   private readonly gtm = inject(GoogleTagManagerService, { optional: true });
@@ -30,11 +32,31 @@ export class AnalyticsService {
     this.gtm?.pushTag({ event, ...params }).catch(() => undefined);
   }
 
+  private saveLoginEntryPoint(entryPoint: LoginEntryPoint): void {
+    try {
+      sessionStorage.setItem(LOGIN_ENTRY_POINT_KEY, entryPoint);
+    } catch {
+      /* private mode / SSR */
+    }
+  }
+
+  private consumeLoginEntryPoint(): string | null {
+    try {
+      const value = sessionStorage.getItem(LOGIN_ENTRY_POINT_KEY);
+      sessionStorage.removeItem(LOGIN_ENTRY_POINT_KEY);
+      return value;
+    } catch {
+      return null;
+    }
+  }
+
   trackLoginInitiated(entryPoint: LoginEntryPoint): void {
+    this.saveLoginEntryPoint(entryPoint);
     this.push('login_initiated', { entry_point: entryPoint });
   }
 
-  trackLogin(entryPoint?: string): void {
+  trackLogin(): void {
+    const entryPoint = this.consumeLoginEntryPoint();
     this.push('login', {
       method: 'synapse_oauth',
       ...(entryPoint ? { entry_point: entryPoint } : {}),

--- a/libs/bixarena/services/src/lib/analytics.service.ts
+++ b/libs/bixarena/services/src/lib/analytics.service.ts
@@ -95,10 +95,6 @@ export class AnalyticsService {
     });
   }
 
-  trackSelectContent(contentType: 'trending_prompt' | 'example_prompt', itemId: string): void {
-    this.push('select_content', { content_type: contentType, item_id: itemId });
-  }
-
   trackVoteSubmitted(
     battleId: string,
     outcome: BattleEvaluationOutcome,
@@ -111,15 +107,10 @@ export class AnalyticsService {
     });
   }
 
-  trackFollowupQuestionSubmitted(
-    battleId: string,
-    roundNumber: number,
-    questionLengthChars: number,
-  ): void {
+  trackFollowupQuestionSubmitted(battleId: string, roundNumber: number): void {
     this.push('followup_question_submitted', {
       battle_id: battleId,
       round_number: roundNumber,
-      question_length_chars: questionLengthChars,
     });
   }
 

--- a/libs/bixarena/services/src/lib/auth.guard.ts
+++ b/libs/bixarena/services/src/lib/auth.guard.ts
@@ -8,7 +8,9 @@ export const authGuard: CanActivateFn = () => {
   const auth = inject(AuthService);
   if (auth.isAuthenticated()) return true;
   if (isPlatformBrowser(inject(PLATFORM_ID))) {
-    inject(BattleGateService).showLoginModal.set(true);
+    const gate = inject(BattleGateService);
+    gate.setLoginEntryPoint('nav_battle_link');
+    gate.showLoginModal.set(true);
   }
   return false;
 };

--- a/libs/bixarena/services/src/lib/auth.service.ts
+++ b/libs/bixarena/services/src/lib/auth.service.ts
@@ -4,6 +4,7 @@ import { LocalStorageService } from '@sagebionetworks/web-shared/angular/storage
 import { ConfigService } from '@sagebionetworks/bixarena/config';
 import { UserInfo } from '@sagebionetworks/bixarena/api-client';
 import { clearPendingPromptStorage } from './battle-gate.service';
+import { AnalyticsService } from './analytics.service';
 
 export interface CachedUser {
   username: string;
@@ -17,6 +18,7 @@ export class AuthService {
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
   private readonly storage = inject(LocalStorageService);
   private readonly configService = inject(ConfigService);
+  private readonly analytics = inject(AnalyticsService);
 
   readonly user = signal<UserInfo | null>(null);
   readonly isAuthenticated = computed(() => this.user() !== null);
@@ -28,12 +30,16 @@ export class AuthService {
 
   async init(): Promise<void> {
     if (!this.isBrowser) return;
+    const wasAuthenticated = this.cachedUser() !== null;
     try {
       const res = await fetch('/userinfo');
       if (res.ok) {
         const user: UserInfo = await res.json();
         this.user.set(user);
         this.saveCache({ username: user.preferred_username ?? '', avatarUrl: user.avatar_url });
+        if (!wasAuthenticated) {
+          this.analytics.trackLogin();
+        }
       } else {
         this.clearCache();
       }
@@ -61,6 +67,7 @@ export class AuthService {
     this.user.set(null);
     this.clearCache();
     clearPendingPromptStorage();
+    this.analytics.trackLogout();
     window.location.href = '/';
   }
 

--- a/libs/bixarena/services/src/lib/battle-gate.service.spec.ts
+++ b/libs/bixarena/services/src/lib/battle-gate.service.spec.ts
@@ -61,6 +61,7 @@ describe('BattleGateService', () => {
       expect(service.consumePendingPrompt()).toEqual({
         prompt: 'hello world',
         examplePromptId: null,
+        entryPoint: null,
       });
       expect(service.consumePendingPrompt()).toBeNull();
     });
@@ -70,6 +71,7 @@ describe('BattleGateService', () => {
       expect(service.consumePendingPrompt()).toEqual({
         prompt: 'curated question',
         examplePromptId: 'ep-42',
+        entryPoint: null,
       });
     });
 
@@ -79,6 +81,7 @@ describe('BattleGateService', () => {
       expect(service.consumePendingPrompt()).toEqual({
         prompt: 'second',
         examplePromptId: null,
+        entryPoint: null,
       });
     });
 

--- a/libs/bixarena/services/src/lib/battle-gate.service.ts
+++ b/libs/bixarena/services/src/lib/battle-gate.service.ts
@@ -1,10 +1,11 @@
 import { inject, Injectable, PLATFORM_ID, signal } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { AuthService } from './auth.service';
-import { AnalyticsService, LoginEntryPoint } from './analytics.service';
+import { AnalyticsService, BattleEntryPoint, LoginEntryPoint } from './analytics.service';
 
 const PENDING_PROMPT_KEY = 'bixarena.pendingPrompt';
 const PENDING_EXAMPLE_PROMPT_ID_KEY = 'bixarena.pendingExamplePromptId';
+const PENDING_PROMPT_ENTRY_POINT_KEY = 'bixarena.pendingPromptEntryPoint';
 const PENDING_PROMPT_TS_KEY = 'bixarena.pendingPromptTs';
 const PENDING_PROMPT_OWNER_KEY = 'bixarena.pendingPromptOwner';
 const PENDING_PROMPT_TTL_MS = 15 * 60 * 1000;
@@ -13,6 +14,7 @@ const PENDING_PROMPT_MAX_LENGTH = 5000;
 export interface PendingPrompt {
   prompt: string;
   examplePromptId: string | null;
+  entryPoint: BattleEntryPoint | null;
 }
 
 // Module-level helper so AuthService.logout can clear pending without
@@ -22,6 +24,7 @@ export function clearPendingPromptStorage(): void {
   try {
     sessionStorage.removeItem(PENDING_PROMPT_KEY);
     sessionStorage.removeItem(PENDING_EXAMPLE_PROMPT_ID_KEY);
+    sessionStorage.removeItem(PENDING_PROMPT_ENTRY_POINT_KEY);
     sessionStorage.removeItem(PENDING_PROMPT_TS_KEY);
     sessionStorage.removeItem(PENDING_PROMPT_OWNER_KEY);
   } catch {
@@ -61,7 +64,11 @@ export class BattleGateService {
   // Stamp owner from cachedUser when known so a different user logging in
   // on the same browser can't inherit this prompt. cachedUser is null for
   // first-time visitors — accepted, the TTL is the only defense in that case.
-  savePendingPrompt(text: string, examplePromptId?: string | null): void {
+  savePendingPrompt(
+    text: string,
+    examplePromptId?: string | null,
+    entryPoint?: BattleEntryPoint,
+  ): void {
     if (!this.isBrowser) return;
     const trimmed = text.trim();
     if (!trimmed) return;
@@ -78,6 +85,11 @@ export class BattleGateService {
         sessionStorage.setItem(PENDING_EXAMPLE_PROMPT_ID_KEY, examplePromptId);
       } else {
         sessionStorage.removeItem(PENDING_EXAMPLE_PROMPT_ID_KEY);
+      }
+      if (entryPoint) {
+        sessionStorage.setItem(PENDING_PROMPT_ENTRY_POINT_KEY, entryPoint);
+      } else {
+        sessionStorage.removeItem(PENDING_PROMPT_ENTRY_POINT_KEY);
       }
     } catch {
       /* private mode / quota — fail silent */
@@ -96,8 +108,11 @@ export class BattleGateService {
       return null;
     }
     const examplePromptId = sessionStorage.getItem(PENDING_EXAMPLE_PROMPT_ID_KEY);
+    const entryPoint = sessionStorage.getItem(
+      PENDING_PROMPT_ENTRY_POINT_KEY,
+    ) as BattleEntryPoint | null;
     this.clearPending();
-    return { prompt: valid, examplePromptId: examplePromptId || null };
+    return { prompt: valid, examplePromptId: examplePromptId || null, entryPoint };
   }
 
   // Public so guards / logout can drop stale state explicitly.

--- a/libs/bixarena/services/src/lib/battle-gate.service.ts
+++ b/libs/bixarena/services/src/lib/battle-gate.service.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable, PLATFORM_ID, signal } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { AuthService } from './auth.service';
+import { AnalyticsService, LoginEntryPoint } from './analytics.service';
 
 const PENDING_PROMPT_KEY = 'bixarena.pendingPrompt';
 const PENDING_EXAMPLE_PROMPT_ID_KEY = 'bixarena.pendingExamplePromptId';
@@ -31,17 +32,29 @@ export function clearPendingPromptStorage(): void {
 @Injectable({ providedIn: 'root' })
 export class BattleGateService {
   readonly authService = inject(AuthService);
+  private readonly analytics = inject(AnalyticsService);
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   readonly showLoginModal = signal(false);
+  private readonly loginEntryPoint = signal<LoginEntryPoint | null>(null);
+
+  setLoginEntryPoint(entryPoint: LoginEntryPoint): void {
+    this.loginEntryPoint.set(entryPoint);
+  }
 
   onLoginComplete(): void {
     this.showLoginModal.set(false);
+    const entryPoint = this.loginEntryPoint();
+    this.loginEntryPoint.set(null);
+    if (entryPoint) {
+      this.analytics.trackLoginInitiated(entryPoint);
+    }
     this.authService.login('/battle');
   }
 
   onLoginCancel(): void {
     this.showLoginModal.set(false);
+    this.loginEntryPoint.set(null);
     this.consumePendingPrompt();
   }
 

--- a/libs/bixarena/ui/src/lib/nav/nav.component.html
+++ b/libs/bixarena/ui/src/lib/nav/nav.component.html
@@ -25,7 +25,7 @@
         />
       </button>
     } @else {
-      <p-button class="login-btn" label="Login" (onClick)="authService.login()" />
+      <p-button class="login-btn" label="Login" (onClick)="login()" />
     }
     <button
       class="theme-toggle"
@@ -113,7 +113,7 @@
     <a routerLink="/leaderboard" routerLinkActive="active" (click)="closeMenu()">Leaderboard</a>
     @if (!showAvatar()) {
       <hr />
-      <p-button label="Login" fluid (onClick)="authService.login(); closeMenu()" />
+      <p-button label="Login" fluid (onClick)="login(); closeMenu()" />
     }
   </nav>
 }

--- a/libs/bixarena/ui/src/lib/nav/nav.component.ts
+++ b/libs/bixarena/ui/src/lib/nav/nav.component.ts
@@ -12,7 +12,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router, RouterModule } from '@angular/router';
 import { filter } from 'rxjs/operators';
 import { ButtonModule } from 'primeng/button';
-import { AuthService, ThemeService } from '@sagebionetworks/bixarena/services';
+import { AnalyticsService, AuthService, ThemeService } from '@sagebionetworks/bixarena/services';
 import { AvatarComponent } from '../avatar/avatar.component';
 
 // Mirror of $md-breakpoint in shared-styles/_variables.scss. Kept as a
@@ -29,6 +29,7 @@ const MD_BREAKPOINT_PX = 768;
 export class NavComponent {
   readonly authService = inject(AuthService);
   readonly themeService = inject(ThemeService);
+  private readonly analytics = inject(AnalyticsService);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
@@ -72,6 +73,11 @@ export class NavComponent {
     if (this.isBrowser && window.innerWidth >= MD_BREAKPOINT_PX) {
       this.closeMenu();
     }
+  }
+
+  login(): void {
+    this.analytics.trackLoginInitiated('nav_login_button');
+    this.authService.login();
   }
 
   private applyBodyScrollLock(): void {

--- a/libs/bixarena/ui/src/lib/onboarding-fab/onboarding-fab.component.ts
+++ b/libs/bixarena/ui/src/lib/onboarding-fab/onboarding-fab.component.ts
@@ -1,4 +1,5 @@
-import { Component, output } from '@angular/core';
+import { Component, inject, output } from '@angular/core';
+import { AnalyticsService } from '@sagebionetworks/bixarena/services';
 
 @Component({
   selector: 'bixarena-onboarding-fab',
@@ -7,8 +8,10 @@ import { Component, output } from '@angular/core';
 })
 export class OnboardingFabComponent {
   readonly openRequested = output<void>();
+  private readonly analytics = inject(AnalyticsService);
 
   open(): void {
+    this.analytics.trackOnboardingReopened();
     this.openRequested.emit();
   }
 }

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
@@ -12,6 +12,7 @@ import {
 } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { ButtonModule } from 'primeng/button';
+import { AnalyticsService } from '@sagebionetworks/bixarena/services';
 import { ModalDialogComponent } from '../modal-dialog/modal-dialog.component';
 
 interface OnboardingFrame {
@@ -35,6 +36,8 @@ export class OnboardingModalComponent {
 
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
   private readonly destroyRef = inject(DestroyRef);
+  private readonly analytics = inject(AnalyticsService);
+  private completedDone = false;
 
   readonly samplePrompt = SAMPLE_PROMPT;
 
@@ -73,7 +76,10 @@ export class OnboardingModalComponent {
   constructor() {
     // Reset to first frame whenever the modal is opened so re-entry starts fresh.
     effect(() => {
-      if (this.visible()) this.currentFrame.set(0);
+      if (this.visible()) {
+        this.currentFrame.set(0);
+        this.analytics.trackOnboardingViewed();
+      }
     });
 
     effect(() => {
@@ -113,11 +119,17 @@ export class OnboardingModalComponent {
   }
 
   done(): void {
+    this.completedDone = true;
+    this.analytics.trackOnboardingCompleted();
     this.visible.set(false);
     this.closed.emit();
   }
 
   onModalClosed(): void {
+    if (!this.completedDone) {
+      this.analytics.trackOnboardingDismissed(this.currentFrame());
+    }
+    this.completedDone = false;
     this.closed.emit();
   }
 


### PR DESCRIPTION
## Description

This PR wires Google Analytics 4 (GA4) event tracking into the BixArena Angular app to give the team visibility into key user flows: login, battles, onboarding, and leaderboard interactions. A new `AnalyticsService` wraps `GoogleTagManagerService` and fires structured events with contextual parameters such as entry points and round numbers. Login entry points are carried through the OIDC redirect via sessionStorage so the analytics context is preserved even after the OAuth round-trip.

## Related Issue

[SMR-774](https://sagebionetworks.jira.com/browse/SMR-774)

## Changelog

- Add `AnalyticsService` with 12 GA4 track methods covering login, battle, onboarding, and leaderboard flows
- Wire `login_initiated` (with entry point), `login`, and `logout` events in auth service, auth guard, and nav component
- Thread `BattleEntryPoint` through `PendingPrompt` and `BattleGateService` so entry point context survives the OIDC redirect into the battle page
- Wire `battle_started`, `vote_submitted`, and `followup_question_submitted` events in `BattleStateService`
- Wire `onboarding_viewed`, `onboarding_completed`, `onboarding_dismissed`, and `onboarding_reopened` events in onboarding modal and FAB components
- Wire `leaderboard_viewed` once per page visit (initial load) and `leaderboard_filter_changed` on category and view (table/chart) changes
- Update unit tests to reflect the extended `PendingPrompt` interface and `submitPrompt` signature

[SMR-774]: https://sagebionetworks.jira.com/browse/SMR-774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ