### PR TITLE
fix(bixarena): drop divergent BT entries from leaderboard snapshots

### DIFF
--- a/apps/bixarena/tools/bixarena_tools/leaderboard/leaderboard.py
+++ b/apps/bixarena/tools/bixarena_tools/leaderboard/leaderboard.py
@@ -71,7 +71,10 @@ def snapshot_add(
     min_total_models: int = typer.Option(
         4,
         "--min-total-models",
-        help="--all only: skip leaderboards with fewer distinct models than this",
+        help=(
+            "Skip the snapshot if fewer surviving entries than this. "
+            "In --all mode also gates on raw distinct-model count before BT."
+        ),
     ),
     dry_run: bool = typer.Option(
         False,
@@ -118,6 +121,7 @@ def snapshot_add(
             num_bootstrap=num_bootstrap,
             min_evals=min_evals,
             significant=significant,
+            min_total_models=min_total_models,
             dry_run=dry_run,
         )
 
@@ -126,6 +130,11 @@ def snapshot_add(
                 "\n[yellow]DRY RUN: Results computed only. "
                 "Database not updated.[/yellow]"
             )
+        elif result.get("skipped_reason"):
+            console.print(f"\n[yellow]Skipped: {result['skipped_reason']}[/yellow]")
+            console.print(f"  • Leaderboard: {result['leaderboard_name']}")
+            console.print(f"  • Evaluations considered: {result['evaluation_count']}")
+            return
         else:
             console.print("\n[bold green]✓ Database updated successfully![/bold green]")
             console.print(f"  • Snapshot ID: {result['snapshot_id']}")

--- a/libs/bixarena/battle/src/lib/battle.component.scss
+++ b/libs/bixarena/battle/src/lib/battle.component.scss
@@ -32,6 +32,12 @@ bixarena-example-prompts {
   align-self: center;
 }
 
+.battle-view .composer-group {
+  --composer-max-width: 100%;
+
+  max-width: none;
+}
+
 // Fixed height so panels scroll internally instead of growing infinitely.
 .battle-view {
   position: relative;

--- a/libs/bixarena/leaderboard-python/bixarena_leaderboard/snapshot_generator.py
+++ b/libs/bixarena/leaderboard-python/bixarena_leaderboard/snapshot_generator.py
@@ -11,6 +11,7 @@ Encapsulates the full snapshot workflow:
 
 import json
 import logging
+import math
 from datetime import UTC, datetime
 
 from bixarena_leaderboard.db_helper import (
@@ -43,20 +44,37 @@ class SnapshotRunError(RuntimeError):
 
 SNAPSHOT_IDENTIFIER_FORMAT = "snapshot_%Y-%m-%d_%H-%M-%S"
 
+# BT can diverge to ±inf on perfectly separable per-category data. Drop entries
+# with extreme btScore; clamp bootstrap CI bounds so they fit NUMERIC(10, 6).
+_BT_SCORE_MIN_EXCLUSIVE = 0.0  # drop if btScore <= this
+_BT_SCORE_MAX = 3000.0  # drop if btScore > this
+_CI_CLAMP = 3000.0  # bootstrap quantiles clamped to [-_CI_CLAMP, _CI_CLAMP]
+
+
+def _entry_has_valid_score(entry: dict) -> bool:
+    s = entry["btScore"]
+    return math.isfinite(s) and _BT_SCORE_MIN_EXCLUSIVE < s <= _BT_SCORE_MAX
+
+
+def _clamp_ci_bounds(entry: dict) -> None:
+    for field in ("bootstrapQ025", "bootstrapQ975"):
+        v = entry[field]
+        if not math.isfinite(v) or v < -_CI_CLAMP:
+            entry[field] = -_CI_CLAMP
+        elif v > _CI_CLAMP:
+            entry[field] = _CI_CLAMP
+
 
 def generate_snapshot(
     leaderboard_slug: str = "overall",
     num_bootstrap: int = 1000,
     min_evals: int = 10,
     significant: bool = False,
+    min_total_models: int = 4,
     dry_run: bool = False,
 ) -> dict:
     """
     Generate and publish a leaderboard snapshot.
-
-    Mirrors the manual CLI flow:
-      bixarena leaderboard snapshot add --min 10
-      bixarena leaderboard snapshot update <id> --visibility public
 
     Args:
         leaderboard_slug: Slug of the leaderboard to generate (default: 'overall').
@@ -64,19 +82,9 @@ def generate_snapshot(
         min_evals: Minimum evaluations per model to include in the snapshot.
         significant: If True, rank by statistical significance (CI overlap).
                      If False, rank by BT score only.
+        min_total_models: Minimum surviving entries required for the snapshot to
+                          publish. Below this, the leaderboard is skipped.
         dry_run: If True, compute rankings but do not write to the database.
-
-    Returns:
-        dict with keys:
-          - snapshot_id: UUID string of created snapshot (None if dry_run)
-          - snapshot_identifier: human-readable identifier string
-          - entry_count: number of ranked model entries
-          - evaluation_count: total evaluations used
-          - leaderboard_name: display name of the leaderboard
-
-    Raises:
-        ValueError: If num_bootstrap is out of range, min_evals is negative,
-                    the leaderboard slug is not found, or no evaluations exist.
     """
     if not (1 <= num_bootstrap <= 5000):
         raise ValueError(
@@ -84,6 +92,8 @@ def generate_snapshot(
         )
     if min_evals < 0:
         raise ValueError(f"min_evals must be >= 0, got {min_evals}")
+    if min_total_models < 0:
+        raise ValueError(f"min_total_models must be >= 0, got {min_total_models}")
 
     with get_db_connection() as conn:
         # Validate leaderboard slug
@@ -132,11 +142,60 @@ def generate_snapshot(
                 for new_rank, entry in enumerate(leaderboard_entries, start=1):
                     entry["rank"] = new_rank
 
+        # Drop entries with non-finite or out-of-range BT scores; clamp survivors' CIs.
+        before = len(leaderboard_entries)
+        leaderboard_entries = [
+            e for e in leaderboard_entries if _entry_has_valid_score(e)
+        ]
+        dropped_invalid = before - len(leaderboard_entries)
+        if dropped_invalid > 0:
+            logger.warning(
+                json.dumps(
+                    {
+                        "event": "leaderboard_dropped_invalid_entries",
+                        "slug": leaderboard_slug,
+                        "dropped_count": dropped_invalid,
+                    }
+                )
+            )
+            if not significant:
+                for new_rank, entry in enumerate(leaderboard_entries, start=1):
+                    entry["rank"] = new_rank
+        for entry in leaderboard_entries:
+            _clamp_ci_bounds(entry)
+
         snapshot_identifier = datetime.now(UTC).strftime(SNAPSHOT_IDENTIFIER_FORMAT)
         description = (
             f"Leaderboard snapshot with {len(all_evaluations)} evaluations "
             f"and {len(leaderboard_entries)} ranked models"
         )
+
+        if len(leaderboard_entries) < min_total_models:
+            reason = (
+                "no_qualifying_entries"
+                if not leaderboard_entries
+                else "insufficient_qualifying_entries"
+            )
+            logger.warning(
+                json.dumps(
+                    {
+                        "event": "leaderboard_skipped",
+                        "slug": leaderboard_slug,
+                        "reason": reason,
+                        "entry_count": len(leaderboard_entries),
+                        "min_total_models": min_total_models,
+                        "evaluation_count": len(all_evaluations),
+                    }
+                )
+            )
+            return {
+                "snapshot_id": None,
+                "snapshot_identifier": None,
+                "entry_count": len(leaderboard_entries),
+                "evaluation_count": len(all_evaluations),
+                "leaderboard_name": target_leaderboard["name"],
+                "skipped_reason": reason,
+            }
 
         if dry_run:
             return {
@@ -286,8 +345,29 @@ def generate_all_snapshots(
                 num_bootstrap=num_bootstrap,
                 min_evals=min_evals,
                 significant=significant,
+                min_total_models=min_total_models,
                 dry_run=dry_run,
             )
+            if result.get("skipped_reason"):
+                skipped.append(
+                    {
+                        "slug": slug,
+                        "reason": result["skipped_reason"],
+                        "battle_count": cand["battle_count"],
+                        "model_count": cand["model_count"],
+                    }
+                )
+                logger.warning(
+                    json.dumps(
+                        {
+                            "event": "leaderboard_skipped",
+                            "slug": slug,
+                            "reason": result["skipped_reason"],
+                            "evaluation_count": result.get("evaluation_count", 0),
+                        }
+                    )
+                )
+                continue
             generated.append({"slug": slug, **result})
             logger.info(
                 json.dumps(

--- a/libs/bixarena/leaderboard-python/tests/test_snapshot_generator.py
+++ b/libs/bixarena/leaderboard-python/tests/test_snapshot_generator.py
@@ -1,12 +1,18 @@
 """Unit tests for generate_snapshot() input validation."""
 
+import math
 from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
 
 from bixarena_leaderboard.snapshot_generator import (
+    _BT_SCORE_MAX,
+    _BT_SCORE_MIN_EXCLUSIVE,
+    _CI_CLAMP,
     SnapshotRunError,
+    _clamp_ci_bounds,
+    _entry_has_valid_score,
     generate_all_snapshots,
     generate_snapshot,
 )
@@ -58,6 +64,12 @@ class TestMinEvalsValidation:
             pass  # DB connection error expected in unit test environment
 
 
+class TestMinTotalModelsValidation:
+    def test_negative(self):
+        with pytest.raises(ValueError, match="min_total_models must be >= 0"):
+            generate_snapshot(num_bootstrap=100, min_total_models=-1)
+
+
 class TestGenerateAllSnapshotsValidation:
     def test_negative_min_total_battles(self):
         with pytest.raises(ValueError, match="min_total_battles must be >= 0"):
@@ -66,6 +78,67 @@ class TestGenerateAllSnapshotsValidation:
     def test_negative_min_total_models(self):
         with pytest.raises(ValueError, match="min_total_models must be >= 0"):
             generate_all_snapshots(min_total_models=-1)
+
+
+class TestEntryHasValidScore:
+    def test_typical_score_is_valid(self):
+        assert _entry_has_valid_score({"btScore": 500.0}) is True
+
+    def test_score_at_max_is_valid(self):
+        assert _entry_has_valid_score({"btScore": _BT_SCORE_MAX}) is True
+
+    def test_score_above_max_is_invalid(self):
+        assert _entry_has_valid_score({"btScore": _BT_SCORE_MAX + 1}) is False
+
+    def test_score_at_lower_threshold_is_invalid(self):
+        # Strict > _BT_SCORE_MIN_EXCLUSIVE; equality is rejected.
+        assert _entry_has_valid_score({"btScore": _BT_SCORE_MIN_EXCLUSIVE}) is False
+
+    def test_negative_score_is_invalid(self):
+        assert _entry_has_valid_score({"btScore": -100.0}) is False
+
+    def test_positive_inf_is_invalid(self):
+        assert _entry_has_valid_score({"btScore": math.inf}) is False
+
+    def test_negative_inf_is_invalid(self):
+        assert _entry_has_valid_score({"btScore": -math.inf}) is False
+
+    def test_nan_is_invalid(self):
+        assert _entry_has_valid_score({"btScore": math.nan}) is False
+
+
+class TestClampCiBounds:
+    @staticmethod
+    def _entry(lo, hi):
+        return {"bootstrapQ025": lo, "bootstrapQ975": hi}
+
+    def test_in_range_unchanged(self):
+        e = self._entry(-100.0, 200.0)
+        _clamp_ci_bounds(e)
+        assert e["bootstrapQ025"] == -100.0
+        assert e["bootstrapQ975"] == 200.0
+
+    def test_above_upper_bound_clamped(self):
+        e = self._entry(-100.0, _CI_CLAMP + 5000)
+        _clamp_ci_bounds(e)
+        assert e["bootstrapQ025"] == -100.0
+        assert e["bootstrapQ975"] == _CI_CLAMP
+
+    def test_below_lower_bound_clamped(self):
+        e = self._entry(-_CI_CLAMP - 5000, 200.0)
+        _clamp_ci_bounds(e)
+        assert e["bootstrapQ025"] == -_CI_CLAMP
+        assert e["bootstrapQ975"] == 200.0
+
+    def test_non_finite_clamped_to_lower_bound(self):
+        # Current behavior: any non-finite value (inf, -inf, NaN) collapses to
+        # -_CI_CLAMP. Asymmetric for +inf, but acceptable since divergent CIs
+        # are uninterpretable anyway.
+        for bad in (math.inf, -math.inf, math.nan):
+            e = self._entry(bad, bad)
+            _clamp_ci_bounds(e)
+            assert e["bootstrapQ025"] == -_CI_CLAMP
+            assert e["bootstrapQ975"] == -_CI_CLAMP
 
 
 @contextmanager
@@ -261,3 +334,63 @@ class TestGenerateAllSnapshotsBehavior:
         assert {e["slug"] for e in summary["generated"]} == {"overall"}
         assert summary["failed"] == [{"slug": "cancer-biology", "error": "boom"}]
         assert summary["total"] == 2
+
+    def test_no_qualifying_entries_routes_to_skipped(self):
+        leaderboards = [{"slug": "cancer-biology", "name": "Cancer Biology"}]
+        stats: dict = {"cancer-biology": {"battle_count": 50, "model_count": 5}}
+        outcomes: dict = {
+            "cancer-biology": {
+                "snapshot_id": None,
+                "snapshot_identifier": None,
+                "entry_count": 0,
+                "evaluation_count": 50,
+                "leaderboard_name": "Cancer Biology",
+                "skipped_reason": "no_qualifying_entries",
+            },
+        }
+        patches = _patch_orchestrator(leaderboards, stats, outcomes)
+        _apply_patches(patches)
+        try:
+            summary = generate_all_snapshots(
+                min_total_battles=10,
+                min_total_models=2,
+            )
+        finally:
+            _stop_patches(patches)
+
+        assert summary["generated"] == []
+        assert summary["failed"] == []
+        assert len(summary["skipped"]) == 1
+        skip = summary["skipped"][0]
+        assert skip["slug"] == "cancer-biology"
+        assert skip["reason"] == "no_qualifying_entries"
+        assert skip["battle_count"] == 50
+        assert skip["model_count"] == 5
+
+    def test_insufficient_qualifying_entries_routes_to_skipped(self):
+        leaderboards = [{"slug": "cancer-biology", "name": "Cancer Biology"}]
+        stats: dict = {"cancer-biology": {"battle_count": 50, "model_count": 5}}
+        outcomes: dict = {
+            "cancer-biology": {
+                "snapshot_id": None,
+                "snapshot_identifier": None,
+                "entry_count": 2,
+                "evaluation_count": 50,
+                "leaderboard_name": "Cancer Biology",
+                "skipped_reason": "insufficient_qualifying_entries",
+            },
+        }
+        patches = _patch_orchestrator(leaderboards, stats, outcomes)
+        _apply_patches(patches)
+        try:
+            summary = generate_all_snapshots(
+                min_total_battles=10,
+                min_total_models=2,
+            )
+        finally:
+            _stop_patches(patches)
+
+        assert summary["generated"] == []
+        assert len(summary["skipped"]) == 1
+        skip = summary["skipped"][0]
+        assert skip["reason"] == "insufficient_qualifying_entries"

--- a/libs/bixarena/styles/src/lib/_layout.scss
+++ b/libs/bixarena/styles/src/lib/_layout.scss
@@ -14,7 +14,7 @@
   --hero-subtitle-font-size: 1rem;
   --hero-subtitle-max-width: 36rem;
   --composer-max-width: 48rem;
-  --composer-input-min-height: 3.5rem;
+  --composer-input-min-height: 2.5rem;
   --panel-body-font-size: var(--text-md);
 }
 

--- a/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.scss
+++ b/libs/bixarena/ui/src/lib/prompt-composer/prompt-composer.component.scss
@@ -115,7 +115,7 @@
   padding: 0.75rem 1rem;
   background: var(--p-surface-50);
   border-radius: 12px;
-  font-size: var(--text-xs);
+  font-size: 0.6875rem;
   line-height: 1.6;
   color: var(--p-text-muted-color);
   text-align: left;
@@ -124,4 +124,10 @@
     color: var(--p-text-color);
     font-weight: 600;
   }
+}
+
+:host-context(.battle-view) .disclaimer {
+  padding: 0 1rem;
+  background: transparent;
+  border-radius: 0;
 }


### PR DESCRIPTION
## Description

The daily leaderboard snapshot job was failing with `psycopg.errors.NumericValueOutOfRange` whenever Bradley-Terry produced ±inf ratings on perfectly-separable per-category data — common at low data density on stage and on any newly-seeded prod category. This PR drops divergent entries before insert, skips the snapshot row when no qualifying entries remain, and respects a per-snapshot model floor so a leaderboard with too few survivors is gracefully skipped rather than published. Bundled in: a few visual tweaks to the battle-view composer (full-width to match panels, tighter input height, flat disclaimer) that reclaim vertical space for the streaming LLM responses without weakening transparency.

## Changelog

- Drop entries with non-finite or out-of-range BT scores before insert; clamp bootstrap CI bounds to fit `NUMERIC(10,6)`
- Skip snapshot creation when no qualifying entries remain, with explicit reason routing (`no_qualifying_entries`, `insufficient_qualifying_entries`)
- Wire `--min-total-models` through both single-slug and `--all` CLI paths so the entry floor is consistently applied
- Lower default `--composer-input-min-height` and widen the battle-view composer to match the model-panel grid
- Flatten the disclaimer panel on battle view (no background, smaller text) to recover vertical space for LLM responses
- Add unit tests covering BT divergence drops, CI clamping, and skipped-reason routing