### PR TITLE
feat(explorers): extend chiclet to support sidebar chiclet style (QTL-36)

### DIFF
--- a/libs/explorers/ui/src/lib/components/chiclet/chiclet.component.html
+++ b/libs/explorers/ui/src/lib/components/chiclet/chiclet.component.html
@@ -2,6 +2,8 @@
   class="explorers-chiclet"
   [style.background-color]="backgroundColor()"
   [style.color]="textColor()"
+  [style.border-radius]="borderRadius()"
+  [style.padding]="padding()"
 >
   <span class="chiclet-label unselectable-text" [style.font-size]="fontSize()">
     <ng-content />

--- a/libs/explorers/ui/src/lib/components/chiclet/chiclet.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/chiclet/chiclet.component.spec.ts
@@ -117,4 +117,20 @@ describe('ChicletComponent', () => {
     const labelEl = fixture.nativeElement.querySelector('.chiclet-label') as HTMLElement;
     expect(labelEl.style.fontSize).toBe('');
   });
+
+  it('should apply borderRadius and padding inputs to the chiclet root', async () => {
+    const { fixture } = await renderTemplate(
+      `<explorers-chiclet borderRadius="3px" padding="6px">PAK1</explorers-chiclet>`,
+    );
+    const root = fixture.nativeElement.querySelector('.explorers-chiclet') as HTMLElement;
+    expect(root.style.borderRadius).toBe('3px');
+    expect(root.style.padding).toBe('6px');
+  });
+
+  it('should not set inline border-radius or padding when those inputs are omitted', async () => {
+    const { fixture } = await renderTemplate(`<explorers-chiclet>PAK1</explorers-chiclet>`);
+    const root = fixture.nativeElement.querySelector('.explorers-chiclet') as HTMLElement;
+    expect(root.style.borderRadius).toBe('');
+    expect(root.style.padding).toBe('');
+  });
 });

--- a/libs/explorers/ui/src/lib/components/chiclet/chiclet.component.ts
+++ b/libs/explorers/ui/src/lib/components/chiclet/chiclet.component.ts
@@ -21,6 +21,8 @@ export class ChicletComponent {
   closeIconColor = input<string>();
   closeIconSize = input<number>(14);
   fontSize = input<string>();
+  borderRadius = input<string>();
+  padding = input<string>();
   removable = input<boolean>(false);
   removeAriaLabel = input<string>('Remove');
   removed = output<void>();

--- a/libs/explorers/ui/src/lib/components/chiclet/chiclet.stories.ts
+++ b/libs/explorers/ui/src/lib/components/chiclet/chiclet.stories.ts
@@ -1,6 +1,6 @@
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
-import { applicationConfig } from '@storybook/angular';
 import type { Meta, StoryObj } from '@storybook/angular';
+import { applicationConfig } from '@storybook/angular';
 import { ChicletComponent } from './chiclet.component';
 
 interface ChicletStoryArgs {
@@ -10,13 +10,15 @@ interface ChicletStoryArgs {
   closeIconColor?: string;
   closeIconSize?: number;
   fontSize?: string;
+  borderRadius?: string;
+  padding?: string;
   removable?: boolean;
   removeAriaLabel?: string;
 }
 
 const meta: Meta<ChicletStoryArgs> = {
   component: ChicletComponent,
-  title: 'UI/ChicletComponent',
+  title: 'UI/Chiclets/ChicletComponent',
   decorators: [
     applicationConfig({
       providers: [provideHttpClient(withInterceptorsFromDi())],
@@ -31,6 +33,8 @@ const meta: Meta<ChicletStoryArgs> = {
         [closeIconColor]="closeIconColor"
         [closeIconSize]="closeIconSize ?? 14"
         [fontSize]="fontSize"
+        [borderRadius]="borderRadius"
+        [padding]="padding"
         [removable]="removable ?? false"
         [removeAriaLabel]="removeAriaLabel ?? 'Remove'"
       >${args.content}</explorers-chiclet>
@@ -55,6 +59,17 @@ export const WithTextColor: Story = {
 
 export const WithFontSize: Story = {
   args: { content: 'APOE', fontSize: '14px' },
+};
+
+export const WithSquareShape: Story = {
+  args: {
+    content: '<b>variant:</b>&nbsp;rs29475839',
+    backgroundColor: 'var(--color-gray-300)',
+    textColor: 'var(--color-gray-900)',
+    fontSize: '14px',
+    borderRadius: '3px',
+    padding: '6px',
+  },
 };
 
 export const WithBoldPrefix: Story = {

--- a/libs/explorers/ui/src/lib/components/filter-chiclet/filter-chiclet.component.stories.ts
+++ b/libs/explorers/ui/src/lib/components/filter-chiclet/filter-chiclet.component.stories.ts
@@ -1,0 +1,24 @@
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import type { Meta, StoryObj } from '@storybook/angular';
+import { applicationConfig } from '@storybook/angular';
+import { FilterChicletComponent } from './filter-chiclet.component';
+
+const meta: Meta<FilterChicletComponent> = {
+  component: FilterChicletComponent,
+  title: 'UI/Chiclets/FilterChicletComponent',
+  decorators: [
+    applicationConfig({
+      providers: [provideHttpClient(withInterceptorsFromDi())],
+    }),
+  ],
+};
+export default meta;
+type Story = StoryObj<FilterChicletComponent>;
+
+export const Default: Story = {
+  args: { name: 'biodomain', value: 'Synapse' },
+};
+
+export const ValueOnly: Story = {
+  args: { value: 'Significance ≤ 0.05' },
+};


### PR DESCRIPTION
## Description

Adds `borderRadius` and `padding` inputs to `ChicletComponent` so the QTL sidebar can render a square-shaped label/value chiclet.

## Related Issue

- [QTL-36](https://sagebionetworks.jira.com/browse/QTL-36)

## Changelog

- Add `borderRadius` and `padding` inputs to `ChicletComponent`
- Add Storybook stories capturing the sidebar design values
- Add a Storybook stories file for `FilterChicletComponent`

## Preview

`nx start explorers-storybook`

Square shape chiclet: 

<img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/175da3cd-f48b-434e-9ade-196b3c92b22b" />

New filter chiclet stories: 
<img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/8806c220-66cf-43af-95e5-4520523c43ce" />


[QTL-36]: https://sagebionetworks.jira.com/browse/QTL-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ