### PR TITLE
feat(bixarena): switch back to full disclaimer and unify border tokens (SMR-775)

### DIFF
--- a/apps/bixarena/app/src/config/application-dev.yaml
+++ b/apps/bixarena/app/src/config/application-dev.yaml
@@ -3,6 +3,9 @@
 analytics:
   googleTagManager:
     enabled: false
+    # TODO: remove once shared GTM_CONFIG schema makes `gtmId` conditional on `enabled`.
+    # Today the schema requires non-empty `gtmId` regardless of `enabled`, so this
+    # placeholder satisfies validation in dev where GTM is disabled.
     id: 'local'
 
 logging:

--- a/apps/bixarena/app/src/config/application-dev.yaml
+++ b/apps/bixarena/app/src/config/application-dev.yaml
@@ -3,6 +3,7 @@
 analytics:
   googleTagManager:
     enabled: false
+    id: 'local'
 
 logging:
   level: debug

--- a/libs/bixarena/battle/src/lib/battle.component.scss
+++ b/libs/bixarena/battle/src/lib/battle.component.scss
@@ -25,7 +25,7 @@ bixarena-example-prompts {
 
 .composer-group {
   width: 100%;
-  max-width: 40rem;
+  max-width: 52rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;

--- a/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
+++ b/libs/bixarena/battle/src/lib/example-prompts/example-prompts.component.scss
@@ -28,7 +28,7 @@
   width: fit-content;
   margin: 0 auto;
   padding: 0.35rem 0.9rem;
-  border: 1px solid var(--p-surface-200);
+  border: 1px solid var(--border);
   border-radius: 999px;
   background: transparent;
   font-family: inherit;
@@ -51,7 +51,7 @@
 
   &:hover:not(:disabled) {
     background: var(--p-surface-200);
-    border-color: var(--p-surface-300);
+    border-color: var(--border-hover);
     color: var(--p-text-color);
     transform: translateY(-1px);
 
@@ -131,7 +131,7 @@
   color: var(--p-text-muted-color);
   font-size: var(--text-sm);
   padding: 2rem;
-  border: 1px dashed var(--p-surface-200);
+  border: 1px dashed var(--border);
   border-radius: var(--p-border-radius-lg);
 }
 

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
@@ -7,7 +7,7 @@
 }
 
 .panel {
-  border: 1px solid var(--p-surface-200);
+  border: 1px solid var(--border);
   border-radius: 16px;
   display: flex;
   flex-direction: column;
@@ -19,7 +19,7 @@
   transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 
   &.selected {
-    border-color: var(--p-surface-400);
+    border-color: var(--border-hover);
   }
 
   &.unselected {
@@ -27,7 +27,7 @@
   }
 
   &.hovered {
-    border-color: var(--p-surface-400);
+    border-color: var(--border-hover);
     box-shadow: 0 4px 16px rgb(0 0 0 / 25%);
     transform: translateY(-2px);
   }
@@ -38,7 +38,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.625rem 1rem;
-  border-bottom: 1px solid var(--p-surface-200);
+  border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
 
@@ -177,7 +177,7 @@
 
 .user-msg {
   background: var(--p-surface-200);
-  border: 1px solid var(--p-surface-300);
+  border: 1px solid var(--border);
   border-radius: 18px 18px 4px;
   padding: 0.5rem 1rem;
   margin-bottom: 1rem;
@@ -269,7 +269,7 @@
 
 .footer {
   padding: 0.5rem 1rem;
-  border-top: 1px solid var(--p-surface-200);
+  border-top: 1px solid var(--border);
   font-size: var(--text-sm);
   font-weight: 620;
   letter-spacing: -0.01em;

--- a/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
+++ b/libs/bixarena/battle/src/lib/model-panel/model-panel.component.scss
@@ -81,7 +81,7 @@
   gap: 0.4rem;
   font-size: var(--text-xs);
   font-weight: 560;
-  color: var(--p-surface-500);
+  color: var(--p-surface-600);
   letter-spacing: -0.01em;
 }
 

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
@@ -30,10 +30,10 @@
   border: 1px solid var(--border);
   border-radius: 100px;
   background: var(--p-surface-100);
-  color: var(--p-surface-600);
+  color: var(--p-surface-700);
   font: inherit;
   font-size: var(--text-sm);
-  font-weight: 520;
+  font-weight: 600;
   cursor: pointer;
   transition: all 0.2s;
   letter-spacing: -0.01em;

--- a/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
+++ b/libs/bixarena/battle/src/lib/voting-bar/voting-bar.component.scss
@@ -27,7 +27,7 @@
   align-items: center;
   gap: 0.375rem;
   padding: 0.5rem 1.25rem;
-  border: 1px solid var(--p-surface-200);
+  border: 1px solid var(--border);
   border-radius: 100px;
   background: var(--p-surface-100);
   color: var(--p-surface-600);
@@ -40,7 +40,7 @@
 
   &:hover {
     background: var(--p-surface-200);
-    border-color: var(--p-surface-300);
+    border-color: var(--border-hover);
     color: var(--p-text-color);
     transform: translateY(-1px);
   }

--- a/libs/bixarena/config/src/lib/config.service.ts
+++ b/libs/bixarena/config/src/lib/config.service.ts
@@ -16,11 +16,23 @@ export class ConfigService extends ConfigLoaderService<RuntimeServerConfig, AppC
   }
 
   override async loadConfig(basePath?: string): Promise<RuntimeServerConfig> {
-    const loaded = await super.loadConfig(basePath);
-    this.config = {
-      ...(loaded as AppConfig),
-      isPlatformServer: isPlatformServer(this.platformId),
-    } as RuntimeServerConfig;
-    return this.config;
+    // TODO: remove once the shared platform/config lib routes its logs through the
+    // shared Logger token (with isDevMode-gated default). This is a bixarena-only
+    // workaround to keep [ConfigLoader] and [YamlParser] noise out of the console.
+    const originalLog = console.log;
+    const originalDebug = console.debug;
+    console.log = () => undefined;
+    console.debug = () => undefined;
+    try {
+      const loaded = await super.loadConfig(basePath);
+      this.config = {
+        ...(loaded as AppConfig),
+        isPlatformServer: isPlatformServer(this.platformId),
+      } as RuntimeServerConfig;
+      return this.config;
+    } finally {
+      console.log = originalLog;
+      console.debug = originalDebug;
+    }
   }
 }

--- a/libs/bixarena/home/src/lib/leaderboard-section/leaderboard-section.component.scss
+++ b/libs/bixarena/home/src/lib/leaderboard-section/leaderboard-section.component.scss
@@ -69,7 +69,7 @@
 
 .col {
   background: var(--p-surface-100);
-  border: 1px solid var(--p-surface-200);
+  border: 1px solid var(--border);
   border-radius: var(--p-border-radius-xl);
   overflow: hidden;
   container-type: inline-size;
@@ -81,7 +81,7 @@
   justify-content: space-between;
   gap: 0.5rem;
   padding: 0.875rem 1.125rem;
-  border-bottom: 1px solid var(--p-surface-200);
+  border-bottom: 1px solid var(--border);
   font-size: var(--text-sm);
   font-weight: 580;
   color: var(--p-text-color);
@@ -231,7 +231,7 @@
     align-items: center;
     justify-content: center;
     gap: 0.375rem;
-    border: 1px solid var(--p-surface-300);
+    border: 1px solid var(--border);
     border-radius: var(--p-border-radius-md);
     background: transparent;
     text-decoration: none;

--- a/libs/bixarena/home/src/lib/stats-section/stats-section.component.scss
+++ b/libs/bixarena/home/src/lib/stats-section/stats-section.component.scss
@@ -23,7 +23,7 @@
 }
 
 .stat + .stat {
-  border-left: 1px solid var(--p-surface-200);
+  border-left: 1px solid var(--border);
   padding-left: 2rem;
 }
 

--- a/libs/bixarena/home/src/lib/trending-section/trending-section.component.scss
+++ b/libs/bixarena/home/src/lib/trending-section/trending-section.component.scss
@@ -101,7 +101,7 @@
     align-items: center;
     justify-content: center;
     gap: 0.375rem;
-    border: 1px solid var(--p-surface-300);
+    border: 1px solid var(--border);
     border-radius: var(--p-border-radius-md);
     background: transparent;
     cursor: pointer;

--- a/libs/bixarena/leaderboard/src/lib/leaderboard-toolbar/leaderboard-toolbar.component.scss
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard-toolbar/leaderboard-toolbar.component.scss
@@ -21,7 +21,7 @@
   gap: 0.5rem;
   height: 2.25rem;
   padding: 0 0.85rem;
-  border: 1px solid var(--p-surface-200);
+  border: 1px solid var(--border);
   border-radius: var(--p-border-radius-md);
   background: var(--p-surface-100);
   color: var(--p-text-color);
@@ -54,7 +54,7 @@
 
   &:hover {
     background: var(--p-surface-200);
-    border-color: var(--p-surface-300);
+    border-color: var(--border-hover);
   }
 }
 
@@ -70,7 +70,7 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.6rem 0.85rem;
-  border-bottom: 1px solid var(--p-surface-200);
+  border-bottom: 1px solid var(--border);
 
   svg {
     color: var(--p-surface-500);
@@ -140,7 +140,7 @@
   max-width: 100%;
   margin-left: auto;
   padding: 0 0.75rem;
-  border: 1px solid var(--p-surface-300);
+  border: 1px solid var(--border);
   border-radius: var(--p-border-radius-md);
   background: var(--p-surface-100);
   color: var(--p-text-color);
@@ -186,7 +186,7 @@
 
   &:hover {
     background: var(--p-surface-100);
-    border-color: var(--p-surface-200);
+    border-color: var(--border);
     color: var(--p-text-color);
   }
 }
@@ -196,7 +196,7 @@
   align-items: center;
   height: 2.25rem;
   padding: 0.15rem;
-  border: 1px solid var(--p-surface-200);
+  border: 1px solid var(--border);
   border-radius: var(--p-border-radius-md);
   background: transparent;
 }
@@ -249,7 +249,7 @@
   gap: 0.45rem;
   height: 2.25rem;
   padding: 0 0.8rem;
-  border: 1px solid var(--p-surface-200);
+  border: 1px solid var(--border);
   border-radius: var(--p-border-radius-md);
   background: transparent;
   color: var(--p-text-color);
@@ -263,12 +263,12 @@
 
   &:hover {
     background: var(--p-surface-100);
-    border-color: var(--p-surface-300);
+    border-color: var(--border-hover);
   }
 
   &.active {
     background: var(--p-surface-100);
-    border-color: var(--p-surface-300);
+    border-color: var(--border-hover);
   }
 
   .count {
@@ -298,7 +298,7 @@
 }
 
 .filter-section + .filter-section {
-  border-top: 1px solid var(--p-surface-200);
+  border-top: 1px solid var(--border);
 }
 
 .filter-section-head {
@@ -346,7 +346,7 @@
   display: inline-flex;
   align-items: center;
   padding: 0.35rem 0.75rem;
-  border: 1px solid var(--p-surface-200);
+  border: 1px solid var(--border);
   border-radius: 999px;
   background: transparent;
   font-family: inherit;
@@ -363,7 +363,7 @@
 
   &.on {
     background: var(--p-surface-200);
-    border-color: var(--p-surface-300);
+    border-color: var(--border-hover);
     font-weight: 540;
   }
 }
@@ -375,7 +375,7 @@
   gap: 0.4rem;
   padding-top: 0.55rem;
   margin-bottom: 0.75rem;
-  border-top: 1px dotted var(--p-surface-200);
+  border-top: 1px dotted var(--border);
 }
 
 .active-filters-label {
@@ -394,7 +394,7 @@
   height: 1.6rem;
   padding: 0 0.4rem 0 0.6rem;
   background: var(--p-surface-100);
-  border: 1px solid var(--p-surface-200);
+  border: 1px solid var(--border);
   border-radius: 999px;
   font-size: var(--text-sm);
   color: var(--p-text-color);

--- a/libs/bixarena/leaderboard/src/lib/leaderboard.component.scss
+++ b/libs/bixarena/leaderboard/src/lib/leaderboard.component.scss
@@ -68,7 +68,7 @@ bixarena-hero {
 
 .table-wrap {
   background: var(--p-surface-50);
-  border: 1px solid var(--p-surface-200);
+  border: 1px solid var(--border);
   border-radius: var(--p-border-radius-md);
   overflow: hidden;
 }
@@ -86,7 +86,7 @@ bixarena-hero {
 
 .retry-btn {
   padding: 0.4rem 0.9rem;
-  border: 1px solid var(--p-surface-200);
+  border: 1px solid var(--border);
   border-radius: var(--p-border-radius-md);
   background: var(--p-surface-100);
   color: var(--p-text-color);

--- a/libs/bixarena/services/src/lib/analytics.service.ts
+++ b/libs/bixarena/services/src/lib/analytics.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, PLATFORM_ID, inject } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { GoogleTagManagerService } from 'angular-google-tag-manager';
 import { BattleEvaluationOutcome } from '@sagebionetworks/bixarena/api-client';
 
@@ -26,7 +27,10 @@ const LOGIN_ENTRY_POINT_KEY = 'bixarena.loginEntryPoint';
 
 @Injectable({ providedIn: 'root' })
 export class AnalyticsService {
-  private readonly gtm = inject(GoogleTagManagerService, { optional: true });
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+  private readonly gtm = this.isBrowser
+    ? inject(GoogleTagManagerService, { optional: true })
+    : null;
 
   private push(event: string, params?: Record<string, unknown>): void {
     this.gtm?.pushTag({ event, ...params }).catch(() => undefined);

--- a/libs/bixarena/styles/src/lib/_overrides.scss
+++ b/libs/bixarena/styles/src/lib/_overrides.scss
@@ -36,7 +36,7 @@
 
   .bixarena-modal.p-dialog {
     background: var(--p-surface-100);
-    border-color: var(--p-surface-200);
+    border-color: var(--border);
     border-radius: 16px;
     box-shadow: 0 16px 64px rgb(0 0 0 / 30%);
     max-width: 480px;
@@ -132,14 +132,14 @@
       font-variation-settings: 'wght' 480;
       color: var(--p-text-muted-color);
       background: transparent;
-      border: 1px solid var(--p-surface-200);
+      border: 1px solid var(--border);
       border-radius: var(--p-border-radius-md);
       cursor: pointer;
       transition: all 0.15s;
 
       &:hover {
         color: var(--p-text-color);
-        border-color: var(--p-surface-300);
+        border-color: var(--border-hover);
         background: transparent;
       }
     }
@@ -194,7 +194,7 @@
       background: var(--p-surface-100);
       padding: 0.75rem 1rem;
       white-space: nowrap;
-      border-color: var(--p-surface-200);
+      border-color: var(--border);
     }
 
     // Shrink sort icons to match the small header type.
@@ -215,7 +215,7 @@
       vertical-align: middle;
       background: transparent;
       color: var(--p-text-color);
-      border-bottom: 1px solid var(--p-surface-200);
+      border-bottom: 1px solid var(--border);
     }
 
     .p-datatable-tbody > tr:last-child > td {
@@ -241,13 +241,13 @@
   .leaderboard-paginator .p-paginator-page.p-paginator-page-selected,
   .leaderboard-paginator .p-paginator-page.p-paginator-page-selected:hover {
     background: var(--p-surface-100);
-    border-color: var(--p-surface-200);
+    border-color: var(--border);
     color: var(--p-text-color);
   }
 
   .leaderboard-paginator .p-paginator-rpp-dropdown.p-select {
     background: var(--p-surface-100);
-    border-color: var(--p-surface-200);
+    border-color: var(--border);
     color: var(--p-text-color);
 
     // PrimeNG hardcodes this ring to orange-300 (#fdba74), bypassing tokens.
@@ -262,7 +262,7 @@
 
   .leaderboard-paginator .p-paginator-rpp-dropdown.p-select.p-focus,
   .leaderboard-paginator .p-paginator-rpp-dropdown.p-select:focus-within {
-    border-color: var(--p-surface-400);
+    border-color: var(--border-hover);
     box-shadow: none;
   }
 

--- a/libs/bixarena/styles/src/lib/_variables.scss
+++ b/libs/bixarena/styles/src/lib/_variables.scss
@@ -12,6 +12,8 @@
   --text-xl: 1.25rem;
   --text-2xl: 2rem;
   --text-3xl: 2.625rem;
+  --border: var(--p-surface-300);
+  --border-hover: var(--p-surface-400);
 }
 
 html:not(.dark) {

--- a/libs/bixarena/ui/src/lib/footer/footer.component.scss
+++ b/libs/bixarena/ui/src/lib/footer/footer.component.scss
@@ -1,7 +1,7 @@
 @use 'shared/typescript/styles/src/shared-styles/variables' as shared;
 
 footer {
-  border-top: 1px solid var(--p-surface-200);
+  border-top: 1px solid var(--border);
   padding: 1rem var(--content-padding-x);
   display: flex;
   align-items: center;

--- a/libs/bixarena/ui/src/lib/nav/nav.component.html
+++ b/libs/bixarena/ui/src/lib/nav/nav.component.html
@@ -10,23 +10,6 @@
   </nav>
   <div class="actions">
     <span class="divider"></span>
-    @if (showAvatar()) {
-      <button
-        class="avatar-btn"
-        (click)="authService.logout()"
-        [title]="'Logout ' + (displayUser()?.username ?? '')"
-        aria-label="Logout"
-      >
-        <bixarena-avatar
-          size="md"
-          shape="circle"
-          [imageUrl]="displayUser()?.avatarUrl ?? null"
-          [name]="displayUser()?.username ?? ''"
-        />
-      </button>
-    } @else {
-      <p-button class="login-btn" label="Login" (onClick)="login()" />
-    }
     <button
       class="theme-toggle"
       (click)="themeService.toggle()"
@@ -65,6 +48,23 @@
         </svg>
       }
     </button>
+    @if (showAvatar()) {
+      <button
+        class="avatar-btn"
+        (click)="authService.logout()"
+        [title]="'Logout ' + (displayUser()?.username ?? '')"
+        aria-label="Logout"
+      >
+        <bixarena-avatar
+          size="md"
+          shape="circle"
+          [imageUrl]="displayUser()?.avatarUrl ?? null"
+          [name]="displayUser()?.username ?? ''"
+        />
+      </button>
+    } @else {
+      <p-button class="login-btn" label="Login" (onClick)="login()" />
+    }
     <button
       class="hamburger"
       type="button"

--- a/libs/bixarena/ui/src/lib/nav/nav.component.scss
+++ b/libs/bixarena/ui/src/lib/nav/nav.component.scss
@@ -14,7 +14,7 @@
   height: var(--nav-height);
   background: var(--p-surface-0);
   color: var(--p-text-color);
-  border-bottom: 1px solid var(--p-surface-200);
+  border-bottom: 1px solid var(--border);
 }
 
 .brand {
@@ -168,7 +168,7 @@
     gap: 0.25rem;
     padding: 1rem var(--content-padding-x);
     background: var(--p-surface-0);
-    border-bottom: 1px solid var(--p-surface-200);
+    border-bottom: 1px solid var(--border);
     box-shadow: 0 8px 24px rgb(0 0 0 / 8%);
     animation: slide-down 0.18s cubic-bezier(0.2, 0.7, 0.3, 1);
 
@@ -194,7 +194,7 @@
 
     hr {
       border: none;
-      border-top: 1px solid var(--p-surface-200);
+      border-top: 1px solid var(--border);
       margin: 0.5rem 0;
     }
   }

--- a/libs/bixarena/ui/src/lib/nav/nav.component.scss
+++ b/libs/bixarena/ui/src/lib/nav/nav.component.scss
@@ -65,7 +65,7 @@
 .actions {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.5rem;
 }
 
 .divider {
@@ -100,7 +100,7 @@
   border: none;
   border-radius: var(--p-border-radius-md);
   background: transparent;
-  color: var(--p-surface-400);
+  color: var(--p-text-muted-color);
   cursor: pointer;
   transition:
     color 0.12s,

--- a/libs/bixarena/ui/src/lib/onboarding-fab/onboarding-fab.component.scss
+++ b/libs/bixarena/ui/src/lib/onboarding-fab/onboarding-fab.component.scss
@@ -11,7 +11,7 @@
   --fab-bg: var(--p-surface-100);
   --fab-bg-hover: var(--p-surface-200);
   --fab-fg: var(--p-text-color);
-  --fab-border: var(--p-surface-200);
+  --fab-border: var(--border);
 
   display: inline-flex;
   align-items: center;
@@ -59,7 +59,7 @@
 .fab:hover,
 .fab:focus-visible {
   background: var(--fab-bg-hover);
-  border-color: var(--p-surface-300);
+  border-color: var(--border-hover);
   box-shadow: 0 8px 24px rgb(0 0 0 / 16%);
 }
 

--- a/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
+++ b/libs/bixarena/ui/src/lib/onboarding-modal/onboarding-modal.component.scss
@@ -67,7 +67,7 @@
   gap: 0.6rem;
   padding: 0.6rem 0.85rem;
   background: var(--p-surface-0);
-  border: 1px solid var(--p-surface-200);
+  border: 1px solid var(--border);
   border-radius: 10px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.85rem;
@@ -105,7 +105,7 @@
 
 .panel {
   background: var(--p-surface-0);
-  border: 1px solid var(--p-surface-200);
+  border: 1px solid var(--border);
   border-radius: 10px;
   display: flex;
   flex-direction: column;
@@ -119,7 +119,7 @@
   justify-content: space-between;
   gap: 0.5rem;
   padding: 0.55rem 0.75rem;
-  border-bottom: 1px solid var(--p-surface-200);
+  border-bottom: 1px solid var(--border);
 }
 
 .panel.selected {
@@ -131,7 +131,7 @@
 @keyframes panel-select {
   0%,
   25% {
-    border-color: var(--p-surface-200);
+    border-color: var(--border);
     box-shadow: none;
   }
 
@@ -142,7 +142,7 @@
   }
 
   100% {
-    border-color: var(--p-surface-200);
+    border-color: var(--border);
     box-shadow: none;
   }
 }
@@ -196,7 +196,7 @@
   align-items: center;
   gap: 0.375rem;
   padding: 0.5rem 1.25rem;
-  border: 1px solid var(--p-surface-200);
+  border: 1px solid var(--border);
   border-radius: 100px;
   background: var(--p-surface-100);
   color: var(--p-surface-600);
@@ -210,7 +210,7 @@
 
 .vb.active {
   background: var(--p-surface-200);
-  border-color: var(--p-surface-300);
+  border-color: var(--border-hover);
   color: var(--p-text-color);
   transform: translateY(-1px);
   animation: vb-activate 4s ease-in-out infinite;
@@ -220,7 +220,7 @@
   0%,
   20% {
     background: var(--p-surface-100);
-    border-color: var(--p-surface-200);
+    border-color: var(--border);
     color: var(--p-surface-600);
     transform: translateY(0);
   }
@@ -228,14 +228,14 @@
   30%,
   78% {
     background: var(--p-surface-200);
-    border-color: var(--p-surface-300);
+    border-color: var(--border-hover);
     color: var(--p-text-color);
     transform: translateY(-1px);
   }
 
   100% {
     background: var(--p-surface-100);
-    border-color: var(--p-surface-200);
+    border-color: var(--border);
     color: var(--p-surface-600);
     transform: translateY(0);
   }
@@ -320,7 +320,7 @@
   gap: 0.85rem;
   padding: 0.45rem 0.85rem;
   background: var(--p-surface-0);
-  border: 1px solid var(--p-surface-200);
+  border: 1px solid var(--border);
   border-radius: 8px;
   font-size: 0.85rem;
 }

--- a/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
+++ b/libs/bixarena/ui/src/lib/prompt-card/prompt-card.component.scss
@@ -17,7 +17,7 @@
   gap: 0.5rem;
   margin-top: 0.875rem;
   padding-top: 0.875rem;
-  border-top: 1px solid var(--p-surface-200);
+  border-top: 1px solid var(--border);
 }
 
 .tag {
@@ -55,7 +55,7 @@
 
 .prompt-card {
   background: var(--p-surface-100);
-  border: 1px solid var(--p-surface-200);
+  border: 1px solid var(--border);
   border-radius: var(--p-border-radius-xl);
   padding: 1.25rem;
   min-height: 8.75rem;
@@ -73,7 +73,7 @@
     box-shadow 0.2s;
 
   &:hover {
-    border-color: var(--p-surface-300);
+    border-color: var(--border-hover);
     transform: translateY(-2px);
     box-shadow: 0 8px 32px rgb(0 0 0 / 25%);
   }
@@ -93,7 +93,7 @@
   }
 
   &:hover {
-    border-color: var(--p-surface-200);
+    border-color: var(--border);
     transform: none;
     box-shadow: none;
   }

--- a/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.html
+++ b/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.html
@@ -33,51 +33,10 @@
   </div>
 </div>
 <p class="disclaimer">
-  <span class="disclaimer-text"
-    >AI may make mistakes. Do not include sensitive or personal information.</span
+  Prompts are checked for biomedical relevance and sent to third-party LLM providers, who may store
+  and use them for training and service improvement.
+  <strong
+    >Don't include private, sensitive, confidential, or personally identifiable information.</strong
   >
-  <button
-    type="button"
-    class="more-info"
-    [attr.aria-expanded]="disclaimerOpen()"
-    aria-label="More info about how prompts are handled"
-    (click)="toggleDisclaimer($event)"
-  >
-    <svg
-      class="more-info-icon"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      aria-hidden="true"
-    >
-      <circle cx="12" cy="12" r="10" />
-      <path d="M12 16v-4M12 8h.01" />
-    </svg>
-    <span>More info</span>
-  </button>
+  AI responses may contain errors &mdash; verify all responses independently.
 </p>
-
-<p-popover
-  #disclaimerPopover
-  styleClass="prompt-disclaimer-popover"
-  (onShow)="disclaimerOpen.set(true)"
-  (onHide)="disclaimerOpen.set(false)"
->
-  <div class="disclaimer-content">
-    <div class="eyebrow">About your prompts</div>
-    <p>
-      Prompts are checked for biomedical relevance and sent to third-party LLM providers, who may
-      store and use them for training and service improvement.
-    </p>
-    <p class="warn">
-      <strong
-        >Don't include private, sensitive, confidential, or personally identifiable
-        information.</strong
-      >
-    </p>
-    <p>AI responses may contain errors. Verify all AI responses independently.</p>
-  </div>
-</p-popover>

--- a/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.html
+++ b/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.html
@@ -33,10 +33,12 @@
   </div>
 </div>
 <p class="disclaimer">
-  Prompts are checked for biomedical relevance and sent to third-party LLM providers, who may store
-  and use them for training and service improvement.
+  Your prompts are processed to ensure they are relevant to biomedical research, and are sent to
+  third-party LLM proxies and AI model providers who may store and use them for training and service
+  improvement.
   <strong
-    >Don't include private, sensitive, confidential, or personally identifiable information.</strong
+    >Do not include private, sensitive, confidential, or personally identifiable information in your
+    prompts.</strong
   >
-  AI responses may contain errors &mdash; verify all responses independently.
+  AI responses may contain errors. Verify all AI responses independently.
 </p>

--- a/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.scss
+++ b/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.scss
@@ -111,14 +111,14 @@
 }
 
 .disclaimer {
-  margin: 0.75rem 0 0;
+  margin: 0.625rem 0 0;
   padding: 0.75rem 1rem;
-  background: var(--p-surface-100);
-  border: 1px solid var(--p-surface-200);
+  background: var(--p-surface-50);
   border-radius: 12px;
   font-size: var(--text-xs);
-  line-height: 1.55;
+  line-height: 1.6;
   color: var(--p-text-muted-color);
+  text-align: left;
 
   strong {
     color: var(--p-text-color);

--- a/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.scss
+++ b/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.scss
@@ -111,75 +111,17 @@
 }
 
 .disclaimer {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 0.4rem 0.5rem;
-  font-size: var(--text-xs);
-  color: var(--p-text-muted-color);
   margin: 0.75rem 0 0;
-}
-
-.disclaimer-text {
-  line-height: 1.5;
-}
-
-.more-info {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--p-text-muted-color);
-  font: inherit;
-  font-size: inherit;
-  font-weight: 500;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  cursor: pointer;
-  transition: color 0.15s;
-
-  &:hover {
-    color: var(--p-text-color);
-  }
-
-  &[aria-expanded='true'] {
-    color: var(--p-text-color);
-  }
-}
-
-.more-info-icon {
-  width: 13px;
-  height: 13px;
-}
-
-.disclaimer-content {
-  max-width: 22rem;
-  font-size: var(--text-sm);
+  padding: 0.75rem 1rem;
+  background: var(--p-surface-100);
+  border: 1px solid var(--p-surface-200);
+  border-radius: 12px;
+  font-size: var(--text-xs);
   line-height: 1.55;
-  color: var(--p-text-color);
-
-  p {
-    margin: 0 0 0.75rem;
-  }
-
-  p:last-child {
-    margin-bottom: 0;
-  }
-
-  .warn {
-    color: var(--p-text-color);
-    font-weight: 500;
-  }
-}
-
-.eyebrow {
-  font-size: 0.6875rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
   color: var(--p-text-muted-color);
-  margin-bottom: 0.65rem;
+
+  strong {
+    color: var(--p-text-color);
+    font-weight: 600;
+  }
 }

--- a/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.scss
+++ b/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.scss
@@ -7,18 +7,18 @@
 
 .comp-card {
   background: var(--p-surface-100);
-  border: 1px solid var(--p-surface-200);
+  border: 1px solid var(--border);
   border-radius: 16px;
   overflow: hidden;
   transition: all 0.25s;
 
   &:hover {
-    border-color: var(--p-surface-300);
+    border-color: var(--border-hover);
     box-shadow: 0 2px 16px rgb(0 0 0 / 8%);
   }
 
   &:focus-within {
-    border-color: var(--p-surface-300);
+    border-color: var(--border-hover);
     box-shadow: 0 4px 32px rgb(0 0 0 / 20%);
   }
 }

--- a/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.ts
+++ b/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.ts
@@ -1,9 +1,8 @@
 import { Component, computed, ElementRef, input, output, signal, viewChild } from '@angular/core';
-import { Popover, PopoverModule } from 'primeng/popover';
 
 @Component({
   selector: 'bixarena-prompt-composer',
-  imports: [PopoverModule],
+  imports: [],
   templateUrl: './prompt-composer.component.html',
   styleUrl: './prompt-composer.component.scss',
 })
@@ -16,12 +15,6 @@ export class PromptComposerComponent {
 
   readonly text = signal('');
   readonly textareaEl = viewChild<ElementRef<HTMLTextAreaElement>>('textarea');
-  private readonly disclaimerPopover = viewChild.required<Popover>('disclaimerPopover');
-  readonly disclaimerOpen = signal(false);
-
-  toggleDisclaimer(event: Event): void {
-    this.disclaimerPopover().toggle(event);
-  }
 
   readonly isHot = computed(() => this.text().trim().length > 0 && !this.disabled());
 


### PR DESCRIPTION
## Description

Per discussion with PCO team, we will keep displaying the full transparency notice inline rather than shorten version with a "More info" disclosure, satisfying the team's transparency requirement that users be informed without needing to click. Bundles related polish: unified border tokens (`--border` / `--border-hover`) for consistent visual treatment across panels, dividers, and bordered buttons; a wider composer on the battle page so the disclaimer wraps cleanly to three lines; and a few small contrast bumps on voting buttons, model panel headers, and the nav theme toggle.

## Related Issue

[SMR-775](https://sagebionetworks.jira.com/browse/SMR-775)

## Changelog

- Replace short "More info"-gated disclaimer with the full inline transparency notice (PII warning, third-party processing, AI error caveat)
- Introduce `--border` and `--border-hover` tokens and migrate all panel, divider, and bordered-button colors across bixarena to use them
- Widen the prompt composer on the battle page so the disclaimer wraps to three lines instead of four
- Reposition theme toggle in the nav (now sits before avatar/login), align its color with nav links, and widen action-row spacing
- Bump contrast on voting buttons, model panel header label, and adjacent text by one surface step
- Suppress verbose `[ConfigLoader]` and `[YamlParser]` console logs from the shared platform lib via a bixarena-only override (with TODO to remove once the shared lib routes through the shared Logger)
- Set placeholder GTM id in `application-dev.yaml` to satisfy current shared schema validation (with TODO to remove once shared GTM schema makes id conditional on enabled)

## Preview

<img width="1426" height="782" alt="Screenshot 2026-05-06 at 12 21 54 PM" src="https://github.com/user-attachments/assets/e98fe4a9-af23-4b9d-9b56-0140ad6cbae1" />


[SMR-775]: https://sagebionetworks.jira.com/browse/SMR-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ