### PR TITLE
fix(bixarena): guard GTM injection with isBrowser in AnalyticsService to prevent SSR crash

### DIFF
--- a/libs/bixarena/services/src/lib/analytics.service.ts
+++ b/libs/bixarena/services/src/lib/analytics.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, PLATFORM_ID, inject } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { GoogleTagManagerService } from 'angular-google-tag-manager';
 import { BattleEvaluationOutcome } from '@sagebionetworks/bixarena/api-client';
 
@@ -26,7 +27,10 @@ const LOGIN_ENTRY_POINT_KEY = 'bixarena.loginEntryPoint';
 
 @Injectable({ providedIn: 'root' })
 export class AnalyticsService {
-  private readonly gtm = inject(GoogleTagManagerService, { optional: true });
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+  private readonly gtm = this.isBrowser
+    ? inject(GoogleTagManagerService, { optional: true })
+    : null;
 
   private push(event: string, params?: Record<string, unknown>): void {
     this.gtm?.pushTag({ event, ...params }).catch(() => undefined);


### PR DESCRIPTION
## Description

During a stage deployment, BixArena's SSR crashed with `TypeError: Cannot read properties of undefined (reading 'analytics')`. The root cause was that `AnalyticsService` eagerly injected `GoogleTagManagerService` as a class field — which synchronously triggered Angular's DI chain to resolve `GTM_CONFIG`, calling the `provideGtmConfig` factory before `configFactory()` had run and before `configService.config` was populated. On SSR, `APP_INITIALIZER` injecting `AuthService` → `AnalyticsService` → `GoogleTagManagerService` → `GTM_CONFIG` factory was enough to trigger this chain. The fix guards GTM injection with `isPlatformBrowser` — consistent with how `AuthService` and `ThemeService` already handle SSR — so the DI chain is never triggered on the server. `AuthService` is intentionally kept in `APP_INITIALIZER` to block first render until the `/userinfo` session check completes, ensuring the nav reflects the correct auth state from the first paint.

## Changelog

- Guard `GoogleTagManagerService` injection in `AnalyticsService` with `isPlatformBrowser`, consistent with sibling services