### PR TITLE
fix(bixarena): defer GoogleTagManagerService injection in AnalyticsService until first use to prevent hydration crash

### DIFF
--- a/libs/bixarena/services/src/lib/analytics.service.ts
+++ b/libs/bixarena/services/src/lib/analytics.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, PLATFORM_ID, inject } from '@angular/core';
+import { Injectable, Injector, PLATFORM_ID, inject } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { GoogleTagManagerService } from 'angular-google-tag-manager';
 import { BattleEvaluationOutcome } from '@sagebionetworks/bixarena/api-client';
@@ -28,9 +28,11 @@ const LOGIN_ENTRY_POINT_KEY = 'bixarena.loginEntryPoint';
 @Injectable({ providedIn: 'root' })
 export class AnalyticsService {
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
-  private readonly gtm = this.isBrowser
-    ? inject(GoogleTagManagerService, { optional: true })
-    : null;
+  private readonly injector = inject(Injector);
+
+  private get gtm(): GoogleTagManagerService | null {
+    return this.isBrowser ? this.injector.get(GoogleTagManagerService, null) : null;
+  }
 
   private push(event: string, params?: Record<string, unknown>): void {
     this.gtm?.pushTag({ event, ...params }).catch(() => undefined);


### PR DESCRIPTION
## Description

Follow-up to [#4055](https://github.com/Sage-Bionetworks/sage-monorepo/pull/4055). After SSR was fixed, the same `Cannot read properties of undefined (reading 'analytics')` crash resurfaced on the browser during hydration. Root cause: `AnalyticsService` was eagerly injecting `GoogleTagManagerService` as a class field, which transitively resolved the `GTM_CONFIG` factory before `configFactory()` finished loading config on the browser. This change replaces the eager injection with a lazy getter via `Injector.get()`, so the GTM DI chain is only triggered on the first analytics `push()` call — by which point `APP_INITIALIZER` has completed and `configService.config` is fully loaded. 

## Related Issue

N/A

## Changelog

- Replace eager `inject(GoogleTagManagerService)` class field with a lazy getter that resolves via `Injector.get()` only when first accessed
- Decouples `AnalyticsService` construction from the `GTM_CONFIG` resolution chain, eliminating the hydration race condition