### PR TITLE
feat(bixarena): add LoggerService with YAML-configurable log levels (SMR-783)

### DIFF
--- a/apps/bixarena/app/src/config/application-dev.yaml
+++ b/apps/bixarena/app/src/config/application-dev.yaml
@@ -3,3 +3,6 @@
 analytics:
   googleTagManager:
     enabled: false
+
+logging:
+  level: debug

--- a/apps/bixarena/app/src/config/application.yaml
+++ b/apps/bixarena/app/src/config/application.yaml
@@ -31,4 +31,7 @@ links:
   feedback: https://forms.gle/WsvSdEfv5MfFpeedA
   sageBionetworks: https://sagebionetworks.org
 
+logging:
+  level: warn
+
 environment: dev

--- a/apps/bixarena/app/src/config/application.yaml
+++ b/apps/bixarena/app/src/config/application.yaml
@@ -32,6 +32,6 @@ links:
   sageBionetworks: https://sagebionetworks.org
 
 logging:
-  level: warn
+  level: info
 
 environment: dev

--- a/libs/bixarena/battle/src/lib/services/battle.service.ts
+++ b/libs/bixarena/battle/src/lib/services/battle.service.ts
@@ -7,7 +7,11 @@ import {
   Model,
 } from '@sagebionetworks/bixarena/api-client';
 import { ConfigService } from '@sagebionetworks/bixarena/config';
-import { AnalyticsService, BattleEntryPoint } from '@sagebionetworks/bixarena/services';
+import {
+  AnalyticsService,
+  BattleEntryPoint,
+  LoggerService,
+} from '@sagebionetworks/bixarena/services';
 import { BattlePhase, INITIAL_STREAM_STATE, ModelStreamState } from '../battle.types';
 import {
   CONTINUE_PROMPT,
@@ -25,6 +29,7 @@ export class BattleStateService {
   private readonly streamService = inject(BattleStreamService);
   private readonly config = inject(ConfigService).config;
   private readonly analytics = inject(AnalyticsService);
+  private readonly logger = inject(LoggerService);
 
   constructor() {
     inject(DestroyRef).onDestroy(() => {
@@ -115,6 +120,7 @@ export class BattleStateService {
     const userMsg = { role: 'user' as const, content: prompt };
     this.resetStreams([userMsg], [userMsg]);
 
+    this.logger.debug('battle: creating battle');
     let battle;
     try {
       battle = await firstValueFrom(
@@ -125,13 +131,14 @@ export class BattleStateService {
       );
       if (!battle) throw new Error('Failed to create battle');
     } catch (err) {
-      console.error('Failed to create battle', err);
+      this.logger.error('battle: failed to create battle', err);
       this.setStreamError('Something went wrong. Try a new battle', false);
       return;
     }
     this.battleId.set(battle.id);
     this.model1.set(battle.model1);
     this.model2.set(battle.model2);
+    this.logger.debug('battle: created', { battleId: battle.id });
     this.analytics.trackBattleStarted(
       battle.id,
       entryPoint ?? 'battle_composer',
@@ -140,7 +147,7 @@ export class BattleStateService {
     try {
       await this.createRoundAndStream(battle.id, battle.model1.id, battle.model2.id, prompt);
     } catch (err) {
-      console.error('Failed to start streaming', err);
+      this.logger.error('battle: failed to start streaming', err);
       this.setStreamError('Something went wrong', true);
     }
   }
@@ -174,6 +181,7 @@ export class BattleStateService {
       status: 'waiting',
     });
 
+    this.logger.debug('battle: continuing round', { which });
     try {
       const round = await firstValueFrom(
         this.battleApi.createBattleRound(battleId, { promptMessage: userMsg }),
@@ -187,7 +195,7 @@ export class BattleStateService {
       else this.model2Sub = sub;
       this.startTimeouts(target, which);
     } catch (err) {
-      console.error('Failed to continue round', err);
+      this.logger.error('battle: failed to continue round', err);
       target.update((s) => ({
         ...s,
         status: 'error',
@@ -216,7 +224,7 @@ export class BattleStateService {
       await this.createRoundAndStream(battleId, model1.id, model2.id, prompt);
       this.analytics.trackFollowupQuestionSubmitted(battleId, this.completedRounds + 1);
     } catch (err) {
-      console.error('Failed to create follow-up round', err);
+      this.logger.error('battle: failed to create follow-up round', err);
       this.setStreamError('Something went wrong', true);
     }
   }
@@ -246,18 +254,19 @@ export class BattleStateService {
       );
       if (!battle) throw new Error('Failed to create battle');
     } catch (err) {
-      console.error('Failed to create matchup', err);
+      this.logger.error('battle: failed to create matchup', err);
       this.setStreamError('Something went wrong. Try a new battle', false);
       return;
     }
     this.battleId.set(battle.id);
     this.model1.set(battle.model1);
     this.model2.set(battle.model2);
+    this.logger.debug('battle: new matchup created', { battleId: battle.id });
     this.analytics.trackBattleStarted(battle.id, 'new_matchup_button', !!this.examplePromptId);
     try {
       await this.createRoundAndStream(battle.id, battle.model1.id, battle.model2.id, prompt);
     } catch (err) {
-      console.error('Failed to start streaming', err);
+      this.logger.error('battle: failed to start streaming', err);
       this.setStreamError('Something went wrong', true);
     }
   }
@@ -273,7 +282,7 @@ export class BattleStateService {
     try {
       await this.createRoundAndStream(battleId, model1.id, model2.id, prompt);
     } catch (err) {
-      console.error('Failed to retry round', err);
+      this.logger.error('battle: failed to retry round', err);
       this.setStreamError('Something went wrong', true);
     }
   }
@@ -290,6 +299,7 @@ export class BattleStateService {
       return;
     }
 
+    this.logger.debug('battle: vote submitted', { battleId, outcome, round: this.completedRounds });
     this.analytics.trackVoteSubmitted(battleId, outcome, this.completedRounds);
     this.selectedOutcome.set(outcome);
     this.promptUsesRemaining.update((n) => Math.max(0, n - 1));
@@ -469,9 +479,11 @@ export class BattleStateService {
       const s2 = this.model2Stream().status;
       if (s1 === 'error' || s2 === 'error') {
         this.phase.set('error');
+        this.logger.debug('battle: both models complete → error phase');
       } else {
         this.completedRounds++;
         this.phase.set('voting');
+        this.logger.debug('battle: both models complete → voting', { round: this.completedRounds });
       }
     }
   }
@@ -490,6 +502,7 @@ export class BattleStateService {
     // Hard cutoff — force error if the model never responds in time
     const hardTimeout = setTimeout(() => {
       if (streamSignal().status === 'waiting' || streamSignal().status === 'streaming') {
+        this.logger.warn('battle: model timed out', { which: key });
         streamSignal.set({
           ...streamSignal(),
           status: 'error',

--- a/libs/bixarena/config/src/lib/config.schema.ts
+++ b/libs/bixarena/config/src/lib/config.schema.ts
@@ -38,6 +38,10 @@ export const AppConfigSchema = BaseConfigSchema.extend({
       id: z.string(),
     }),
   }),
+
+  logging: z.object({
+    level: z.enum(['debug', 'info', 'warn', 'error']).default('warn'),
+  }),
 });
 
 export type AppConfig = z.infer<typeof AppConfigSchema>;

--- a/libs/bixarena/config/src/lib/config.schema.ts
+++ b/libs/bixarena/config/src/lib/config.schema.ts
@@ -39,9 +39,11 @@ export const AppConfigSchema = BaseConfigSchema.extend({
     }),
   }),
 
-  logging: z.object({
-    level: z.enum(['debug', 'info', 'warn', 'error']).default('warn'),
-  }),
+  logging: z
+    .object({
+      level: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
+    })
+    .default({ level: 'info' }),
 });
 
 export type AppConfig = z.infer<typeof AppConfigSchema>;

--- a/libs/bixarena/home/src/lib/composer-section/composer-section.component.ts
+++ b/libs/bixarena/home/src/lib/composer-section/composer-section.component.ts
@@ -72,7 +72,7 @@ export class ComposerSectionComponent implements OnInit {
           }),
         ),
         catchError((err) => {
-          this.logger.error('❌ Failed to fetch composer placeholder prompts', err);
+          this.logger.error('Failed to fetch composer placeholder prompts', err);
           return of(null);
         }),
         takeUntilDestroyed(this.destroyRef),

--- a/libs/bixarena/home/src/lib/composer-section/composer-section.component.ts
+++ b/libs/bixarena/home/src/lib/composer-section/composer-section.component.ts
@@ -18,7 +18,7 @@ import {
   ExamplePromptSort,
 } from '@sagebionetworks/bixarena/api-client';
 import { ConfigService } from '@sagebionetworks/bixarena/config';
-import { AuthService, BattleGateService } from '@sagebionetworks/bixarena/services';
+import { AuthService, BattleGateService, LoggerService } from '@sagebionetworks/bixarena/services';
 import { PromptComposerComponent } from '@sagebionetworks/bixarena/ui';
 
 const STATIC_PLACEHOLDER = 'Ask anything biomedical...';
@@ -40,6 +40,7 @@ const REDUCED_MOTION_ROTATE_MS = 5000;
 export class ComposerSectionComponent implements OnInit {
   private readonly auth = inject(AuthService);
   private readonly gate = inject(BattleGateService);
+  private readonly logger = inject(LoggerService);
   private readonly router = inject(Router);
   private readonly examplePrompts = inject(ExamplePromptService);
   private readonly destroyRef = inject(DestroyRef);
@@ -61,17 +62,17 @@ export class ComposerSectionComponent implements OnInit {
       pageSize: PROMPT_POOL_SIZE,
       active: true,
     };
-    console.debug('🔎 Fetching composer placeholder prompts', query);
+    this.logger.debug('🔎 Fetching composer placeholder prompts', query);
     this.examplePrompts
       .listExamplePrompts(query)
       .pipe(
         tap((page) =>
-          console.debug('✅ Fetched composer placeholder prompts', {
+          this.logger.debug('✅ Fetched composer placeholder prompts', {
             count: page?.examplePrompts?.length ?? 0,
           }),
         ),
         catchError((err) => {
-          console.error('❌ Failed to fetch composer placeholder prompts', err);
+          this.logger.error('❌ Failed to fetch composer placeholder prompts', err);
           return of(null);
         }),
         takeUntilDestroyed(this.destroyRef),

--- a/libs/bixarena/home/src/lib/leaderboard-section/leaderboard-section.component.ts
+++ b/libs/bixarena/home/src/lib/leaderboard-section/leaderboard-section.component.ts
@@ -78,7 +78,7 @@ export class LeaderboardSectionComponent implements OnInit {
       .pipe(
         tap((all) => this.logger.debug('✅ Fetched leaderboard list', { count: all.length })),
         catchError((err) => {
-          this.logger.error('❌ Failed to fetch leaderboard list', err);
+          this.logger.error('Failed to fetch leaderboard list', err);
           return of<LeaderboardListInner[]>([]);
         }),
         takeUntilDestroyed(this.destroyRef),
@@ -101,7 +101,7 @@ export class LeaderboardSectionComponent implements OnInit {
               ),
               map((page) => this.toColumn(l, page)),
               catchError((err) => {
-                this.logger.error('❌ Failed to fetch leaderboard column', err);
+                this.logger.error('Failed to fetch leaderboard column', err);
                 return of<LeaderboardColumn | null>(null);
               }),
             );

--- a/libs/bixarena/home/src/lib/leaderboard-section/leaderboard-section.component.ts
+++ b/libs/bixarena/home/src/lib/leaderboard-section/leaderboard-section.component.ts
@@ -18,7 +18,11 @@ import {
   LeaderboardListInner,
   LeaderboardService,
 } from '@sagebionetworks/bixarena/api-client';
-import { AnalyticsService, ModelOrgLogoService } from '@sagebionetworks/bixarena/services';
+import {
+  AnalyticsService,
+  LoggerService,
+  ModelOrgLogoService,
+} from '@sagebionetworks/bixarena/services';
 import { AvatarComponent } from '@sagebionetworks/bixarena/ui';
 import { TooltipModule } from 'primeng/tooltip';
 import { LEADERBOARD_COLUMN_COUNT, LOOKBACK_DAYS } from '../home.constants';
@@ -54,6 +58,7 @@ export class LeaderboardSectionComponent implements OnInit {
   private readonly leaderboardApi = inject(LeaderboardService);
   private readonly orgLogo = inject(ModelOrgLogoService);
   private readonly analytics = inject(AnalyticsService);
+  private readonly logger = inject(LoggerService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
@@ -67,13 +72,13 @@ export class LeaderboardSectionComponent implements OnInit {
   ngOnInit(): void {
     if (!this.isBrowser) return;
 
-    console.debug('🔎 Fetching leaderboard list for home columns');
+    this.logger.debug('🔎 Fetching leaderboard list for home columns');
     this.leaderboardApi
       .listLeaderboards()
       .pipe(
-        tap((all) => console.debug('✅ Fetched leaderboard list', { count: all.length })),
+        tap((all) => this.logger.debug('✅ Fetched leaderboard list', { count: all.length })),
         catchError((err) => {
-          console.error('❌ Failed to fetch leaderboard list', err);
+          this.logger.error('❌ Failed to fetch leaderboard list', err);
           return of<LeaderboardListInner[]>([]);
         }),
         takeUntilDestroyed(this.destroyRef),
@@ -85,10 +90,10 @@ export class LeaderboardSectionComponent implements OnInit {
         forkJoin(
           withSnapshot.map((l) => {
             const query = { pageSize: LEADERBOARD_COLUMN_COUNT, lookback: LOOKBACK_DAYS };
-            console.debug('🔎 Fetching leaderboard column', { leaderboardId: l.id, query });
+            this.logger.debug('🔎 Fetching leaderboard column', { leaderboardId: l.id, query });
             return this.leaderboardApi.getLeaderboard(l.id, query).pipe(
               tap((page) =>
-                console.debug('✅ Fetched leaderboard column', {
+                this.logger.debug('✅ Fetched leaderboard column', {
                   leaderboardId: l.id,
                   entries: page.entries.length,
                   voteCount: page.voteCount,
@@ -96,7 +101,7 @@ export class LeaderboardSectionComponent implements OnInit {
               ),
               map((page) => this.toColumn(l, page)),
               catchError((err) => {
-                console.error('❌ Failed to fetch leaderboard column', err);
+                this.logger.error('❌ Failed to fetch leaderboard column', err);
                 return of<LeaderboardColumn | null>(null);
               }),
             );

--- a/libs/bixarena/home/src/lib/stats-section/stats-section.component.ts
+++ b/libs/bixarena/home/src/lib/stats-section/stats-section.component.ts
@@ -37,7 +37,7 @@ export class StatsSectionComponent {
       .pipe(
         tap((s) => this.logger.debug('✅ Fetched public stats', s)),
         catchError((err) => {
-          this.logger.error('❌ Failed to fetch public stats', err);
+          this.logger.error('Failed to fetch public stats', err);
           return of(null);
         }),
       ),
@@ -63,7 +63,7 @@ export class StatsSectionComponent {
         .pipe(
           tap((s) => this.logger.debug('✅ Fetched user stats', s)),
           catchError((err) => {
-            this.logger.error('❌ Failed to fetch user stats', err);
+            this.logger.error('Failed to fetch user stats', err);
             return of(null);
           }),
           takeUntilDestroyed(this.destroyRef),

--- a/libs/bixarena/home/src/lib/stats-section/stats-section.component.ts
+++ b/libs/bixarena/home/src/lib/stats-section/stats-section.component.ts
@@ -11,7 +11,7 @@ import { DecimalPipe } from '@angular/common';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { catchError, of, tap } from 'rxjs';
 import { StatsService, UserService, UserStats } from '@sagebionetworks/bixarena/api-client';
-import { AuthService } from '@sagebionetworks/bixarena/services';
+import { AuthService, LoggerService } from '@sagebionetworks/bixarena/services';
 
 @Component({
   selector: 'bixarena-stats-section',
@@ -22,6 +22,7 @@ import { AuthService } from '@sagebionetworks/bixarena/services';
 })
 export class StatsSectionComponent {
   private readonly auth = inject(AuthService);
+  private readonly logger = inject(LoggerService);
   private readonly userStatsService = inject(UserService);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -34,9 +35,9 @@ export class StatsSectionComponent {
     inject(StatsService)
       .getPublicStats()
       .pipe(
-        tap((s) => console.debug('✅ Fetched public stats', s)),
+        tap((s) => this.logger.debug('✅ Fetched public stats', s)),
         catchError((err) => {
-          console.error('❌ Failed to fetch public stats', err);
+          this.logger.error('❌ Failed to fetch public stats', err);
           return of(null);
         }),
       ),
@@ -60,9 +61,9 @@ export class StatsSectionComponent {
       this.userStatsService
         .getUserStats()
         .pipe(
-          tap((s) => console.debug('✅ Fetched user stats', s)),
+          tap((s) => this.logger.debug('✅ Fetched user stats', s)),
           catchError((err) => {
-            console.error('❌ Failed to fetch user stats', err);
+            this.logger.error('❌ Failed to fetch user stats', err);
             return of(null);
           }),
           takeUntilDestroyed(this.destroyRef),

--- a/libs/bixarena/home/src/lib/trending-section/trending-section.component.ts
+++ b/libs/bixarena/home/src/lib/trending-section/trending-section.component.ts
@@ -18,7 +18,7 @@ import {
   ExamplePromptService,
   ExamplePromptSort,
 } from '@sagebionetworks/bixarena/api-client';
-import { AuthService, BattleGateService } from '@sagebionetworks/bixarena/services';
+import { AuthService, BattleGateService, LoggerService } from '@sagebionetworks/bixarena/services';
 import { PromptCardComponent } from '@sagebionetworks/bixarena/ui';
 import { LOOKBACK_DAYS, TRENDING_PAGE_SIZE } from '../home.constants';
 
@@ -39,6 +39,7 @@ function formatCategory(slug: BiomedicalCategory): string {
 export class TrendingSectionComponent implements OnInit {
   private readonly auth = inject(AuthService);
   private readonly gate = inject(BattleGateService);
+  private readonly logger = inject(LoggerService);
   private readonly router = inject(Router);
   private readonly examplePrompts = inject(ExamplePromptService);
   private readonly destroyRef = inject(DestroyRef);
@@ -66,17 +67,17 @@ export class TrendingSectionComponent implements OnInit {
       lookback: LOOKBACK_DAYS,
       pageSize: TRENDING_PAGE_SIZE,
     };
-    console.debug('🔎 Fetching trending prompts', query);
+    this.logger.debug('🔎 Fetching trending prompts', query);
     this.examplePrompts
       .listExamplePrompts(query)
       .pipe(
         tap((page) =>
-          console.debug('✅ Fetched trending prompts', {
+          this.logger.debug('✅ Fetched trending prompts', {
             count: page?.examplePrompts?.length ?? 0,
           }),
         ),
         catchError((err) => {
-          console.error('❌ Failed to fetch trending prompts', err);
+          this.logger.error('❌ Failed to fetch trending prompts', err);
           return of(null);
         }),
         takeUntilDestroyed(this.destroyRef),

--- a/libs/bixarena/home/src/lib/trending-section/trending-section.component.ts
+++ b/libs/bixarena/home/src/lib/trending-section/trending-section.component.ts
@@ -77,7 +77,7 @@ export class TrendingSectionComponent implements OnInit {
           }),
         ),
         catchError((err) => {
-          this.logger.error('❌ Failed to fetch trending prompts', err);
+          this.logger.error('Failed to fetch trending prompts', err);
           return of(null);
         }),
         takeUntilDestroyed(this.destroyRef),

--- a/libs/bixarena/leaderboard/src/lib/services/leaderboard.service.spec.ts
+++ b/libs/bixarena/leaderboard/src/lib/services/leaderboard.service.spec.ts
@@ -1,3 +1,5 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { noop, of, throwError } from 'rxjs';
 import {
@@ -59,7 +61,12 @@ describe('LeaderboardFacadeService', () => {
       listLeaderboards: jest.fn().mockReturnValue(of([])),
     };
     TestBed.configureTestingModule({
-      providers: [LeaderboardFacadeService, { provide: LeaderboardApiService, useValue: api }],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        LeaderboardFacadeService,
+        { provide: LeaderboardApiService, useValue: api },
+      ],
     });
     service = TestBed.inject(LeaderboardFacadeService);
   });

--- a/libs/bixarena/leaderboard/src/lib/services/leaderboard.service.ts
+++ b/libs/bixarena/leaderboard/src/lib/services/leaderboard.service.ts
@@ -1,4 +1,5 @@
 import { inject, Injectable, signal } from '@angular/core';
+import { LoggerService } from '@sagebionetworks/bixarena/services';
 import { firstValueFrom } from 'rxjs';
 import {
   LeaderboardEntry,
@@ -11,6 +12,7 @@ import { DEFAULT_CATEGORY_SLUG, LOOKBACK_DAYS } from '../leaderboard.constants';
 @Injectable()
 export class LeaderboardFacadeService {
   private readonly api = inject(LeaderboardApiService);
+  private readonly logger = inject(LoggerService);
 
   readonly leaderboards = signal<LeaderboardListInner[]>([]);
   readonly entries = signal<LeaderboardEntry[]>([]);
@@ -29,9 +31,9 @@ export class LeaderboardFacadeService {
       const withEntries = (list ?? []).filter(
         (l) => (l.latestSnapshot?.entryCount ?? 0) > 0,
       ).length;
-      console.debug('✅ Fetched leaderboard categories', { total, withEntries });
+      this.logger.debug('✅ Fetched leaderboard categories', { total, withEntries });
     } catch (err) {
-      console.error('❌ Failed to fetch leaderboard categories', err);
+      this.logger.error('❌ Failed to fetch leaderboard categories', err);
       this.leaderboards.set([]);
     }
   }
@@ -43,7 +45,7 @@ export class LeaderboardFacadeService {
     this.loading.set(true);
     this.error.set(null);
     const finalQuery: LeaderboardSearchQuery = { lookback: LOOKBACK_DAYS, ...query };
-    console.debug('🔎 Fetching leaderboard data', { leaderboardId, query: finalQuery });
+    this.logger.debug('🔎 Fetching leaderboard data', { leaderboardId, query: finalQuery });
     try {
       const page = await firstValueFrom(this.api.getLeaderboard(leaderboardId, finalQuery));
       this.entries.set(page.entries);
@@ -51,7 +53,7 @@ export class LeaderboardFacadeService {
       this.entryCount.set(page.entryCount);
       this.voteCount.set(page.voteCount);
       this.snapshotUpdatedAt.set(page.updatedAt);
-      console.debug('✅ Fetched leaderboard data', {
+      this.logger.debug('✅ Fetched leaderboard data', {
         leaderboardId,
         entries: page.entries.length,
         totalElements: page.totalElements,
@@ -60,7 +62,7 @@ export class LeaderboardFacadeService {
         priorSnapshotId: page.priorSnapshotId ?? null,
       });
     } catch (err) {
-      console.error('❌ Failed to fetch leaderboard data', {
+      this.logger.error('❌ Failed to fetch leaderboard data', {
         leaderboardId,
         query: finalQuery,
         err,

--- a/libs/bixarena/leaderboard/src/lib/services/leaderboard.service.ts
+++ b/libs/bixarena/leaderboard/src/lib/services/leaderboard.service.ts
@@ -33,7 +33,7 @@ export class LeaderboardFacadeService {
       ).length;
       this.logger.debug('✅ Fetched leaderboard categories', { total, withEntries });
     } catch (err) {
-      this.logger.error('❌ Failed to fetch leaderboard categories', err);
+      this.logger.error('Failed to fetch leaderboard categories', err);
       this.leaderboards.set([]);
     }
   }
@@ -62,7 +62,7 @@ export class LeaderboardFacadeService {
         priorSnapshotId: page.priorSnapshotId ?? null,
       });
     } catch (err) {
-      this.logger.error('❌ Failed to fetch leaderboard data', {
+      this.logger.error('Failed to fetch leaderboard data', {
         leaderboardId,
         query: finalQuery,
         err,

--- a/libs/bixarena/services/src/index.ts
+++ b/libs/bixarena/services/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/analytics.service';
+export * from './lib/logger.service';
 export * from './lib/meta-tag.service';
 export * from './lib/auth.guard';
 export * from './lib/auth.service';

--- a/libs/bixarena/services/src/lib/auth.service.ts
+++ b/libs/bixarena/services/src/lib/auth.service.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '@sagebionetworks/bixarena/config';
 import { UserInfo } from '@sagebionetworks/bixarena/api-client';
 import { clearPendingPromptStorage } from './battle-gate.service';
 import { AnalyticsService } from './analytics.service';
+import { LoggerService } from './logger.service';
 
 export interface CachedUser {
   username: string;
@@ -19,6 +20,7 @@ export class AuthService {
   private readonly storage = inject(LocalStorageService);
   private readonly configService = inject(ConfigService);
   private readonly analytics = inject(AnalyticsService);
+  private readonly logger = inject(LoggerService);
 
   readonly user = signal<UserInfo | null>(null);
   readonly isAuthenticated = computed(() => this.user() !== null);
@@ -31,25 +33,30 @@ export class AuthService {
   async init(): Promise<void> {
     if (!this.isBrowser) return;
     const wasAuthenticated = this.cachedUser() !== null;
+    this.logger.debug('auth: checking session');
     try {
       const res = await fetch('/userinfo');
       if (res.ok) {
         const user: UserInfo = await res.json();
         this.user.set(user);
         this.saveCache({ username: user.preferred_username ?? '', avatarUrl: user.avatar_url });
+        this.logger.debug('auth: session active');
         if (!wasAuthenticated) {
           this.analytics.trackLogin();
         }
       } else {
+        this.logger.debug('auth: no active session', { status: res.status });
         this.clearCache();
       }
-    } catch {
+    } catch (err) {
+      this.logger.warn('auth: session check failed', { error: String(err) });
       this.clearCache();
     }
   }
 
   login(returnTo?: string): void {
     if (!this.isBrowser) return;
+    this.logger.debug('auth: redirecting to login', { returnTo });
     const base = `${this.authUrl}/auth/login`;
     window.location.href = returnTo ? `${base}?return_to=${encodeURIComponent(returnTo)}` : base;
   }
@@ -58,16 +65,22 @@ export class AuthService {
   // On failure, user stays logged in and can retry.
   async logout(): Promise<void> {
     if (!this.isBrowser) return;
+    this.logger.debug('auth: logout requested');
     try {
       const res = await fetch('/auth/logout', { method: 'POST' });
-      if (!res.ok) return;
-    } catch {
+      if (!res.ok) {
+        this.logger.warn('auth: logout request failed', { status: res.status });
+        return;
+      }
+    } catch (err) {
+      this.logger.warn('auth: logout request failed', { error: String(err) });
       return;
     }
     this.user.set(null);
     this.clearCache();
     clearPendingPromptStorage();
     this.analytics.trackLogout();
+    this.logger.debug('auth: logout complete');
     window.location.href = '/';
   }
 

--- a/libs/bixarena/services/src/lib/battle-gate.service.ts
+++ b/libs/bixarena/services/src/lib/battle-gate.service.ts
@@ -2,6 +2,7 @@ import { inject, Injectable, PLATFORM_ID, signal } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { AuthService } from './auth.service';
 import { AnalyticsService, BattleEntryPoint, LoginEntryPoint } from './analytics.service';
+import { LoggerService } from './logger.service';
 
 const PENDING_PROMPT_KEY = 'bixarena.pendingPrompt';
 const PENDING_EXAMPLE_PROMPT_ID_KEY = 'bixarena.pendingExamplePromptId';
@@ -36,6 +37,7 @@ export function clearPendingPromptStorage(): void {
 export class BattleGateService {
   readonly authService = inject(AuthService);
   private readonly analytics = inject(AnalyticsService);
+  private readonly logger = inject(LoggerService);
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   readonly showLoginModal = signal(false);
@@ -52,10 +54,12 @@ export class BattleGateService {
     if (entryPoint) {
       this.analytics.trackLoginInitiated(entryPoint);
     }
+    this.logger.debug('battle-gate: login confirmed, redirecting to /battle');
     this.authService.login('/battle');
   }
 
   onLoginCancel(): void {
+    this.logger.debug('battle-gate: login cancelled');
     this.showLoginModal.set(false);
     this.loginEntryPoint.set(null);
     this.consumePendingPrompt();
@@ -105,6 +109,7 @@ export class BattleGateService {
     const valid = this.peekValidPrompt();
     if (!valid) {
       this.clearPending();
+      this.logger.debug('battle-gate: no valid pending prompt');
       return null;
     }
     const examplePromptId = sessionStorage.getItem(PENDING_EXAMPLE_PROMPT_ID_KEY);
@@ -112,6 +117,7 @@ export class BattleGateService {
       PENDING_PROMPT_ENTRY_POINT_KEY,
     ) as BattleEntryPoint | null;
     this.clearPending();
+    this.logger.debug('battle-gate: pending prompt consumed');
     return { prompt: valid, examplePromptId: examplePromptId || null, entryPoint };
   }
 

--- a/libs/bixarena/services/src/lib/logger.service.ts
+++ b/libs/bixarena/services/src/lib/logger.service.ts
@@ -10,7 +10,7 @@ export class LoggerService {
   private readonly configService = inject(ConfigService);
 
   private allows(level: LogLevel): boolean {
-    const configured = (this.configService.config?.logging?.level ?? 'warn') as LogLevel;
+    const configured = this.configService.config?.logging?.level ?? 'info';
     return LEVEL_ORDER[level] >= LEVEL_ORDER[configured];
   }
 

--- a/libs/bixarena/services/src/lib/logger.service.ts
+++ b/libs/bixarena/services/src/lib/logger.service.ts
@@ -34,6 +34,7 @@ export class LoggerService {
   }
 
   warn(message: string, data?: unknown): void {
+    if (!this.allows('warn')) return;
     if (data !== undefined) {
       console.warn(message, data);
     } else {
@@ -42,6 +43,7 @@ export class LoggerService {
   }
 
   error(message: string, error?: unknown): void {
+    if (!this.allows('error')) return;
     if (error !== undefined) {
       console.error(message, error);
     } else {

--- a/libs/bixarena/services/src/lib/logger.service.ts
+++ b/libs/bixarena/services/src/lib/logger.service.ts
@@ -1,0 +1,51 @@
+import { inject, Injectable, isDevMode } from '@angular/core';
+import { ConfigService } from '@sagebionetworks/bixarena/config';
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const LEVEL_ORDER: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+
+@Injectable({ providedIn: 'root' })
+export class LoggerService {
+  private readonly configService = inject(ConfigService);
+
+  private allows(level: LogLevel): boolean {
+    const configured = (this.configService.config?.logging?.level ?? 'warn') as LogLevel;
+    return LEVEL_ORDER[level] >= LEVEL_ORDER[configured];
+  }
+
+  // isDevMode() is a hard floor: debug never outputs in prod builds even if YAML is misconfigured.
+  debug(message: string, data?: unknown): void {
+    if (!isDevMode() || !this.allows('debug')) return;
+    if (data !== undefined) {
+      console.debug(message, data);
+    } else {
+      console.debug(message);
+    }
+  }
+
+  info(message: string, data?: unknown): void {
+    if (!this.allows('info')) return;
+    if (data !== undefined) {
+      console.info(message, data);
+    } else {
+      console.info(message);
+    }
+  }
+
+  warn(message: string, data?: unknown): void {
+    if (data !== undefined) {
+      console.warn(message, data);
+    } else {
+      console.warn(message);
+    }
+  }
+
+  error(message: string, error?: unknown): void {
+    if (error !== undefined) {
+      console.error(message, error);
+    } else {
+      console.error(message);
+    }
+  }
+}

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
@@ -4,7 +4,6 @@ import {
   DestroyRef,
   effect,
   inject,
-  isDevMode,
   model,
   output,
   PLATFORM_ID,
@@ -12,7 +11,7 @@ import {
 } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { ButtonModule } from 'primeng/button';
-import { AnalyticsService } from '@sagebionetworks/bixarena/services';
+import { AnalyticsService, LoggerService } from '@sagebionetworks/bixarena/services';
 import { ModalDialogComponent } from '../modal-dialog/modal-dialog.component';
 
 interface OnboardingFrame {
@@ -37,6 +36,7 @@ export class OnboardingModalComponent {
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
   private readonly destroyRef = inject(DestroyRef);
   private readonly analytics = inject(AnalyticsService);
+  private readonly logger = inject(LoggerService);
   private completedDone = false;
 
   readonly samplePrompt = SAMPLE_PROMPT;
@@ -112,7 +112,7 @@ export class OnboardingModalComponent {
 
   goTo(index: number): void {
     if (index < 0 || index >= this.frames.length) {
-      if (isDevMode()) console.warn('OnboardingModal: invalid frame index', index);
+      this.logger.warn('OnboardingModal: invalid frame index', { index });
       return;
     }
     this.currentFrame.set(index);

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.ts
@@ -112,7 +112,7 @@ export class OnboardingModalComponent {
 
   goTo(index: number): void {
     if (index < 0 || index >= this.frames.length) {
-      this.logger.warn('OnboardingModal: invalid frame index', { index });
+      this.logger.debug('OnboardingModal: invalid frame index', { index });
       return;
     }
     this.currentFrame.set(index);


### PR DESCRIPTION
## Description

Browser `console.debug` calls in the BixArena Angular app had no production gate — any developer opening DevTools with Verbose enabled could see internal API state. This PR introduces a `LoggerService` that gates output through a YAML-configurable `logging.level` (`debug` in dev, `info` in prod) with `isDevMode()` as a hard floor so debug logs never appear in production builds regardless of config. All existing `console.debug` call sites are migrated to the service, and targeted useful-but-safe logs are added to the auth, battle, and battle-gate flows to aid debugging of user-facing issues.

## Related Issue

[SMR-783](https://sagebionetworks.jira.com/browse/SMR-783)

## Changelog

- Add `LoggerService` with `debug` / `info` / `warn` / `error` levels, all four gated by `logging.level` config; `debug` additionally blocked by `isDevMode()` in prod builds
- Add `logging` field to `AppConfigSchema` with object-level default so configs omitting the block don't fail Zod validation
- Set prod log level to `info` (consistent with api-service and Gradio defaults); dev override stays at `debug`
- Migrate all existing `console.debug` / `console.error` call sites in home, leaderboard, onboarding, auth, and battle to `LoggerService`
- Add structured debug logs to auth flow (session check, login redirect, logout lifecycle) and battle flow (battle creation, vote submission, model timeout, phase transitions)
- Fix `LeaderboardFacadeService` test spec to provide `HttpClient` required by the new `LoggerService` injection chain

[SMR-783]: https://sagebionetworks.jira.com/browse/SMR-783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ