### PR TITLE
feat(explorers): extend boxplot chart styling for qtl (QTL-39)

### DIFF
--- a/libs/explorers/CLAUDE.md
+++ b/libs/explorers/CLAUDE.md
@@ -32,7 +32,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 nx test explorers-<lib-name>               # run unit tests for a lib
 nx lint explorers-<lib-name>               # lint a lib
 nx start explorers-storybook       # serve explorers Storybook (port 4402)
-nx run explorers-charts-angular:storybook  # serve charts Storybook (port 4400)
+nx start explorers-charts-angular          # serve charts Storybook (port 4400)
 ```
 
 ## Testing Conventions

--- a/libs/explorers/charts-angular/project.json
+++ b/libs/explorers/charts-angular/project.json
@@ -23,7 +23,7 @@
         "fix": true
       }
     },
-    "storybook": {
+    "start": {
       "executor": "@storybook/angular:start-storybook",
       "options": {
         "port": 4400,

--- a/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
+++ b/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
@@ -30,6 +30,11 @@ const renderTestComponent = async (props: BoxplotProps) => {
       [pointOpacity]="pointOpacity"
       [noDataStyle]="noDataStyle"
       [chartStyle]="chartStyle"
+      [laneBackgroundColors]="laneBackgroundColors"
+      [showAxisTicks]="showAxisTicks"
+      [boxplotBoxStyle]="boxplotBoxStyle"
+      [axisTickLabelStyle]="axisTickLabelStyle"
+      [axisLineStyle]="axisLineStyle"
     ></div>`,
   })
   class TestComponent {
@@ -50,6 +55,11 @@ const renderTestComponent = async (props: BoxplotProps) => {
     pointOpacity = props.pointOpacity;
     noDataStyle = props.noDataStyle;
     chartStyle = props.chartStyle;
+    laneBackgroundColors = props.laneBackgroundColors;
+    showAxisTicks = props.showAxisTicks;
+    boxplotBoxStyle = props.boxplotBoxStyle;
+    axisTickLabelStyle = props.axisTickLabelStyle;
+    axisLineStyle = props.axisLineStyle;
   }
 
   return await render(TestComponent, {

--- a/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
+++ b/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
@@ -19,7 +19,7 @@ const meta: Meta<BoxplotDirective> = {
   },
   render: (args: BoxplotProps) => ({
     props: args,
-    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [xAxisLabelFormatter]="xAxisLabelFormatter" [xAxisCategories]="xAxisCategories" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisLabelTooltipFormatter]="xAxisLabelTooltipFormatter" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes" [showLegend]="showLegend" [pointOpacity]="pointOpacity" [noDataStyle]="noDataStyle" [chartStyle]="chartStyle" [laneBackgroundColors]="laneBackgroundColors" [showAxisTicks]="showAxisTicks" [boxplotBoxFillColor]="boxplotBoxFillColor" [boxplotBoxBorderColor]="boxplotBoxBorderColor" [axisTickLabelStyle]="axisTickLabelStyle" [axisLineStyle]="axisLineStyle"></div>`,
+    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [xAxisLabelFormatter]="xAxisLabelFormatter" [xAxisCategories]="xAxisCategories" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisLabelTooltipFormatter]="xAxisLabelTooltipFormatter" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes" [showLegend]="showLegend" [pointOpacity]="pointOpacity" [noDataStyle]="noDataStyle" [chartStyle]="chartStyle" [laneBackgroundColors]="laneBackgroundColors" [showAxisTicks]="showAxisTicks" [boxplotBoxStyle]="boxplotBoxStyle" [axisTickLabelStyle]="axisTickLabelStyle" [axisLineStyle]="axisLineStyle"></div>`,
   }),
 };
 export default meta;
@@ -79,8 +79,11 @@ export const Styled: Story = {
     pointTooltipFormatter: (pt: CategoryPoint) => `${pt.pointCategory}: ${pt.value}`,
     laneBackgroundColors: ['#F9F9FA', '#FFFFFF'],
     showAxisTicks: false,
-    boxplotBoxFillColor: 'rgba(210, 175, 129, 0.5)',
-    boxplotBoxBorderColor: '#22252A',
+    boxplotBoxStyle: {
+      fillColor: 'rgba(210, 175, 129, 0.5)',
+      borderColor: '#22252A',
+      borderWidth: 1,
+    },
     axisTickLabelStyle: { fontSize: '12px', fontWeight: 400, color: '#4A5056' },
     axisLineStyle: { width: 1, color: '#000' },
   },

--- a/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
+++ b/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
@@ -19,7 +19,7 @@ const meta: Meta<BoxplotDirective> = {
   },
   render: (args: BoxplotProps) => ({
     props: args,
-    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [xAxisLabelFormatter]="xAxisLabelFormatter" [xAxisCategories]="xAxisCategories" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisLabelTooltipFormatter]="xAxisLabelTooltipFormatter" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes" [showLegend]="showLegend" [pointOpacity]="pointOpacity" [noDataStyle]="noDataStyle" [chartStyle]="chartStyle"></div>`,
+    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [xAxisLabelFormatter]="xAxisLabelFormatter" [xAxisCategories]="xAxisCategories" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisLabelTooltipFormatter]="xAxisLabelTooltipFormatter" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes" [showLegend]="showLegend" [pointOpacity]="pointOpacity" [noDataStyle]="noDataStyle" [chartStyle]="chartStyle" [laneBackgroundColors]="laneBackgroundColors" [showAxisTicks]="showAxisTicks" [boxplotBoxFillColor]="boxplotBoxFillColor" [boxplotBoxBorderColor]="boxplotBoxBorderColor" [axisTickLabelStyle]="axisTickLabelStyle" [axisLineStyle]="axisLineStyle"></div>`,
   }),
 };
 export default meta;
@@ -69,5 +69,19 @@ export const DynamicSummary: Story = {
     pointOpacity: 0.5,
     noDataStyle: 'grayBackground',
     chartStyle: 'grayGrid',
+  },
+};
+
+export const Styled: Story = {
+  args: {
+    summaries: staticBoxplotSummaries,
+    points: [],
+    pointTooltipFormatter: (pt: CategoryPoint) => `${pt.pointCategory}: ${pt.value}`,
+    laneBackgroundColors: ['#F9F9FA', '#FFFFFF'],
+    showAxisTicks: false,
+    boxplotBoxFillColor: 'rgba(210, 175, 129, 0.5)',
+    boxplotBoxBorderColor: '#22252A',
+    axisTickLabelStyle: { fontSize: '12px', fontWeight: 400, color: '#4A5056' },
+    axisLineStyle: { width: 1, color: '#000' },
   },
 };

--- a/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.ts
+++ b/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.ts
@@ -1,7 +1,8 @@
 import { Directive, ElementRef, inject, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
 import {
-  AxisTickLabelStyle,
   AxisLineStyle,
+  AxisTickLabelStyle,
+  BoxplotBoxStyle,
   BoxplotChart,
   BoxplotProps,
   CategoryBoxplotSummary,
@@ -40,8 +41,7 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
   @Input() chartStyle: undefined | ChartStyle;
   @Input() laneBackgroundColors: undefined | string[];
   @Input() showAxisTicks: undefined | boolean;
-  @Input() boxplotBoxFillColor: undefined | string;
-  @Input() boxplotBoxBorderColor: undefined | string;
+  @Input() boxplotBoxStyle: undefined | BoxplotBoxStyle;
   @Input() axisTickLabelStyle: undefined | AxisTickLabelStyle;
   @Input() axisLineStyle: undefined | AxisLineStyle;
 
@@ -78,8 +78,7 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
       chartStyle: this.chartStyle,
       laneBackgroundColors: this.laneBackgroundColors,
       showAxisTicks: this.showAxisTicks,
-      boxplotBoxFillColor: this.boxplotBoxFillColor,
-      boxplotBoxBorderColor: this.boxplotBoxBorderColor,
+      boxplotBoxStyle: this.boxplotBoxStyle,
       axisTickLabelStyle: this.axisTickLabelStyle,
       axisLineStyle: this.axisLineStyle,
     };

--- a/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.ts
+++ b/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.ts
@@ -1,5 +1,7 @@
 import { Directive, ElementRef, inject, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
 import {
+  AxisTickLabelStyle,
+  AxisLineStyle,
   BoxplotChart,
   BoxplotProps,
   CategoryBoxplotSummary,
@@ -36,6 +38,12 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
   @Input() pointOpacity: undefined | number;
   @Input() noDataStyle: undefined | 'textOnly' | 'grayBackground';
   @Input() chartStyle: undefined | ChartStyle;
+  @Input() laneBackgroundColors: undefined | string[];
+  @Input() showAxisTicks: undefined | boolean;
+  @Input() boxplotBoxFillColor: undefined | string;
+  @Input() boxplotBoxBorderColor: undefined | string;
+  @Input() axisTickLabelStyle: undefined | AxisTickLabelStyle;
+  @Input() axisLineStyle: undefined | AxisLineStyle;
 
   ngOnInit() {
     this.boxplot = new BoxplotChart(this.el.nativeElement, this.getBoxplotProps());
@@ -68,6 +76,12 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
       pointOpacity: this.pointOpacity,
       noDataStyle: this.noDataStyle,
       chartStyle: this.chartStyle,
+      laneBackgroundColors: this.laneBackgroundColors,
+      showAxisTicks: this.showAxisTicks,
+      boxplotBoxFillColor: this.boxplotBoxFillColor,
+      boxplotBoxBorderColor: this.boxplotBoxBorderColor,
+      axisTickLabelStyle: this.axisTickLabelStyle,
+      axisLineStyle: this.axisLineStyle,
     };
   }
 }

--- a/libs/explorers/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/explorers/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -73,6 +73,9 @@ export class BoxplotChart {
     xAxisLabelFormatter: BoxplotProps['xAxisLabelFormatter'],
     xAxisLabelTooltipFormatter: BoxplotProps['xAxisLabelTooltipFormatter'],
     boxplotChartTheme: BoxplotChartTheme,
+    showAxisTicks: BoxplotProps['showAxisTicks'],
+    axisTickLabelStyle: BoxplotProps['axisTickLabelStyle'],
+    axisLineStyle: BoxplotProps['axisLineStyle'],
   ) {
     // Use two xAxes:
     //  - value: used to jitter points with multiple pointCategories, where
@@ -85,6 +88,8 @@ export class BoxplotChart {
       {
         id: 'value-x-axis',
         type: 'value',
+        // Render above the boxplot series so lane background fills don't occlude the axis line.
+        z: 10,
         axisLine: {
           onZero: false,
         },
@@ -104,9 +109,11 @@ export class BoxplotChart {
       {
         id: 'category-x-axis',
         type: 'category',
+        z: 10,
         data: xAxisCategories,
         axisLabel: {
           ...boxplotChartTheme.xAxisLabelTextStyle,
+          ...(axisTickLabelStyle ?? {}),
           interval: 0, // ensure all labels are shown
           formatter: (value) => {
             if (xAxisLabelFormatter) {
@@ -117,9 +124,11 @@ export class BoxplotChart {
         },
         axisTick: {
           alignWithLabel: true,
+          show: showAxisTicks !== false,
         },
         axisLine: {
           onZero: false,
+          ...(axisLineStyle ? { lineStyle: axisLineStyle } : {}),
         },
         tooltip: {
           ...(xAxisLabelTooltipFormatter && {
@@ -142,21 +151,31 @@ export class BoxplotChart {
     yAxisMin: BoxplotProps['yAxisMin'],
     yAxisMax: BoxplotProps['yAxisMax'],
     boxplotChartTheme: BoxplotChartTheme,
+    showAxisTicks: BoxplotProps['showAxisTicks'],
+    axisTickLabelStyle: BoxplotProps['axisTickLabelStyle'],
+    axisLineStyle: BoxplotProps['axisLineStyle'],
   ) {
     const yAxisOptions: EChartsOption['yAxis'] = {
       type: 'value',
+      // Render above the boxplot series so lane background fills don't occlude the axis line.
+      z: 10,
       name: yAxisTitle,
       nameLocation: 'middle',
       nameGap: boxplotChartTheme.yAxisTickLabelMaxWidth,
       nameTextStyle: boxplotChartTheme.yAxisTitleTextStyle,
       axisLine: {
         show: true,
+        ...(axisLineStyle ? { lineStyle: axisLineStyle } : {}),
+      },
+      axisTick: {
+        show: showAxisTicks !== false,
       },
       axisLabel: {
         width: boxplotChartTheme.yAxisTickLabelMaxWidth,
         hideOverlap: true,
         showMinLabel: yAxisMin == null,
         showMaxLabel: yAxisMax == null,
+        ...(axisTickLabelStyle ?? {}),
       },
       splitLine: boxplotChartTheme.yAxisSplitLine,
       min: yAxisMin ? yAxisMin - yAxisPadding : undefined,
@@ -183,6 +202,12 @@ export class BoxplotChart {
       pointCategoryShapes,
       pointOpacity,
       chartStyle,
+      laneBackgroundColors,
+      showAxisTicks,
+      boxplotBoxFillColor,
+      boxplotBoxBorderColor,
+      axisTickLabelStyle,
+      axisLineStyle,
     } = boxplotProps;
 
     const showLegend = boxplotProps.showLegend || false;
@@ -272,13 +297,34 @@ export class BoxplotChart {
     const boxplotSeriesBase: SeriesOption = {
       type: 'boxplot',
       z: 1,
-      itemStyle: boxplotChartTheme.boxplotItemStyle,
+      itemStyle: {
+        ...boxplotChartTheme.boxplotItemStyle,
+        ...(boxplotBoxFillColor ? { color: boxplotBoxFillColor } : {}),
+        ...(boxplotBoxBorderColor ? { borderColor: boxplotBoxBorderColor } : {}),
+      },
       boxWidth: [7, 115],
       silent: true,
       tooltip: {
         show: false,
       },
-      markArea: boxplotChartTheme.getBoxplotMarkArea?.(xAxisCategories),
+      markArea: laneBackgroundColors?.length
+        ? {
+            itemStyle: {},
+            data: xAxisCategories.map((_, idx) => {
+              const halfWidth = 0.5; // lanes butt up against each other (no gap)
+              const pcIndex = idx + 1;
+              return [
+                {
+                  xAxis: pcIndex - halfWidth,
+                  itemStyle: {
+                    color: laneBackgroundColors[idx % laneBackgroundColors.length],
+                  },
+                },
+                { xAxis: pcIndex + halfWidth },
+              ];
+            }),
+          }
+        : boxplotChartTheme.getBoxplotMarkArea?.(xAxisCategories),
     };
     if (summaries) {
       seriesOpts.push({
@@ -372,8 +418,19 @@ export class BoxplotChart {
         xAxisLabelFormatter,
         xAxisLabelTooltipFormatter,
         boxplotChartTheme,
+        showAxisTicks,
+        axisTickLabelStyle,
+        axisLineStyle,
       ),
-      yAxis: this.getYAxisOptions(yAxisTitle, yAxisMin, yAxisMax, boxplotChartTheme),
+      yAxis: this.getYAxisOptions(
+        yAxisTitle,
+        yAxisMin,
+        yAxisMax,
+        boxplotChartTheme,
+        showAxisTicks,
+        axisTickLabelStyle,
+        axisLineStyle,
+      ),
       tooltip: boxplotChartTheme.tooltip,
       series: seriesOpts,
     };

--- a/libs/explorers/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/explorers/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -204,8 +204,7 @@ export class BoxplotChart {
       chartStyle,
       laneBackgroundColors,
       showAxisTicks,
-      boxplotBoxFillColor,
-      boxplotBoxBorderColor,
+      boxplotBoxStyle,
       axisTickLabelStyle,
       axisLineStyle,
     } = boxplotProps;
@@ -299,8 +298,11 @@ export class BoxplotChart {
       z: 1,
       itemStyle: {
         ...boxplotChartTheme.boxplotItemStyle,
-        ...(boxplotBoxFillColor ? { color: boxplotBoxFillColor } : {}),
-        ...(boxplotBoxBorderColor ? { borderColor: boxplotBoxBorderColor } : {}),
+        ...(boxplotBoxStyle?.fillColor ? { color: boxplotBoxStyle.fillColor } : {}),
+        ...(boxplotBoxStyle?.borderColor ? { borderColor: boxplotBoxStyle.borderColor } : {}),
+        ...(typeof boxplotBoxStyle?.borderWidth === 'number'
+          ? { borderWidth: boxplotBoxStyle.borderWidth }
+          : {}),
       },
       boxWidth: [7, 115],
       silent: true,

--- a/libs/explorers/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/explorers/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -1,10 +1,10 @@
 import { DatasetComponentOption, ECharts, EChartsOption, SeriesOption } from 'echarts';
 import { CallbackDataParams } from 'echarts/types/dist/shared';
-import { DEFAULT_COLOR } from '../constants';
 import {
   grayGridBoxplotChartTheme,
   minimalBoxplotChartTheme,
 } from '../chart-theme/boxplot-chart-theme';
+import { DEFAULT_COLOR } from '../constants';
 import { BoxplotProps, CategoryPoint } from '../models';
 import { BoxplotChartTheme } from '../models/boxplot';
 import {
@@ -88,7 +88,7 @@ export class BoxplotChart {
       {
         id: 'value-x-axis',
         type: 'value',
-        // Render above the boxplot series so lane background fills don't occlude the axis line.
+        // Ensure axes render above series markAreas
         z: 10,
         axisLine: {
           onZero: false,
@@ -113,7 +113,7 @@ export class BoxplotChart {
         data: xAxisCategories,
         axisLabel: {
           ...boxplotChartTheme.xAxisLabelTextStyle,
-          ...(axisTickLabelStyle ?? {}),
+          ...axisTickLabelStyle,
           interval: 0, // ensure all labels are shown
           formatter: (value) => {
             if (xAxisLabelFormatter) {
@@ -157,7 +157,7 @@ export class BoxplotChart {
   ) {
     const yAxisOptions: EChartsOption['yAxis'] = {
       type: 'value',
-      // Render above the boxplot series so lane background fills don't occlude the axis line.
+      // Ensure axes render above series markAreas
       z: 10,
       name: yAxisTitle,
       nameLocation: 'middle',
@@ -171,11 +171,11 @@ export class BoxplotChart {
         show: showAxisTicks !== false,
       },
       axisLabel: {
+        ...axisTickLabelStyle,
         width: boxplotChartTheme.yAxisTickLabelMaxWidth,
         hideOverlap: true,
         showMinLabel: yAxisMin == null,
         showMaxLabel: yAxisMax == null,
-        ...(axisTickLabelStyle ?? {}),
       },
       splitLine: boxplotChartTheme.yAxisSplitLine,
       min: yAxisMin ? yAxisMin - yAxisPadding : undefined,
@@ -311,7 +311,6 @@ export class BoxplotChart {
       },
       markArea: laneBackgroundColors?.length
         ? {
-            itemStyle: {},
             data: xAxisCategories.map((_, idx) => {
               const halfWidth = 0.5; // lanes butt up against each other (no gap)
               const pcIndex = idx + 1;

--- a/libs/explorers/charts/src/lib/models/boxplot.ts
+++ b/libs/explorers/charts/src/lib/models/boxplot.ts
@@ -71,7 +71,8 @@ export interface BoxplotProps {
   noDataStyle?: 'textOnly' | 'grayBackground';
   chartStyle?: ChartStyle;
   /* if defined, lanes will be filled with these colors, cycling through the array
-  per x-axis category. Lanes butt up against each other with no gap. */
+  per x-axis category. Lanes butt up against each other with no gap. Overrides the
+  active chartStyle's lane background (e.g. grayGrid's gray bands). */
   laneBackgroundColors?: string[];
   /* if false, hides axis tick marks on the category x-axis and the y-axis. */
   showAxisTicks?: boolean;

--- a/libs/explorers/charts/src/lib/models/boxplot.ts
+++ b/libs/explorers/charts/src/lib/models/boxplot.ts
@@ -70,7 +70,31 @@ export interface BoxplotProps {
   pointOpacity?: number;
   noDataStyle?: 'textOnly' | 'grayBackground';
   chartStyle?: ChartStyle;
+  /* if defined, lanes will be filled with these colors, cycling through the array
+  per x-axis category. Lanes butt up against each other with no gap. */
+  laneBackgroundColors?: string[];
+  /* if false, hides axis tick marks on the category x-axis and the y-axis. */
+  showAxisTicks?: boolean;
+  /* if defined, overrides the boxplot box fill color. */
+  boxplotBoxFillColor?: string;
+  /* if defined, overrides the boxplot box border color. */
+  boxplotBoxBorderColor?: string;
+  /* if defined, overrides tick-label typography on both the category x-axis and the y-axis. */
+  axisTickLabelStyle?: AxisTickLabelStyle;
+  /* if defined, overrides the axis line stroke on both the category x-axis and the y-axis. */
+  axisLineStyle?: AxisLineStyle;
 }
+
+export type AxisTickLabelStyle = {
+  fontSize?: string;
+  fontWeight?: 'normal' | 'bold' | 'bolder' | 'lighter' | number;
+  color?: string;
+};
+
+export type AxisLineStyle = {
+  width?: number;
+  color?: string;
+};
 
 export interface BoxplotChartTheme extends BaseChartTheme {
   boxplotItemStyle: BoxplotSeriesOption['itemStyle'];

--- a/libs/explorers/charts/src/lib/models/boxplot.ts
+++ b/libs/explorers/charts/src/lib/models/boxplot.ts
@@ -75,15 +75,19 @@ export interface BoxplotProps {
   laneBackgroundColors?: string[];
   /* if false, hides axis tick marks on the category x-axis and the y-axis. */
   showAxisTicks?: boolean;
-  /* if defined, overrides the boxplot box fill color. */
-  boxplotBoxFillColor?: string;
-  /* if defined, overrides the boxplot box border color. */
-  boxplotBoxBorderColor?: string;
+  /* if defined, overrides the boxplot box fill, border color, and/or border width. */
+  boxplotBoxStyle?: BoxplotBoxStyle;
   /* if defined, overrides tick-label typography on both the category x-axis and the y-axis. */
   axisTickLabelStyle?: AxisTickLabelStyle;
   /* if defined, overrides the axis line stroke on both the category x-axis and the y-axis. */
   axisLineStyle?: AxisLineStyle;
 }
+
+export type BoxplotBoxStyle = {
+  fillColor?: string;
+  borderColor?: string;
+  borderWidth?: number;
+};
 
 export type AxisTickLabelStyle = {
   fontSize?: string;

--- a/libs/explorers/charts/src/lib/models/index.ts
+++ b/libs/explorers/charts/src/lib/models/index.ts
@@ -1,6 +1,7 @@
 export type {
-  AxisTickLabelStyle,
   AxisLineStyle,
+  AxisTickLabelStyle,
+  BoxplotBoxStyle,
   BoxplotProps,
   CategoryAsValueBoxplotSummary,
   CategoryAsValuePoint,

--- a/libs/explorers/charts/src/lib/models/index.ts
+++ b/libs/explorers/charts/src/lib/models/index.ts
@@ -1,4 +1,6 @@
 export type {
+  AxisTickLabelStyle,
+  AxisLineStyle,
   BoxplotProps,
   CategoryAsValueBoxplotSummary,
   CategoryAsValuePoint,


### PR DESCRIPTION
## Description

Add five optional style-override props on the shared `BoxplotChart` so QTL can render boxplots in its own visual style without forking a new theme. Existing consumers (Agora, Model-AD) are unaffected.

## Related Issue

- [QTL-39](https://sagebionetworks.jira.com/browse/QTL-39)

## Changelog

- Add `laneBackgroundColors`, `showAxisTicks`, `boxplotBoxStyle`, `axisTickLabelStyle`, and `axisLineStyle` to `BoxplotProps` and `BoxplotDirective`
- Render adjacent lane backgrounds with no gap and lift axes above the series so the lane fills don't occlude axis lines
- Add a `Styled` Storybook story showcasing the new props
- Rename the `explorers-charts-angular` storybook target from `storybook` to `start` to match the other Storybooks

## Preview

`nx start explorers-charts-angular` - Styled story shows QTL style: 
<img width="645" height="323" alt="QTL-39" src="https://github.com/user-attachments/assets/942d5e94-b1ea-4405-8c3d-21a1b25166e1" />

Agora boxplot unchanged (`/genes/ENSG00000171862/evidence/rna`): 

dev | this PR
:---: | :---: 
<img width="719" height="631" alt="QTL-39_agora_dev" src="https://github.com/user-attachments/assets/d5aa47f8-b4fe-4747-8e4b-4de184c1a305" /> | <img width="720" height="632" alt="QTL-39_agora_pr" src="https://github.com/user-attachments/assets/39d3dffb-e4fa-4c50-9759-f4faa9856c62" />

Model-AD boxplot unchanged (`/genes/ENSMUSG00000086714?modelGroup=5xFAD%20(IU%2FJax%2FPitt)&tissue=Hemibrain`):

dev | this PR
:---: | :---: 
<img width="1083" height="433" alt="QTL-39_modelad_dev" src="https://github.com/user-attachments/assets/a77d1be0-e98d-4000-8b04-1cef76509045" /> | <img width="1095" height="428" alt="QTL-39_modelad_pr" src="https://github.com/user-attachments/assets/f63412bc-3b05-4a17-9d6b-e69aa154dc81" />


[QTL-39]: https://sagebionetworks.jira.com/browse/QTL-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ