### PR TITLE
feat(qtl): polish footer styling for narrower viewports and version text (QTL-98)

### DIFF
--- a/libs/explorers/ui/src/lib/components/footer/footer.component.scss
+++ b/libs/explorers/ui/src/lib/components/footer/footer.component.scss
@@ -76,7 +76,7 @@ footer {
       display: flex;
       flex-direction: row;
       gap: 40px;
-      color: var(--color-gray-100);
+      color: var(--footer-versions-color, var(--color-gray-100));
     }
   }
 }

--- a/libs/explorers/ui/src/lib/components/footer/footer.component.scss
+++ b/libs/explorers/ui/src/lib/components/footer/footer.component.scss
@@ -9,8 +9,9 @@ footer {
   background: var(--footer-background, var(--color-primary));
   padding: 10px var(--footer-padding-x, 10px);
   min-height: var(--footer-height);
+  column-gap: 40px;
 
-  @media (min-width: vars.$md-breakpoint) {
+  @media (min-width: vars.$lg-breakpoint) {
     justify-content: space-between;
   }
 
@@ -24,7 +25,7 @@ footer {
       padding: 0;
       margin: 10px 0;
 
-      @media (min-width: vars.$md-breakpoint) {
+      @media (min-width: vars.$lg-breakpoint) {
         margin: 0;
       }
 
@@ -67,7 +68,7 @@ footer {
     gap: 50px;
     margin: 10px 0;
 
-    @media (min-width: vars.$md-breakpoint) {
+    @media (min-width: vars.$lg-breakpoint) {
       margin: 0;
     }
 

--- a/libs/qtl/styles/src/lib/_general.scss
+++ b/libs/qtl/styles/src/lib/_general.scss
@@ -5,6 +5,7 @@
   --footer-background: linear-gradient(0deg, rgb(0 0 0 / 40%) 0%, rgb(0 0 0 / 40%) 100%),
     linear-gradient(90deg, #2a77dc 0%, #b186df 51.44%, #65d8bf 100%);
   --footer-padding-x: 60px;
+  --footer-versions-color: rgb(255 255 255 / 70%);
   --header-padding-y: 24px;
   --header-padding-x: 60px;
   --header-link-color: #6e76ae;

--- a/libs/qtl/styles/src/lib/_general.scss
+++ b/libs/qtl/styles/src/lib/_general.scss
@@ -1,3 +1,5 @@
+@use 'explorers/styles/src/variables' as variables;
+
 :root {
   --font-family-primary: 'DM Sans Variable', sans-serif;
   --footer-background: linear-gradient(0deg, rgb(0 0 0 / 40%) 0%, rgb(0 0 0 / 40%) 100%),
@@ -6,6 +8,11 @@
   --header-padding-y: 24px;
   --header-padding-x: 60px;
   --header-link-color: #6e76ae;
+
+  @media (width < #{variables.$lg-breakpoint}) {
+    --footer-background: linear-gradient(0deg, rgb(0 0 0 / 40%) 0%, rgb(0 0 0 / 40%) 100%),
+      linear-gradient(90deg, #2a77dc 0%, #b186df 122.55%);
+  }
 }
 
 html,


### PR DESCRIPTION
## Description

Polish the QTL footer to match the design spec across viewport sizes. The data/site version labels now use a lighter, semi-transparent white instead of the shared gray default, and the footer background gradient and layout have been tuned so that the wrapped layout used on narrower viewports renders cleanly. The breakpoint at which the footer switches from a wrapped (stacked) layout to a single-row layout is raised from `md` to `lg` so the wrapped style applies consistently across the explorers footer.

## Related Issue

- [QTL-98](https://sagebionetworks.jira.com/browse/QTL-98)

## Changelog

- Add `--footer-versions-color` CSS custom property to `explorers-ui` footer and use it for the data/site version text color
- Set `--footer-versions-color` to `rgb(255 255 255 / 70%)` in QTL styles
- Switch footer layout breakpoint from `md` to `lg` so the wrapped/stacked layout applies consistently at the large breakpoint
- Add a 40px `column-gap` to the footer to space items in the wrapped layout
- Add a QTL-specific footer background gradient for viewports narrower than `lg`

## Testing

- In `apps/qtl/app/src/config/application.yaml`, set `appVersion` to a non-`local` value (e.g. `1.0.0-df6b767`) so the data/site version labels display as they would on prod
- Serve the QTL app and scroll to the footer: `qtl-build-images && qtl-docker-start`
- At a wide viewport (>= `lg` breakpoint, 992px), confirm the footer renders in a single row with footer links on the left and the data/site versions on the right, using the original three-stop gradient background
- Resize the viewport below the `lg` breakpoint (< 992px) and confirm the footer wraps (links and versions stack), and that the background gradient switches to the narrower-viewport variant
- Confirm the data/site version text renders in a semi-transparent white rather than the shared gray, in both wide and narrow layouts

### Preview

Before: QTL footer at a wide viewport and at a narrow viewport has gray version text and previous gradient AND versions wrapped styling changes based on viewport width (left-aligned, then center-aligned): 

https://github.com/user-attachments/assets/95e56aef-2cf9-42db-b289-b2dcf69e6a96

After: QTL footer has the new semi-transparent white version text and updated narrow-viewport gradient AND versions wrapped styling consistent at narrower viewport widths (center-aligned): 

https://github.com/user-attachments/assets/1360ef6f-5d45-464a-bca2-add3bce27103

[QTL-98]: https://sagebionetworks.jira.com/browse/QTL-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ