### PR TITLE
refactor(bixarena): consolidate classification method IDs and add OpenRouter model fallback

### DIFF
--- a/apps/bixarena/ai-service/.env.example
+++ b/apps/bixarena/ai-service/.env.example
@@ -21,3 +21,8 @@ BIXARENA_AI_OPENROUTER_API_KEY=
 # Valkey configuration
 BIXARENA_AI_VALKEY_HOST=bixarena-valkey
 BIXARENA_AI_VALKEY_PORT=8116
+BIXARENA_AI_OPENROUTER_MODEL=anthropic/claude-haiku-4.5
+BIXARENA_AI_OPENROUTER_FALLBACK_MODEL=google/gemini-2.5-flash
+
+# Classification method ID — bump when changing the prompt or model
+BIXARENA_AI_CLASSIFICATION_METHOD=openrouter-haiku-v1

--- a/apps/bixarena/ai-service/.env.example
+++ b/apps/bixarena/ai-service/.env.example
@@ -22,7 +22,7 @@ BIXARENA_AI_OPENROUTER_API_KEY=
 BIXARENA_AI_VALKEY_HOST=bixarena-valkey
 BIXARENA_AI_VALKEY_PORT=8116
 BIXARENA_AI_OPENROUTER_MODEL=anthropic/claude-haiku-4.5
-BIXARENA_AI_OPENROUTER_FALLBACK_MODEL=google/gemini-2.5-flash
+BIXARENA_AI_OPENROUTER_FALLBACK_MODEL=anthropic/claude-3.5-haiku
 
 # Classification method ID — bump when changing the prompt or model
 BIXARENA_AI_CLASSIFICATION_METHOD=openrouter-haiku-v1

--- a/apps/bixarena/ai-service/bixarena_ai_service/cache.py
+++ b/apps/bixarena/ai-service/bixarena_ai_service/cache.py
@@ -60,7 +60,7 @@ async def get_cached_validation(prompt: str, settings: Settings) -> dict | None:
     """
     try:
         client = await _get_client(settings)
-        key = _make_key(_PROMPT_KEY_PREFIX, settings.prompt_validation_method, prompt)
+        key = _make_key(_PROMPT_KEY_PREFIX, settings.classification_method, prompt)
         raw = await client.get(key)
         if raw is not None:
             logger.info("Cache hit for prompt validation")
@@ -82,7 +82,7 @@ async def set_cached_validation(
     """Store a validation result in the cache."""
     try:
         client = await _get_client(settings)
-        key = _make_key(_PROMPT_KEY_PREFIX, settings.prompt_validation_method, prompt)
+        key = _make_key(_PROMPT_KEY_PREFIX, settings.classification_method, prompt)
         value = json.dumps({"confidence": confidence, "is_biomedical": is_biomedical})
         await client.set(key, value, ex=settings.valkey_cache_ttl)
         logger.debug("Cached prompt validation result")
@@ -113,7 +113,7 @@ async def get_cached_battle_validation(
     try:
         client = await _get_client(settings)
         key = _make_battle_key(
-            _BATTLE_KEY_PREFIX, settings.battle_validation_method, prompts
+            _BATTLE_KEY_PREFIX, settings.classification_method, prompts
         )
         raw = await client.get(key)
         if raw is not None:
@@ -137,7 +137,7 @@ async def set_cached_battle_validation(
     try:
         client = await _get_client(settings)
         key = _make_battle_key(
-            _BATTLE_KEY_PREFIX, settings.battle_validation_method, prompts
+            _BATTLE_KEY_PREFIX, settings.classification_method, prompts
         )
         value = json.dumps({"confidence": confidence, "is_biomedical": is_biomedical})
         await client.set(key, value, ex=settings.valkey_cache_ttl)
@@ -162,9 +162,7 @@ async def get_cached_prompt_categorization(
     """
     try:
         client = await _get_client(settings)
-        key = _make_key(
-            _PROMPT_CAT_KEY_PREFIX, settings.prompt_categorization_method, prompt
-        )
+        key = _make_key(_PROMPT_CAT_KEY_PREFIX, settings.classification_method, prompt)
         raw = await client.get(key)
         if raw is not None:
             logger.info("Cache hit for prompt categorization")
@@ -187,9 +185,7 @@ async def set_cached_prompt_categorization(
     """
     try:
         client = await _get_client(settings)
-        key = _make_key(
-            _PROMPT_CAT_KEY_PREFIX, settings.prompt_categorization_method, prompt
-        )
+        key = _make_key(_PROMPT_CAT_KEY_PREFIX, settings.classification_method, prompt)
         value = json.dumps({"category": category})
         await client.set(key, value, ex=settings.valkey_cache_ttl)
         logger.debug("Cached prompt categorization result")
@@ -207,7 +203,7 @@ async def get_cached_battle_categorization(
     try:
         client = await _get_client(settings)
         key = _make_battle_key(
-            _BATTLE_CAT_KEY_PREFIX, settings.battle_categorization_method, prompts
+            _BATTLE_CAT_KEY_PREFIX, settings.classification_method, prompts
         )
         raw = await client.get(key)
         if raw is not None:
@@ -228,7 +224,7 @@ async def set_cached_battle_categorization(
     try:
         client = await _get_client(settings)
         key = _make_battle_key(
-            _BATTLE_CAT_KEY_PREFIX, settings.battle_categorization_method, prompts
+            _BATTLE_CAT_KEY_PREFIX, settings.classification_method, prompts
         )
         value = json.dumps(categories)
         await client.set(key, value, ex=settings.valkey_cache_ttl)

--- a/apps/bixarena/ai-service/bixarena_ai_service/classifier.py
+++ b/apps/bixarena/ai-service/bixarena_ai_service/classifier.py
@@ -180,7 +180,16 @@ async def classify(system_prompt: str, user_message: str) -> float:
                 ],
             },
             messages=[
-                {"role": "system", "content": system_prompt},
+                {
+                    "role": "system",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": system_prompt,
+                            "cache_control": {"type": "ephemeral"},
+                        }
+                    ],
+                },
                 {"role": "user", "content": user_message},
             ],
             temperature=0.0,
@@ -245,7 +254,16 @@ async def categorize(system_prompt: str, user_message: str) -> list[str]:
             ],
         },
         messages=[
-            {"role": "system", "content": system_prompt},
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": system_prompt,
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            },
             {"role": "user", "content": user_message},
         ],
         temperature=0.0,
@@ -285,7 +303,16 @@ async def categorize_single(system_prompt: str, user_message: str) -> str | None
             ],
         },
         messages=[
-            {"role": "system", "content": system_prompt},
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": system_prompt,
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            },
             {"role": "user", "content": user_message},
         ],
         temperature=0.0,

--- a/apps/bixarena/ai-service/bixarena_ai_service/classifier.py
+++ b/apps/bixarena/ai-service/bixarena_ai_service/classifier.py
@@ -108,6 +108,15 @@ SINGLE_CATEGORY_SCHEMA = {
 }
 
 
+def _log_model_used(actual: str, configured: str) -> None:
+    if actual != configured:
+        logger.warning(
+            "OpenRouter used fallback model: %s (primary: %s)", actual, configured
+        )
+    else:
+        logger.debug("OpenRouter model: %s", actual)
+
+
 def parse_confidence(raw: str) -> float:
     """Extract and clamp the confidence value from the LLM response.
 
@@ -192,6 +201,7 @@ async def classify(system_prompt: str, user_message: str) -> float:
         )
 
         raw = response.choices[0].message.content or ""
+        _log_model_used(response.model, settings.openrouter_model)
         logger.debug("LLM raw response: %s", raw[:200])
         return parse_confidence(raw)
 
@@ -257,6 +267,7 @@ async def categorize(system_prompt: str, user_message: str) -> list[str]:
     )
 
     raw = response.choices[0].message.content or ""
+    _log_model_used(response.model, settings.openrouter_model)
     logger.debug("LLM raw response: %s", raw[:200])
     return parse_categories(raw)
 
@@ -297,5 +308,6 @@ async def categorize_single(system_prompt: str, user_message: str) -> str | None
     )
 
     raw = response.choices[0].message.content or ""
+    _log_model_used(response.model, settings.openrouter_model)
     logger.debug("LLM raw response: %s", raw[:200])
     return parse_single_category(raw)

--- a/apps/bixarena/ai-service/bixarena_ai_service/classifier.py
+++ b/apps/bixarena/ai-service/bixarena_ai_service/classifier.py
@@ -180,16 +180,7 @@ async def classify(system_prompt: str, user_message: str) -> float:
                 ],
             },
             messages=[
-                {
-                    "role": "system",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": system_prompt,
-                            "cache_control": {"type": "ephemeral"},
-                        }
-                    ],
-                },
+                {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_message},
             ],
             temperature=0.0,
@@ -254,16 +245,7 @@ async def categorize(system_prompt: str, user_message: str) -> list[str]:
             ],
         },
         messages=[
-            {
-                "role": "system",
-                "content": [
-                    {
-                        "type": "text",
-                        "text": system_prompt,
-                        "cache_control": {"type": "ephemeral"},
-                    }
-                ],
-            },
+            {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_message},
         ],
         temperature=0.0,
@@ -303,16 +285,7 @@ async def categorize_single(system_prompt: str, user_message: str) -> str | None
             ],
         },
         messages=[
-            {
-                "role": "system",
-                "content": [
-                    {
-                        "type": "text",
-                        "text": system_prompt,
-                        "cache_control": {"type": "ephemeral"},
-                    }
-                ],
-            },
+            {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_message},
         ],
         temperature=0.0,

--- a/apps/bixarena/ai-service/bixarena_ai_service/classifier.py
+++ b/apps/bixarena/ai-service/bixarena_ai_service/classifier.py
@@ -173,6 +173,12 @@ async def classify(system_prompt: str, user_message: str) -> float:
 
         response = await client.chat.completions.create(
             model=settings.openrouter_model,
+            extra_body={
+                "models": [
+                    settings.openrouter_model,
+                    settings.openrouter_fallback_model,
+                ],
+            },
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_message},
@@ -232,6 +238,12 @@ async def categorize(system_prompt: str, user_message: str) -> list[str]:
 
     response = await client.chat.completions.create(
         model=settings.openrouter_model,
+        extra_body={
+            "models": [
+                settings.openrouter_model,
+                settings.openrouter_fallback_model,
+            ],
+        },
         messages=[
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_message},
@@ -266,6 +278,12 @@ async def categorize_single(system_prompt: str, user_message: str) -> str | None
 
     response = await client.chat.completions.create(
         model=settings.openrouter_model,
+        extra_body={
+            "models": [
+                settings.openrouter_model,
+                settings.openrouter_fallback_model,
+            ],
+        },
         messages=[
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_message},

--- a/apps/bixarena/ai-service/bixarena_ai_service/config.py
+++ b/apps/bixarena/ai-service/bixarena_ai_service/config.py
@@ -35,6 +35,7 @@ class Settings(BaseSettings):
     openrouter_api_key: str = ""
     openrouter_base_url: str = "https://openrouter.ai/api/v1"
     openrouter_model: str = "anthropic/claude-haiku-4.5"
+    openrouter_fallback_model: str = "google/gemini-2.5-flash"
     openrouter_timeout: float = 30.0
     openrouter_max_retries: int = 2
 

--- a/apps/bixarena/ai-service/bixarena_ai_service/config.py
+++ b/apps/bixarena/ai-service/bixarena_ai_service/config.py
@@ -49,12 +49,9 @@ class Settings(BaseSettings):
     app_url: str = "https://bioarena.io"
     app_title: str = "BioArena"
 
-    # Validation / categorization method IDs — used as part of the cache key.
+    # Classification method ID — used as part of the Valkey cache key.
     # Bump when changing the classification prompt or model.
-    prompt_validation_method: str = "openrouter-haiku-v1"
-    battle_validation_method: str = "openrouter-haiku-v1"
-    prompt_categorization_method: str = "openrouter-haiku-v1"
-    battle_categorization_method: str = "openrouter-haiku-v1"
+    classification_method: str = "openrouter-haiku-v1"
 
     # Valkey configuration (DB 3 — DB 0/1/2 used by api/gateway/auth)
     valkey_host: str = "bixarena-valkey"

--- a/apps/bixarena/ai-service/bixarena_ai_service/config.py
+++ b/apps/bixarena/ai-service/bixarena_ai_service/config.py
@@ -35,7 +35,7 @@ class Settings(BaseSettings):
     openrouter_api_key: str = ""
     openrouter_base_url: str = "https://openrouter.ai/api/v1"
     openrouter_model: str = "anthropic/claude-haiku-4.5"
-    openrouter_fallback_model: str = "google/gemini-2.5-flash"
+    openrouter_fallback_model: str = "anthropic/claude-3.5-haiku"
     openrouter_timeout: float = 30.0
     openrouter_max_retries: int = 2
 

--- a/apps/bixarena/ai-service/bixarena_ai_service/impl/battle_categorization_impl.py
+++ b/apps/bixarena/ai-service/bixarena_ai_service/impl/battle_categorization_impl.py
@@ -68,7 +68,7 @@ class BattleCategorizationApiImpl(BaseBattleCategorizationApi):
 
         # Sanitize each prompt
         sanitized = [p.strip()[: settings.prompt_max_length] for p in prompts]
-        method = settings.battle_categorization_method
+        method = settings.classification_method
 
         # Check Valkey cache first. Empty cached lists are valid "no fit" results
         # and short-circuit the LLM call.

--- a/apps/bixarena/ai-service/bixarena_ai_service/impl/battle_validation_impl.py
+++ b/apps/bixarena/ai-service/bixarena_ai_service/impl/battle_validation_impl.py
@@ -60,7 +60,7 @@ class BattleValidationApiImpl(BaseBattleValidationApi):
         # Sanitize each prompt
         sanitized = [p.strip()[: settings.prompt_max_length] for p in prompts]
 
-        method = settings.battle_validation_method
+        method = settings.classification_method
 
         # Check Valkey cache first.
         cached = await get_cached_battle_validation(sanitized, settings)

--- a/apps/bixarena/ai-service/bixarena_ai_service/impl/prompt_categorization_impl.py
+++ b/apps/bixarena/ai-service/bixarena_ai_service/impl/prompt_categorization_impl.py
@@ -62,7 +62,7 @@ class PromptCategorizationApiImpl(BasePromptCategorizationApi):
         # Sanitize: strip whitespace and enforce max length
         # (defence-in-depth; the API layer already validates length).
         sanitized = prompt.strip()[: settings.prompt_max_length]
-        method = settings.prompt_categorization_method
+        method = settings.classification_method
 
         # Check Valkey cache first. A cached ``{"category": null}`` is a valid
         # "no fit" result and short-circuits the LLM call.

--- a/apps/bixarena/ai-service/bixarena_ai_service/impl/prompt_validation_impl.py
+++ b/apps/bixarena/ai-service/bixarena_ai_service/impl/prompt_validation_impl.py
@@ -59,7 +59,7 @@ class PromptValidationApiImpl(BasePromptValidationApi):
         # (defense-in-depth; the API layer already validates length).
         sanitized = prompt.strip()[: settings.prompt_max_length]
 
-        method = settings.prompt_validation_method
+        method = settings.classification_method
 
         # Check Valkey cache first.
         cached = await get_cached_validation(sanitized, settings)

--- a/apps/bixarena/infra/cdk/bixarena_infra_cdk/shared/stacks/ai_service_stack.py
+++ b/apps/bixarena/infra/cdk/bixarena_infra_cdk/shared/stacks/ai_service_stack.py
@@ -73,7 +73,7 @@ class AiServiceStack(cdk.Stack):
             # OpenRouter / LLM configuration
             "BIXARENA_AI_OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
             "BIXARENA_AI_OPENROUTER_MODEL": "anthropic/claude-haiku-4.5",
-            "BIXARENA_AI_OPENROUTER_FALLBACK_MODEL": "google/gemini-2.5-flash",
+            "BIXARENA_AI_OPENROUTER_FALLBACK_MODEL": "anthropic/claude-3.5-haiku",
             "BIXARENA_AI_OPENROUTER_TIMEOUT": "30.0",
             "BIXARENA_AI_OPENROUTER_MAX_RETRIES": "2",
             # Classification method ID (bump when changing prompt or model)

--- a/apps/bixarena/infra/cdk/bixarena_infra_cdk/shared/stacks/ai_service_stack.py
+++ b/apps/bixarena/infra/cdk/bixarena_infra_cdk/shared/stacks/ai_service_stack.py
@@ -73,6 +73,7 @@ class AiServiceStack(cdk.Stack):
             # OpenRouter / LLM configuration
             "BIXARENA_AI_OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
             "BIXARENA_AI_OPENROUTER_MODEL": "anthropic/claude-haiku-4.5",
+            "BIXARENA_AI_OPENROUTER_FALLBACK_MODEL": "google/gemini-2.5-flash",
             "BIXARENA_AI_OPENROUTER_TIMEOUT": "30.0",
             "BIXARENA_AI_OPENROUTER_MAX_RETRIES": "2",
             # Classification method ID (bump when changing prompt or model)

--- a/apps/bixarena/infra/cdk/bixarena_infra_cdk/shared/stacks/ai_service_stack.py
+++ b/apps/bixarena/infra/cdk/bixarena_infra_cdk/shared/stacks/ai_service_stack.py
@@ -75,11 +75,8 @@ class AiServiceStack(cdk.Stack):
             "BIXARENA_AI_OPENROUTER_MODEL": "anthropic/claude-haiku-4.5",
             "BIXARENA_AI_OPENROUTER_TIMEOUT": "30.0",
             "BIXARENA_AI_OPENROUTER_MAX_RETRIES": "2",
-            # Validation/categorization method IDs (bump when changing prompt or model)
-            "BIXARENA_AI_PROMPT_VALIDATION_METHOD": "openrouter-haiku-v1",
-            "BIXARENA_AI_BATTLE_VALIDATION_METHOD": "openrouter-haiku-v1",
-            "BIXARENA_AI_PROMPT_CATEGORIZATION_METHOD": "openrouter-haiku-v1",
-            "BIXARENA_AI_BATTLE_CATEGORIZATION_METHOD": "openrouter-haiku-v1",
+            # Classification method ID (bump when changing prompt or model)
+            "BIXARENA_AI_CLASSIFICATION_METHOD": "openrouter-haiku-v1",
             # Valkey cache connection
             "BIXARENA_AI_VALKEY_HOST": valkey_endpoint,
             "BIXARENA_AI_VALKEY_PORT": valkey_port,


### PR DESCRIPTION
## Description

This PR tightens the BixArena AI service configuration by consolidating four redundant per-endpoint classification method ID settings into a single shared \`classification_method\` setting, and adds an \`anthropic/claude-3.5-haiku\` fallback model for all OpenRouter classification calls. The fallback activates automatically via OpenRouter's native \`models\` array routing when the primary \`claude-haiku-4.5\` hits a rate limit or returns a 5xx error, requiring no additional error-handling code. Choosing the same haiku class as fallback means both models share the single \`openrouter-haiku-v1\` cache namespace — no dual-namespace complexity, no method attribution tracking needed.

## Related Issue

N/A

## Changelog

- Consolidate \`prompt_validation_method\`, \`battle_validation_method\`, \`prompt_categorization_method\`, and \`battle_categorization_method\` settings into a single \`classification_method\` setting used by all four endpoints
- Add \`anthropic/claude-3.5-haiku\` as OpenRouter fallback model via \`extra_body.models\` array in all three classifier functions (\`classify\`, \`categorize\`, \`categorize_single\`)
- Update \`ai_service_stack.py\` to reflect the consolidated setting and new \`BIXARENA_AI_OPENROUTER_FALLBACK_MODEL\` env var
- Update \`.env.example\` with \`BIXARENA_AI_OPENROUTER_FALLBACK_MODEL\` and \`BIXARENA_AI_CLASSIFICATION_METHOD\`

## Preview

The AI service classification pipeline now has:

- Single \`classification_method\` setting to bump when changing prompt or model, invalidating all four endpoint caches at once
- Automatic OpenRouter fallback to \`claude-3.5-haiku\` on primary model rate limits or 5xx errors — same haiku class, no cache namespace split
- Both primary and fallback models configurable via env vars (\`BIXARENA_AI_OPENROUTER_MODEL\`, \`BIXARENA_AI_OPENROUTER_FALLBACK_MODEL\`)