### PR TITLE
feat(explorers): extend comparison tool to support optional sidebar content (QTL-97)

### DIFF
--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-footer/comparison-tool-footer.component.scss
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-footer/comparison-tool-footer.component.scss
@@ -2,10 +2,16 @@
 
 .comparison-tool-footer {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
+  row-gap: 8px;
   padding: 12px 20px;
-  padding-left: var(--comparison-tool-primary-column-width);
+  padding-left: clamp(
+    20px,
+    calc(20px + (100vw - 1200px) * 0.35),
+    var(--comparison-tool-primary-column-width)
+  );
   border-top: 1px solid var(--color-gray-300);
 
   p-paginator {

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool.component.html
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool.component.html
@@ -5,20 +5,29 @@
     </div>
   }
 
-  <div [style.display]="isLoading() ? 'none' : 'block'">
+  <div class="comparison-tool-content" [style.display]="isLoading() ? 'none' : 'flex'">
     <explorers-comparison-tool-header />
     <explorers-comparison-tool-filter-list />
-    <div class="comparison-tool-body">
-      <div class="comparison-tool-body-inner">
-        <div class="comparison-tool-tables">
-          <explorers-comparison-tool-controls />
-          <explorers-comparison-tool-table />
-          <ng-content></ng-content>
-          <explorers-comparison-tool-filter-panel />
+    <div class="comparison-tool-with-sidebar">
+      <div class="comparison-tool-main">
+        <div class="comparison-tool-body">
+          <div class="comparison-tool-body-inner">
+            <div class="comparison-tool-tables">
+              <explorers-comparison-tool-controls />
+              <explorers-comparison-tool-table />
+              <ng-content></ng-content>
+              <explorers-comparison-tool-filter-panel />
+            </div>
+          </div>
+          <explorers-heatmap-details-panel />
         </div>
+        <explorers-comparison-tool-footer />
       </div>
-      <explorers-heatmap-details-panel />
+      @if (hasSidebar()) {
+        <aside class="comparison-tool-sidebar">
+          <ng-content select="[ctSidebar]"></ng-content>
+        </aside>
+      }
     </div>
-    <explorers-comparison-tool-footer />
   </div>
 </main>

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool.component.scss
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool.component.scss
@@ -14,8 +14,36 @@ main {
     justify-content: center;
   }
 
-  .comparison-tool-body {
+  .comparison-tool-content {
     flex: 1 1 auto;
+    flex-direction: column;
+
+    .comparison-tool-with-sidebar {
+      display: flex;
+      flex-direction: row;
+      flex: 1 1 auto;
+
+      .comparison-tool-main {
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+
+      .comparison-tool-sidebar {
+        flex: 0 0 auto;
+        z-index: 1;
+        width: clamp(300px, calc(300px + (100vw - 1920px) * 0.5), 600px);
+        box-shadow:
+          0 6px 24px 0 rgb(0 0 0 / 5%),
+          0 0 0 1px rgb(0 0 0 / 8%);
+        overflow-y: auto;
+      }
+    }
+  }
+
+  .comparison-tool-body {
+    flex: 0 1 auto;
     display: flex;
     flex-direction: column;
     overflow-x: auto;

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool.component.spec.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool.component.spec.ts
@@ -12,25 +12,29 @@ import {
   SvgIconServiceStub,
 } from '@sagebionetworks/explorers/testing';
 import { LoadingContainerComponent } from '@sagebionetworks/explorers/util';
-import { render } from '@testing-library/angular';
+import { render, screen } from '@testing-library/angular';
 import { MessageService } from 'primeng/api';
 import { ComparisonToolComponent } from './comparison-tool.component';
+
+function getTestProviders() {
+  return [
+    provideHttpClient(),
+    provideNoopAnimations(),
+    provideLoadingIconColors(),
+    MessageService,
+    provideExplorersConfig({ visualizationOverviewPanes: [] }),
+    ...provideComparisonToolService({
+      configs: mockComparisonToolConfigs,
+    }),
+    ...provideComparisonToolFilterService(),
+    { provide: SvgIconService, useClass: SvgIconServiceStub },
+  ];
+}
 
 async function setup() {
   const { fixture } = await render(ComparisonToolComponent, {
     imports: [LoadingContainerComponent],
-    providers: [
-      provideHttpClient(),
-      provideNoopAnimations(),
-      provideLoadingIconColors(),
-      MessageService,
-      provideExplorersConfig({ visualizationOverviewPanes: [] }),
-      ...provideComparisonToolService({
-        configs: mockComparisonToolConfigs,
-      }),
-      ...provideComparisonToolFilterService(),
-      { provide: SvgIconService, useClass: SvgIconServiceStub },
-    ],
+    providers: getTestProviders(),
   });
 
   const component = fixture.componentInstance;
@@ -47,5 +51,27 @@ describe('Comparison Tool Component', () => {
     const { component } = await setup();
     expect(component.isLoading()).toBe(true);
     expect(component.loadingResultsCount()).toBe(mockComparisonToolConfigs[0].row_count);
+  });
+
+  it('does not render the sidebar by default', async () => {
+    const { container } = await render(ComparisonToolComponent, {
+      imports: [LoadingContainerComponent],
+      providers: getTestProviders(),
+    });
+    expect(container.querySelector('.comparison-tool-sidebar')).toBeNull();
+  });
+
+  it('renders projected sidebar content when hasSidebar is true', async () => {
+    const { container } = await render(
+      '<explorers-comparison-tool [isLoading]="false" [hasSidebar]="true">' +
+        '<div ctSidebar>sidebar test content</div>' +
+        '</explorers-comparison-tool>',
+      {
+        imports: [ComparisonToolComponent, LoadingContainerComponent],
+        providers: getTestProviders(),
+      },
+    );
+    expect(container.querySelector('.comparison-tool-sidebar')).not.toBeNull();
+    expect(screen.getByText('sidebar test content')).toBeInTheDocument();
   });
 });

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool.component.stories.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool.component.stories.ts
@@ -36,6 +36,8 @@ type StoryArgs = Omit<
   // Panel visibility
   legendVisible?: boolean;
   visualizationOverviewVisible?: boolean;
+  // Sidebar
+  hasSidebar?: boolean;
 };
 
 // Inner component that provides services - will be remounted when configs change
@@ -48,7 +50,17 @@ type StoryArgs = Omit<
     ...provideComparisonToolService(),
     ...provideComparisonToolFilterService(),
   ],
-  template: '<explorers-comparison-tool [isLoading]="false" />',
+  template: `
+    <explorers-comparison-tool [isLoading]="false" [hasSidebar]="hasSidebar() ?? false">
+      @if (hasSidebar()) {
+        <div ctSidebar style="padding: 16px;">
+          <h3 style="margin-top: 0;">Sidebar placeholder</h3>
+          <p>Content projected into the comparison-tool sidebar slot.</p>
+          <p>Resize the viewport past ~1920px to see the width grow toward 600px.</p>
+        </div>
+      }
+    </explorers-comparison-tool>
+  `,
 })
 class ComparisonToolInnerComponent {
   // Header inputs
@@ -74,6 +86,8 @@ class ComparisonToolInnerComponent {
   // Panel visibility inputs
   legendVisible = input<boolean>();
   visualizationOverviewVisible = input<boolean>();
+  // Sidebar input
+  hasSidebar = input<boolean>();
 
   private readonly comparisonToolService = inject(ComparisonToolService);
 
@@ -183,6 +197,7 @@ class ComparisonToolInnerComponent {
         [pinnedItems]="pinnedItems()"
         [legendVisible]="legendVisible()"
         [visualizationOverviewVisible]="visualizationOverviewVisible()"
+        [hasSidebar]="hasSidebar()"
       />
     }
   `,
@@ -206,6 +221,7 @@ class ComparisonToolStoryWrapperComponent {
   pinnedItems = input<string[]>();
   legendVisible = input<boolean>();
   visualizationOverviewVisible = input<boolean>();
+  hasSidebar = input<boolean>();
 
   // Key changes when configs or defaultSort change, triggering inner component remount
   protected readonly configKey = computed(() => {
@@ -331,6 +347,15 @@ const meta: Meta<StoryArgs> = {
         'User can toggle visibility afterward.',
       table: { category: 'Controls' },
     },
+    // Sidebar category
+    hasSidebar: {
+      control: 'boolean',
+      description:
+        'Whether to render the optional right-hand sidebar panel. ' +
+        'When true, content projected via the `ctSidebar` attribute is shown alongside the body and footer. ' +
+        'Width responsively clamps between 300px and 600px based on viewport.',
+      table: { category: 'Sidebar' },
+    },
   },
   decorators: [
     applicationConfig({
@@ -386,5 +411,12 @@ export const Demo: Story = {
     // Panel visibility
     legendVisible: false,
     visualizationOverviewVisible: false,
+  },
+};
+
+export const WithSidebar: Story = {
+  args: {
+    ...Demo.args,
+    hasSidebar: true,
   },
 };

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool.component.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool.component.ts
@@ -28,6 +28,7 @@ export class ComparisonToolComponent {
   private readonly comparisonToolService = inject(ComparisonToolService);
 
   isLoading = input(true);
+  hasSidebar = input(false);
 
   currentConfig = this.comparisonToolService.currentConfig;
   loadingResultsCount = this.comparisonToolService.loadingResultsCount;


### PR DESCRIPTION
## Description

Extend `<explorers-comparison-tool>` with an optional right-hand sidebar panel that consumer apps can fill via content projection. The sidebar is intended for contextual content (e.g., selection details, side widgets) that needs to sit alongside the comparison table without consuming the table's horizontal space or interfering with its horizontal scroll. The work also smooths out the comparison-tool-footer's behavior on narrower widths so that the paginator and help-links no longer collide with the new sidebar.

## Related Issue

- [QTL-97](https://sagebionetworks.jira.com/browse/QTL-97)

## Changelog

- Add optional right-hand sidebar panel to `ComparisonToolComponent` via `hasSidebar` input and `[ctSidebar]` content projection
- Make the sidebar width responsive: stays at 300px on typical viewports and clamps up to 600px on very wide ones
- Make `comparison-tool-footer` responsive on narrow widths so the paginator and help-links no longer collide with the sidebar
- Add a `WithSidebar` Storybook story and unit tests for the new feature

## Preview

To exercise the sidebar end-to-end in an actual app (the unit tests cover render presence/absence but not the layout):

1. Temporarily edit `libs/model-ad/disease-correlation-comparison-tool/src/lib/disease-correlation-comparison-tool.component.html` to enable the sidebar and project placeholder content:
   ```html
   <explorers-comparison-tool [isLoading]="!isInitialized()" [hasSidebar]="true">
     <div ctSidebar style="padding: 16px;">
       <h3 style="margin-top: 0;">Sidebar placeholder</h3>
       <p>This is temporary content projected into the comparison-tool sidebar slot.</p>
     </div>
   </explorers-comparison-tool>
   ```
2. Build images and start the stack:
   ```bash
   model-ad-build-images && model-ad-docker-start
   ```
3. In the browser, navigate to the Disease Correlation page and confirm:
   - The sidebar appears on the right at ~300px wide, with its top aligned to the top of the comparison-tool body (just under the filter-list).
   - The sidebar's bottom aligns with the top of the global app footer.
   - Horizontally scrolling the table still reveals every column -- no column is hidden underneath the sidebar.
   - At a very wide viewport (drag the window past ~2000px), the sidebar grows smoothly toward 600px.
   - At a narrow viewport (< ~1200px), the comparison-tool-footer's help-links and paginator wrap to separate rows and the paginator's left padding shrinks instead of overlapping the sidebar.
   - With `[hasSidebar]="false"` (or the input omitted), the layout is visually identical to `main`.

https://github.com/user-attachments/assets/a3727b40-45ec-4b46-b489-255009320706

https://github.com/user-attachments/assets/f548f3f8-e6de-4e6d-8300-9299ae06cc02

You can also view the new feature in isolation via Storybook:

```bash
nx start explorers-storybook   # port 4402
```

Open `Comparison Tool / ComparisonToolComponent / WithSidebar` to see the projected sidebar with the standard demo data, and toggle the `hasSidebar` control in the Sidebar category to compare against the default `Demo` story.

<img width="1624" height="1056" alt="QTL-97_storybook" src="https://github.com/user-attachments/assets/cf0e19ac-ef90-4652-86c9-99def5932311" />

[QTL-97]: https://sagebionetworks.jira.com/browse/QTL-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ