### PR TITLE
feat(explorers): extend forest plot to support qtl style (QTL-40)

### DIFF
--- a/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
+++ b/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
@@ -19,7 +19,7 @@ const meta: Meta<BoxplotDirective> = {
   },
   render: (args: BoxplotProps) => ({
     props: args,
-    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [xAxisLabelFormatter]="xAxisLabelFormatter" [xAxisCategories]="xAxisCategories" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisLabelTooltipFormatter]="xAxisLabelTooltipFormatter" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes" [showLegend]="showLegend" [pointOpacity]="pointOpacity" [noDataStyle]="noDataStyle" [chartStyle]="chartStyle" [laneBackgroundColors]="laneBackgroundColors" [showAxisTicks]="showAxisTicks" [boxplotBoxStyle]="boxplotBoxStyle" [axisTickLabelStyle]="axisTickLabelStyle" [axisLineStyle]="axisLineStyle"></div>`,
+    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [xAxisLabelFormatter]="xAxisLabelFormatter" [xAxisCategories]="xAxisCategories" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisLabelTooltipFormatter]="xAxisLabelTooltipFormatter" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes" [showLegend]="showLegend" [pointOpacity]="pointOpacity" [noDataStyle]="noDataStyle" [chartStyle]="chartStyle" [laneBackgroundColors]="laneBackgroundColors" [showAxisTicks]="showAxisTicks" [boxplotBoxStyle]="boxplotBoxStyle" [axisTickLabelStyle]="axisTickLabelStyle" [axisLineStyle]="axisLineStyle" [tooltipStyle]="tooltipStyle"></div>`,
   }),
 };
 export default meta;
@@ -86,5 +86,6 @@ export const Styled: Story = {
     },
     axisTickLabelStyle: { fontSize: '12px', fontWeight: 400, color: '#4A5056' },
     axisLineStyle: { width: 1, color: '#000' },
+    tooltipStyle: { backgroundColor: '#22252A' },
   },
 };

--- a/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.ts
+++ b/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.ts
@@ -8,6 +8,7 @@ import {
   CategoryBoxplotSummary,
   CategoryPoint,
   ChartStyle,
+  TooltipStyle,
 } from '@sagebionetworks/explorers/charts';
 import { CallbackDataParams } from 'echarts/types/dist/shared';
 
@@ -44,6 +45,7 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
   @Input() boxplotBoxStyle: undefined | BoxplotBoxStyle;
   @Input() axisTickLabelStyle: undefined | AxisTickLabelStyle;
   @Input() axisLineStyle: undefined | AxisLineStyle;
+  @Input() tooltipStyle: undefined | TooltipStyle;
 
   ngOnInit() {
     this.boxplot = new BoxplotChart(this.el.nativeElement, this.getBoxplotProps());
@@ -81,6 +83,7 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
       boxplotBoxStyle: this.boxplotBoxStyle,
       axisTickLabelStyle: this.axisTickLabelStyle,
       axisLineStyle: this.axisLineStyle,
+      tooltipStyle: this.tooltipStyle,
     };
   }
 }

--- a/libs/explorers/charts-angular/src/lib/forest-plot/forest-plot.directive.spec.ts
+++ b/libs/explorers/charts-angular/src/lib/forest-plot/forest-plot.directive.spec.ts
@@ -52,4 +52,45 @@ describe('ForestPlotDirective', () => {
 
     setOptionsSpy.mockRestore();
   });
+
+  it('should forward QTL styling inputs to ForestPlotChart.setOptions', async () => {
+    @Component({
+      imports: [ForestPlotDirective],
+      template: `<div
+        sageForestPlot
+        [items]="items"
+        [showZeroLine]="false"
+        [xAxisLineStyle]="{ width: 1, color: '#22252A' }"
+        [yAxisLineStyle]="{ width: 1, color: '#22252A' }"
+        [xAxisTickLabelStyle]="{ fontSize: '12px', fontWeight: 400, color: '#4A5056' }"
+        [yAxisTickLabelStyle]="{ fontSize: '16px', fontWeight: 400, color: '#353A3F' }"
+        [showXAxisLabelsOnTop]="true"
+        [xAxisGridLineStyle]="{ width: 1, color: '#D0D4D9', type: 'dotted' }"
+        [yAxisGridLineStyle]="{ width: 1, color: '#F1F2F4', type: 'solid' }"
+        [rowHoverHighlightStyle]="{ backgroundColor: 'rgba(158, 158, 158, 0.15)', thickness: 13 }"
+      ></div>`,
+    })
+    class StyledTestComponent {
+      items = forestPlotItems;
+    }
+
+    const setOptionsSpy = jest.spyOn(ForestPlotChart.prototype, 'setOptions');
+    await render(StyledTestComponent);
+
+    expect(setOptionsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        showZeroLine: false,
+        xAxisLineStyle: { width: 1, color: '#22252A' },
+        yAxisLineStyle: { width: 1, color: '#22252A' },
+        xAxisTickLabelStyle: { fontSize: '12px', fontWeight: 400, color: '#4A5056' },
+        yAxisTickLabelStyle: { fontSize: '16px', fontWeight: 400, color: '#353A3F' },
+        showXAxisLabelsOnTop: true,
+        xAxisGridLineStyle: { width: 1, color: '#D0D4D9', type: 'dotted' },
+        yAxisGridLineStyle: { width: 1, color: '#F1F2F4', type: 'solid' },
+        rowHoverHighlightStyle: { backgroundColor: 'rgba(158, 158, 158, 0.15)', thickness: 13 },
+      }),
+    );
+
+    setOptionsSpy.mockRestore();
+  });
 });

--- a/libs/explorers/charts-angular/src/lib/forest-plot/forest-plot.directive.stories.ts
+++ b/libs/explorers/charts-angular/src/lib/forest-plot/forest-plot.directive.stories.ts
@@ -30,8 +30,21 @@ const meta: Meta<ForestPlotDirective> = {
       [defaultLineColor]="defaultLineColor"
       [defaultPointColor]="defaultPointColor"
       [pointSize]="pointSize"
+      [ciLineWidth]="ciLineWidth"
       [showCILabels]="showCILabels"
       [noDataStyle]="noDataStyle"
+      [showZeroLine]="showZeroLine"
+      [xAxisInterval]="xAxisInterval"
+      [xAxisLabelPrecision]="xAxisLabelPrecision"
+      [xAxisLineStyle]="xAxisLineStyle"
+      [yAxisLineStyle]="yAxisLineStyle"
+      [xAxisTickLabelStyle]="xAxisTickLabelStyle"
+      [yAxisTickLabelStyle]="yAxisTickLabelStyle"
+      [showXAxisLabelsOnTop]="showXAxisLabelsOnTop"
+      [xAxisGridLineStyle]="xAxisGridLineStyle"
+      [yAxisGridLineStyle]="yAxisGridLineStyle"
+      [rowHoverHighlightStyle]="rowHoverHighlightStyle"
+      [tooltipStyle]="tooltipStyle"
     ></div>`,
   }),
 };
@@ -65,12 +78,26 @@ export const Default: Story = {
   },
 };
 
-export const ColoredByLine: Story = {
+export const Styled: Story = {
   args: {
     items: forestPlotItemsColoredByLine,
-    showCILabels: true,
-    xAxisTitle: 'LOG 2 FOLD CHANGE',
-    yAxisLabelTooltipFormatter: (category: string) => TISSUE_NAMES[category] ?? category,
-    pointTooltipFormatter: (item) => `Log Fold Change: ${item.value.toPrecision(3)}`,
+    xAxisMin: -0.1,
+    xAxisMax: 0.7,
+    showCILabels: false,
+    pointSize: 11,
+    ciLineWidth: 1,
+    pointTooltipFormatter: (item) => `Effect size: ${item.value.toPrecision(2)}`,
+    showZeroLine: false,
+    xAxisInterval: 0.2,
+    xAxisLabelPrecision: 1,
+    xAxisLineStyle: { width: 1, color: '#22252A' },
+    yAxisLineStyle: { width: 1, color: '#22252A' },
+    xAxisTickLabelStyle: { fontSize: '18px', fontWeight: 400, color: '#4A5056' },
+    yAxisTickLabelStyle: { fontSize: '18px', fontWeight: 400, color: '#4A5056' },
+    showXAxisLabelsOnTop: true,
+    xAxisGridLineStyle: { width: 1, color: '#D0D4D9', type: 'dotted' },
+    yAxisGridLineStyle: { width: 1, color: '#F1F2F4', type: 'solid' },
+    rowHoverHighlightStyle: { backgroundColor: 'rgba(158, 158, 158, 0.15)', thickness: 13 },
+    tooltipStyle: { backgroundColor: '#22252A' },
   },
 };

--- a/libs/explorers/charts-angular/src/lib/forest-plot/forest-plot.directive.ts
+++ b/libs/explorers/charts-angular/src/lib/forest-plot/forest-plot.directive.ts
@@ -9,9 +9,14 @@ import {
   OnDestroy,
 } from '@angular/core';
 import {
+  AxisLineStyle,
+  AxisTickLabelStyle,
   ForestPlotChart,
   ForestPlotItem,
   ForestPlotProps,
+  GridLineStyle,
+  RowHoverHighlightStyle,
+  TooltipStyle,
 } from '@sagebionetworks/explorers/charts';
 
 @Directive({
@@ -33,8 +38,21 @@ export class ForestPlotDirective implements OnDestroy {
   defaultLineColor = input<string>();
   defaultPointColor = input<string>();
   pointSize = input<number>();
+  ciLineWidth = input<number>();
   showCILabels = input<boolean>();
   noDataStyle = input<'textOnly' | 'grayBackground'>();
+  showZeroLine = input<boolean>();
+  xAxisInterval = input<number>();
+  xAxisLabelPrecision = input<number>();
+  xAxisLineStyle = input<AxisLineStyle>();
+  yAxisLineStyle = input<AxisLineStyle>();
+  xAxisTickLabelStyle = input<AxisTickLabelStyle>();
+  yAxisTickLabelStyle = input<AxisTickLabelStyle>();
+  showXAxisLabelsOnTop = input<boolean>();
+  xAxisGridLineStyle = input<GridLineStyle>();
+  yAxisGridLineStyle = input<GridLineStyle>();
+  rowHoverHighlightStyle = input<RowHoverHighlightStyle>();
+  tooltipStyle = input<TooltipStyle>();
 
   private forestPlot: ForestPlotChart | undefined;
 
@@ -51,8 +69,21 @@ export class ForestPlotDirective implements OnDestroy {
     defaultLineColor: this.defaultLineColor(),
     defaultPointColor: this.defaultPointColor(),
     pointSize: this.pointSize(),
+    ciLineWidth: this.ciLineWidth(),
     showCILabels: this.showCILabels(),
     noDataStyle: this.noDataStyle(),
+    showZeroLine: this.showZeroLine(),
+    xAxisInterval: this.xAxisInterval(),
+    xAxisLabelPrecision: this.xAxisLabelPrecision(),
+    xAxisLineStyle: this.xAxisLineStyle(),
+    yAxisLineStyle: this.yAxisLineStyle(),
+    xAxisTickLabelStyle: this.xAxisTickLabelStyle(),
+    yAxisTickLabelStyle: this.yAxisTickLabelStyle(),
+    showXAxisLabelsOnTop: this.showXAxisLabelsOnTop(),
+    xAxisGridLineStyle: this.xAxisGridLineStyle(),
+    yAxisGridLineStyle: this.yAxisGridLineStyle(),
+    rowHoverHighlightStyle: this.rowHoverHighlightStyle(),
+    tooltipStyle: this.tooltipStyle(),
   }));
 
   constructor() {

--- a/libs/explorers/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/explorers/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -139,8 +139,8 @@ export class BoxplotChart {
             },
             backgroundColor: tooltipStyle?.backgroundColor ?? '#63676c',
             // borderWidth: 0 preserves the historical "no border" look when borderColor is unset
-            borderColor: tooltipStyle?.borderColor ?? 'transparent',
             borderWidth: tooltipStyle?.borderColor ? 1 : 0,
+            borderColor: tooltipStyle?.borderColor ?? 'transparent',
             ...(tooltipStyle?.color && { textStyle: { color: tooltipStyle.color } }),
             extraCssText: 'opacity: 0.9',
           }),

--- a/libs/explorers/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/explorers/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -79,7 +79,6 @@ export class BoxplotChart {
     axisLineStyle: BoxplotProps['axisLineStyle'],
     tooltipStyle: BoxplotProps['tooltipStyle'],
   ) {
-    const xAxisTooltipBackground = tooltipStyle?.backgroundColor ?? '#63676c';
     // Use two xAxes:
     //  - value: used to jitter points with multiple pointCategories, where
     //           xAxisCategory is mapped to 1-based index values for both
@@ -138,7 +137,12 @@ export class BoxplotChart {
             formatter: (params: CallbackDataParams) => {
               return xAxisLabelTooltipFormatter(params);
             },
-            extraCssText: `border: unset; opacity: 0.9; background-color: ${xAxisTooltipBackground}`,
+            backgroundColor: tooltipStyle?.backgroundColor ?? '#63676c',
+            // borderWidth: 0 preserves the historical "no border" look when borderColor is unset
+            borderColor: tooltipStyle?.borderColor ?? 'transparent',
+            borderWidth: tooltipStyle?.borderColor ? 1 : 0,
+            ...(tooltipStyle?.color && { textStyle: { color: tooltipStyle.color } }),
+            extraCssText: 'opacity: 0.9',
           }),
           show: Boolean(xAxisLabelTooltipFormatter),
         },

--- a/libs/explorers/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/explorers/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -10,6 +10,7 @@ import { BoxplotChartTheme } from '../models/boxplot';
 import {
   addXAxisValueToBoxplotSummaries,
   addXAxisValueToCategoryPoint,
+  buildTooltip,
   formatCategoryPointsForBoxplotTransform,
   getCategoryPointColor,
   getCategoryPointShape,
@@ -76,7 +77,9 @@ export class BoxplotChart {
     showAxisTicks: BoxplotProps['showAxisTicks'],
     axisTickLabelStyle: BoxplotProps['axisTickLabelStyle'],
     axisLineStyle: BoxplotProps['axisLineStyle'],
+    tooltipStyle: BoxplotProps['tooltipStyle'],
   ) {
+    const xAxisTooltipBackground = tooltipStyle?.backgroundColor ?? '#63676c';
     // Use two xAxes:
     //  - value: used to jitter points with multiple pointCategories, where
     //           xAxisCategory is mapped to 1-based index values for both
@@ -135,7 +138,7 @@ export class BoxplotChart {
             formatter: (params: CallbackDataParams) => {
               return xAxisLabelTooltipFormatter(params);
             },
-            extraCssText: 'border: unset; opacity: 0.9; background-color: #63676c',
+            extraCssText: `border: unset; opacity: 0.9; background-color: ${xAxisTooltipBackground}`,
           }),
           show: Boolean(xAxisLabelTooltipFormatter),
         },
@@ -207,6 +210,7 @@ export class BoxplotChart {
       boxplotBoxStyle,
       axisTickLabelStyle,
       axisLineStyle,
+      tooltipStyle,
     } = boxplotProps;
 
     const showLegend = boxplotProps.showLegend || false;
@@ -422,6 +426,7 @@ export class BoxplotChart {
         showAxisTicks,
         axisTickLabelStyle,
         axisLineStyle,
+        tooltipStyle,
       ),
       yAxis: this.getYAxisOptions(
         yAxisTitle,
@@ -432,7 +437,7 @@ export class BoxplotChart {
         axisTickLabelStyle,
         axisLineStyle,
       ),
-      tooltip: boxplotChartTheme.tooltip,
+      tooltip: buildTooltip(boxplotChartTheme.tooltip, tooltipStyle),
       series: seriesOpts,
     };
 

--- a/libs/explorers/charts/src/lib/constants.ts
+++ b/libs/explorers/charts/src/lib/constants.ts
@@ -1,11 +1,11 @@
-import type { EChartsOption } from 'echarts';
+import type { TooltipOption } from './models';
 
 export const DEFAULT_POINT_SIZE = 18;
 export const DEFAULT_COLOR = '#8b8ad1';
 export const GRAY_BACKGROUND_COLOR = '#AEB5BC1A';
 export const Y_AXIS_TICK_LABELS_MAX_WIDTH = 80;
 
-export const DARK_TOOLTIP: EChartsOption['tooltip'] = {
+export const DARK_TOOLTIP: TooltipOption = {
   confine: true,
   position: 'top',
   backgroundColor: '#63676C',
@@ -15,7 +15,7 @@ export const DARK_TOOLTIP: EChartsOption['tooltip'] = {
     'opacity: 1 !important; width: auto; max-width: 300px; white-space: pre-wrap; text-align: center;',
 };
 
-export const LIGHT_TOOLTIP: EChartsOption['tooltip'] = {
+export const LIGHT_TOOLTIP: TooltipOption = {
   ...DARK_TOOLTIP,
   backgroundColor: 'white',
   borderRadius: 0,

--- a/libs/explorers/charts/src/lib/constants.ts
+++ b/libs/explorers/charts/src/lib/constants.ts
@@ -1,4 +1,4 @@
-import type { TooltipOption } from './models';
+import type { TooltipOption } from './types';
 
 export const DEFAULT_POINT_SIZE = 18;
 export const DEFAULT_COLOR = '#8b8ad1';

--- a/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-axis.ts
+++ b/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-axis.ts
@@ -31,8 +31,11 @@ export function computeXTickPositions(xMin: number, xMax: number, interval: numb
   const lastK = Math.floor(xMax / interval + epsilon);
   const positions: number[] = [];
   for (let k = firstK; k <= lastK; k++) {
-    // `+ 0` normalizes -0 to 0 for strict-equality assertions.
-    positions.push(k * interval + 0);
+    // Re-multiplication drifts (e.g. 3 * 0.2 = 0.6000000000000001). Round to 10 decimals
+    // so each tick matches its nominal value -- otherwise ECharts can drop the max tick
+    // when xMax lands exactly on an interval multiple. `+ 0` normalizes -0 to 0 for
+    // strict-equality assertions.
+    positions.push(Math.round(k * interval * 1e10) / 1e10 + 0);
   }
   return positions;
 }

--- a/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-axis.ts
+++ b/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-axis.ts
@@ -1,0 +1,161 @@
+import { EChartsOption } from 'echarts';
+import { CallbackDataParams } from 'echarts/types/dist/shared';
+import { ForestPlotProps } from '../models';
+import { AXIS_STYLE, TEXT_STYLE } from '../point-plot-defaults';
+
+const X_AXIS_LABEL_TEXT_STYLE = { color: AXIS_STYLE.tickLabelColor, fontSize: 14 };
+const Y_AXIS_LABEL_TEXT_STYLE = { color: AXIS_STYLE.tickLabelColor, fontSize: 16 };
+
+// Symmetric bounds from max(|ciLeft|, |ciRight|) *1.1
+export function computeXBounds(props: ForestPlotProps): [number, number] {
+  if (props.xAxisMin !== undefined && props.xAxisMax !== undefined) {
+    return [props.xAxisMin, props.xAxisMax];
+  }
+  const maxAbs = props.items.reduce(
+    (acc, item) => Math.max(acc, Math.abs(item.ciLeft), Math.abs(item.ciRight)),
+    0,
+  );
+  const bound = maxAbs === 0 ? 1 : maxAbs * 1.1;
+  return [-bound, bound];
+}
+
+// Returns multiples of `interval` (anchored to 0) that fall within [xMin, xMax].
+// Ticks land on round values regardless of xMin -- e.g. interval 0.2 within [-0.1, 0.7]
+// yields [0, 0.2, 0.4, 0.6], not the xMin-anchored [-0.1, 0.1, 0.3, 0.5, 0.7].
+export function computeXTickPositions(xMin: number, xMax: number, interval: number): number[] {
+  if (interval <= 0) return [];
+  // Epsilon absorbs floating-point drift in the boundary divisions -- e.g. -0.6 / 0.2
+  // computes to -2.9999..., which without nudging would ceil to -2 and skip the -0.6 tick.
+  const epsilon = 1e-9;
+  const firstK = Math.ceil(xMin / interval - epsilon);
+  const lastK = Math.floor(xMax / interval + epsilon);
+  const positions: number[] = [];
+  for (let k = firstK; k <= lastK; k++) {
+    // `+ 0` normalizes -0 to 0 for strict-equality assertions.
+    positions.push(k * interval + 0);
+  }
+  return positions;
+}
+
+export function buildXAxis(
+  props: ForestPlotProps,
+  xMin: number,
+  xMax: number,
+  xTickPositions: number[],
+): EChartsOption['xAxis'] {
+  // With auto-computed bounds (±maxAbs * 1.1) and the default interval, xMin and xMax
+  // land on tick multiples, so customValues includes labels right at the chart edges
+  // where they tend to clip against the axis-line end. Suppress them in that case.
+  // When the consumer explicitly sets bounds, we show every tick they asked for.
+  const boundsAreExplicit = props.xAxisMin !== undefined && props.xAxisMax !== undefined;
+
+  const bottomXAxis = {
+    type: 'value' as const,
+    // Ensure axes render above the row-hover axisPointer band
+    z: 10,
+    min: xMin,
+    max: xMax,
+    name: props.xAxisTitle,
+    nameLocation: 'middle' as const,
+    nameGap: AXIS_STYLE.titleGap,
+    nameTextStyle: TEXT_STYLE.axisName,
+    axisLine: {
+      show: true,
+      lineStyle: { ...AXIS_STYLE.line, ...props.xAxisLineStyle },
+    },
+    // splitLine is rendered via gridLineSeries so we control alignment + z-order
+    splitLine: { show: false },
+    // customValues pins ticks/labels to the exact positions our gridLineSeries
+    // draws at, anchored to round multiples of the interval.
+    axisTick: { customValues: xTickPositions },
+    axisLabel: {
+      ...X_AXIS_LABEL_TEXT_STYLE,
+      formatter: (tickValue: number) => tickValue.toFixed(props.xAxisLabelPrecision ?? 2),
+      customValues: xTickPositions,
+      ...(!boundsAreExplicit && { showMinLabel: false, showMaxLabel: false }),
+      ...props.xAxisTickLabelStyle,
+    },
+    // x-axis pointer is never used; only the y-axis carries the row-hover band
+    axisPointer: { show: false },
+  };
+
+  if (props.showXAxisLabelsOnTop) {
+    return [
+      bottomXAxis,
+      {
+        ...bottomXAxis,
+        position: 'top',
+        name: undefined,
+        // Top axis carries labels only -- no axis line or ticks
+        axisLine: { show: false },
+        axisTick: { show: false },
+      },
+    ];
+  }
+  return bottomXAxis;
+}
+
+export function buildYAxis(
+  props: ForestPlotProps,
+  yAxisCategories: string[],
+  tooltip: EChartsOption['tooltip'],
+  rowHoverLabelFormatter: ((cat: string) => string) | undefined,
+): EChartsOption['yAxis'] {
+  const yAxisLabelTooltipFormatter = props.yAxisLabelTooltipFormatter;
+  const rowHoverHighlightStyle = props.rowHoverHighlightStyle;
+  const yAxisTickLabelStyle = props.yAxisTickLabelStyle;
+
+  return {
+    type: 'category',
+    // Ensure axes render above the row-hover axisPointer band
+    z: 10,
+    data: yAxisCategories,
+    inverse: true,
+    axisTick: { show: false },
+    // The zero reference at x=0 is drawn by zeroLineSeries (a custom series), not by the
+    // y-axis line. So the y-axis line is hidden by default. When yAxisLineStyle is provided,
+    // we show it as a frame line at the left edge -- onZero: false prevents ECharts from
+    // collapsing it onto x=0 where it would overlap the zero reference.
+    axisLine: props.yAxisLineStyle
+      ? { show: true, onZero: false, lineStyle: props.yAxisLineStyle }
+      : { show: false },
+    triggerEvent: Boolean(yAxisLabelTooltipFormatter),
+    tooltip: {
+      ...tooltip,
+      show: Boolean(yAxisLabelTooltipFormatter),
+      ...(yAxisLabelTooltipFormatter && {
+        formatter: (params: CallbackDataParams) => yAxisLabelTooltipFormatter(params.name),
+      }),
+    },
+    axisLabel: {
+      ...Y_AXIS_LABEL_TEXT_STYLE,
+      margin: 30,
+      ...yAxisTickLabelStyle,
+      ...(rowHoverLabelFormatter && {
+        formatter: rowHoverLabelFormatter,
+        rich: { b: { ...yAxisTickLabelStyle, fontWeight: 700 } },
+      }),
+    },
+    // splitLine is rendered via gridLineSeries so it aligns with category ticks
+    splitLine: { show: false },
+    // Row-hover highlight: a line-type axisPointer on the y-axis paints a horizontal
+    // band centered on the row tick. lineStyle.width controls the band thickness in
+    // pixels (kept smaller than the row pitch so adjacent rows don't overlap).
+    axisPointer: rowHoverHighlightStyle
+      ? {
+          show: true,
+          type: 'line' as const,
+          triggerEmphasis: false,
+          triggerTooltip: false,
+          label: { show: false },
+          lineStyle: {
+            // Default for axisPointer.lineStyle is 'dashed' -- force solid so the
+            // band fills continuously across the row instead of showing gaps.
+            type: 'solid' as const,
+            width: rowHoverHighlightStyle.thickness,
+            color: rowHoverHighlightStyle.backgroundColor,
+          },
+        }
+      : { show: false },
+  };
+}

--- a/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-axis.ts
+++ b/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-axis.ts
@@ -43,10 +43,15 @@ export function buildXAxis(
   xMax: number,
   xTickPositions: number[],
 ): EChartsOption['xAxis'] {
-  // With auto-computed bounds (±maxAbs * 1.1) and the default interval, xMin and xMax
-  // land on tick multiples, so customValues includes labels right at the chart edges
-  // where they tend to clip against the axis-line end. Suppress them in that case.
-  // When the consumer explicitly sets bounds, we show every tick they asked for.
+  // Two tick modes: an empty xTickPositions means the caller did not pin tick
+  // values, so we let ECharts pick "nice" round ticks via splitNumber. A non-empty
+  // array means tick positions were precomputed (typically from xAxisInterval) and
+  // we pin them with customValues so axis ticks align with our gridLineSeries.
+  const useCustomTicks = xTickPositions.length > 0;
+
+  // With auto-computed bounds (±maxAbs * 1.1), labels at xMin/xMax clip against the
+  // axis-line end -- suppress them in that case. When the consumer sets bounds
+  // explicitly, we show every label they asked for.
   const boundsAreExplicit = props.xAxisMin !== undefined && props.xAxisMax !== undefined;
 
   const bottomXAxis = {
@@ -65,13 +70,13 @@ export function buildXAxis(
     },
     // splitLine is rendered via gridLineSeries so we control alignment + z-order
     splitLine: { show: false },
-    // customValues pins ticks/labels to the exact positions our gridLineSeries
-    // draws at, anchored to round multiples of the interval.
-    axisTick: { customValues: xTickPositions },
+    ...(useCustomTicks
+      ? { axisTick: { customValues: xTickPositions } }
+      : { splitNumber: AXIS_STYLE.valueAxisSplitNumber }),
     axisLabel: {
       ...X_AXIS_LABEL_TEXT_STYLE,
       formatter: (tickValue: number) => tickValue.toFixed(props.xAxisLabelPrecision ?? 2),
-      customValues: xTickPositions,
+      ...(useCustomTicks && { customValues: xTickPositions }),
       ...(!boundsAreExplicit && { showMinLabel: false, showMaxLabel: false }),
       ...props.xAxisTickLabelStyle,
     },

--- a/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-chart.spec.ts
+++ b/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-chart.spec.ts
@@ -302,45 +302,51 @@ describe('ForestPlotChart', () => {
       expect((getOption().series as unknown[]).length).toBe(2);
     });
 
-    it('pins x-axis tick positions via customValues by default', () => {
+    it('lets ECharts pick x-axis ticks via splitNumber when no xAxisInterval is provided', () => {
+      // Default mode: customValues is not set; ECharts uses its own "nice number"
+      // algorithm to pick round tick values from the configured splitNumber.
       makeChart();
       const xAxis = getOption().xAxis as {
-        axisLabel: { customValues: number[] };
-        axisTick: { customValues: number[] };
+        splitNumber?: number;
+        axisTick?: { customValues?: number[] };
+        axisLabel: { customValues?: number[] };
       };
-      expect(xAxis.axisLabel.customValues.length).toBeGreaterThan(0);
-      expect(xAxis.axisTick.customValues).toEqual(xAxis.axisLabel.customValues);
+      expect(xAxis.splitNumber).toBe(10);
+      expect(xAxis.axisTick).toBeUndefined();
+      expect(xAxis.axisLabel.customValues).toBeUndefined();
     });
 
     it('anchors x-axis ticks to round multiples of xAxisInterval', () => {
       makeChart({ xAxisMin: -0.1, xAxisMax: 0.7, xAxisInterval: 0.2 });
-      const xAxis = getOption().xAxis as { axisLabel: { customValues: number[] } };
+      const xAxis = getOption().xAxis as {
+        axisLabel: { customValues: number[] };
+        axisTick: { customValues: number[] };
+      };
       // 0.2 anchored within [-0.1, 0.7] yields [0, 0.2, 0.4, 0.6], not the
       // xMin-anchored [-0.1, 0.1, 0.3, 0.5, 0.7]
       const rounded = xAxis.axisLabel.customValues.map((v) => Math.round(v * 100) / 100);
       expect(rounded).toEqual([0, 0.2, 0.4, 0.6]);
+      expect(xAxis.axisTick.customValues).toEqual(xAxis.axisLabel.customValues);
     });
 
-    it('falls back to the default interval when xAxisInterval is non-positive', () => {
-      // 0 (or negative) would otherwise yield an empty customValues array via
-      // computeXTickPositions, leaving the chart with no x-axis labels at all.
-      const zeroIntervalTicks = (() => {
-        makeChart({ xAxisInterval: 0 });
-        return (getOption().xAxis as { axisLabel: { customValues: number[] } }).axisLabel
-          .customValues;
-      })();
-      const defaultTicks = (() => {
-        makeChart();
-        return (getOption().xAxis as { axisLabel: { customValues: number[] } }).axisLabel
-          .customValues;
-      })();
-      expect(zeroIntervalTicks).toEqual(defaultTicks);
-      expect(zeroIntervalTicks.length).toBeGreaterThan(0);
+    it('falls back to ECharts splitNumber when xAxisInterval is non-positive', () => {
+      // 0 (or negative) would otherwise produce an empty customValues array via
+      // computeXTickPositions, leaving the chart with no x-axis labels at all. Falling
+      // back to splitNumber matches the no-interval default so the axis stays labelled.
+      makeChart({ xAxisInterval: 0 });
+      const xAxis = getOption().xAxis as {
+        splitNumber?: number;
+        axisTick?: { customValues?: number[] };
+        axisLabel: { customValues?: number[] };
+      };
+      expect(xAxis.splitNumber).toBe(10);
+      expect(xAxis.axisTick).toBeUndefined();
+      expect(xAxis.axisLabel.customValues).toBeUndefined();
     });
 
     it('hides min/max x-axis labels when bounds are auto-computed', () => {
-      // Auto-bounds land on tick multiples (±maxAbs * 1.1 with splitNumber 10),
-      // so labels would otherwise render right at the chart edges.
+      // Auto-bounds (±maxAbs * 1.1) sit just past the data; suppress edge labels so
+      // they don't clip against the axis-line end if ECharts places a tick there.
       makeChart();
       const xAxis = getOption().xAxis as {
         axisLabel: { showMinLabel: boolean; showMaxLabel: boolean };

--- a/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-chart.spec.ts
+++ b/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-chart.spec.ts
@@ -321,6 +321,23 @@ describe('ForestPlotChart', () => {
       expect(rounded).toEqual([0, 0.2, 0.4, 0.6]);
     });
 
+    it('falls back to the default interval when xAxisInterval is non-positive', () => {
+      // 0 (or negative) would otherwise yield an empty customValues array via
+      // computeXTickPositions, leaving the chart with no x-axis labels at all.
+      const zeroIntervalTicks = (() => {
+        makeChart({ xAxisInterval: 0 });
+        return (getOption().xAxis as { axisLabel: { customValues: number[] } }).axisLabel
+          .customValues;
+      })();
+      const defaultTicks = (() => {
+        makeChart();
+        return (getOption().xAxis as { axisLabel: { customValues: number[] } }).axisLabel
+          .customValues;
+      })();
+      expect(zeroIntervalTicks).toEqual(defaultTicks);
+      expect(zeroIntervalTicks.length).toBeGreaterThan(0);
+    });
+
     it('hides min/max x-axis labels when bounds are auto-computed', () => {
       // Auto-bounds land on tick multiples (±maxAbs * 1.1 with splitNumber 10),
       // so labels would otherwise render right at the chart edges.

--- a/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-chart.spec.ts
+++ b/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-chart.spec.ts
@@ -67,6 +67,14 @@ describe('computeXTickPositions', () => {
     expect(computeXTickPositions(0, 1, 0)).toEqual([]);
     expect(computeXTickPositions(0, 1, -0.1)).toEqual([]);
   });
+
+  it('rounds away floating-point drift so ticks match nominal values', () => {
+    // Without rounding, 3 * 0.2 evaluates to 0.6000000000000001, which is > xMax = 0.6
+    // and can cause ECharts to drop the max tick or render it just past the axis line.
+    const positions = computeXTickPositions(0, 0.6, 0.2);
+    expect(positions).toEqual([0, 0.2, 0.4, 0.6]);
+    expect(positions[positions.length - 1]).toBe(0.6);
+  });
 });
 
 describe('computeXBounds', () => {

--- a/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-chart.spec.ts
+++ b/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-chart.spec.ts
@@ -4,16 +4,14 @@ import { DEFAULT_COLOR } from '../constants';
 import { forestPlotItems } from '../mocks';
 import { ForestPlotItem, ForestPlotProps } from '../models';
 import { initChart, setNoDataOption } from '../utils';
-import {
-  ForestPlotChart,
-  computeInitialHeight,
-  computeXBounds,
-  resolveItemColor,
-} from './forest-plot-chart';
+import { computeXBounds, computeXTickPositions } from './forest-plot-axis';
+import { ForestPlotChart, computeInitialHeight } from './forest-plot-chart';
+import { resolveItemColor } from './forest-plot-series';
 
 jest.mock('../utils', () => ({
   initChart: jest.fn(),
   setNoDataOption: jest.fn(),
+  buildTooltip: jest.fn((base) => base),
 }));
 
 describe('resolveItemColor', () => {
@@ -43,6 +41,31 @@ describe('computeInitialHeight', () => {
   it('enforces minimum height of 490px when computed height is below floor', () => {
     expect(computeInitialHeight(0)).toBe('490px');
     expect(computeInitialHeight(9)).toBe('490px');
+  });
+});
+
+describe('computeXTickPositions', () => {
+  const round2 = (arr: number[]) => arr.map((v) => Math.round(v * 100) / 100);
+
+  it('anchors ticks to multiples of interval, not to xMin', () => {
+    // The user-visible bug this guards against: with xMin -0.1 and interval 0.2,
+    // anchoring to xMin would yield -0.1, 0.1, 0.3, 0.5, 0.7. We want the round values.
+    expect(round2(computeXTickPositions(-0.1, 0.7, 0.2))).toEqual([0, 0.2, 0.4, 0.6]);
+  });
+
+  it('includes ticks at the bounds when they land on a multiple', () => {
+    expect(round2(computeXTickPositions(0, 1, 0.2))).toEqual([0, 0.2, 0.4, 0.6, 0.8, 1]);
+  });
+
+  it('handles negative ranges', () => {
+    expect(round2(computeXTickPositions(-0.6, 0.6, 0.2))).toEqual([
+      -0.6, -0.4, -0.2, 0, 0.2, 0.4, 0.6,
+    ]);
+  });
+
+  it('returns an empty array for non-positive intervals', () => {
+    expect(computeXTickPositions(0, 1, 0)).toEqual([]);
+    expect(computeXTickPositions(0, 1, -0.1)).toEqual([]);
   });
 });
 
@@ -104,7 +127,14 @@ function makeChart(props: Partial<ForestPlotProps> = {}): ForestPlotChart {
 describe('ForestPlotChart', () => {
   const mockSetOption = jest.fn();
   const mockDispose = jest.fn();
-  const mockChart = { setOption: mockSetOption, dispose: mockDispose };
+  const mockOn = jest.fn();
+  const mockOff = jest.fn();
+  const mockChart = {
+    setOption: mockSetOption,
+    dispose: mockDispose,
+    on: mockOn,
+    off: mockOff,
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -193,7 +223,7 @@ describe('ForestPlotChart', () => {
       expect((getOption().grid as { bottom: number }).bottom).toBe(50);
     });
 
-    it('renders 3 series (zero line, CI line, dots)', () => {
+    it('renders 3 series by default (zero line, CI line, dots)', () => {
       makeChart();
       expect((getOption().series as unknown[]).length).toBe(3);
     });
@@ -226,9 +256,12 @@ describe('ForestPlotChart', () => {
     it('uses default dot tooltip when no pointTooltipFormatter', () => {
       makeChart();
       const series = getOption().series as {
-        tooltip: { formatter: (p: CallbackDataParams) => string };
+        type: string;
+        tooltip?: { formatter: (p: CallbackDataParams) => string };
       }[];
-      const dotSeries = series[2];
+      const dotSeries = series.find((s) => s.type === 'scatter') as {
+        tooltip: { formatter: (p: CallbackDataParams) => string };
+      };
       const result = dotSeries.tooltip.formatter({ dataIndex: 0 } as CallbackDataParams);
       expect(result).toBe(`Value: ${forestPlotItems[0].value}`);
     });
@@ -237,11 +270,236 @@ describe('ForestPlotChart', () => {
       const formatter = (item: ForestPlotItem) => `custom: ${item.yAxisCategory}`;
       makeChart({ pointTooltipFormatter: formatter });
       const series = getOption().series as {
-        tooltip: { formatter: (p: CallbackDataParams) => string };
+        type: string;
+        tooltip?: { formatter: (p: CallbackDataParams) => string };
       }[];
-      const dotSeries = series[2];
+      const dotSeries = series.find((s) => s.type === 'scatter') as {
+        tooltip: { formatter: (p: CallbackDataParams) => string };
+      };
       const result = dotSeries.tooltip.formatter({ dataIndex: 0 } as CallbackDataParams);
       expect(result).toBe(`custom: ${forestPlotItems[0].yAxisCategory}`);
+    });
+
+    it('handles array params from axis-pointer-triggered tooltips', () => {
+      // When top-level axisPointer with triggerOn: 'mousemove' is active, ECharts
+      // can invoke series tooltip formatters with an array of params instead of one.
+      makeChart();
+      const series = getOption().series as {
+        type: string;
+        tooltip?: { formatter: (p: CallbackDataParams | CallbackDataParams[]) => string };
+      }[];
+      const dotSeries = series.find((s) => s.type === 'scatter') as {
+        tooltip: { formatter: (p: CallbackDataParams | CallbackDataParams[]) => string };
+      };
+      const result = dotSeries.tooltip.formatter([{ dataIndex: 1 } as CallbackDataParams]);
+      expect(result).toBe(`Value: ${forestPlotItems[1].value}`);
+    });
+  });
+
+  describe('setOptions -- QTL styling', () => {
+    it('omits zero line series when showZeroLine is false', () => {
+      makeChart({ showZeroLine: false });
+      expect((getOption().series as unknown[]).length).toBe(2);
+    });
+
+    it('pins x-axis tick positions via customValues by default', () => {
+      makeChart();
+      const xAxis = getOption().xAxis as {
+        axisLabel: { customValues: number[] };
+        axisTick: { customValues: number[] };
+      };
+      expect(xAxis.axisLabel.customValues.length).toBeGreaterThan(0);
+      expect(xAxis.axisTick.customValues).toEqual(xAxis.axisLabel.customValues);
+    });
+
+    it('anchors x-axis ticks to round multiples of xAxisInterval', () => {
+      makeChart({ xAxisMin: -0.1, xAxisMax: 0.7, xAxisInterval: 0.2 });
+      const xAxis = getOption().xAxis as { axisLabel: { customValues: number[] } };
+      // 0.2 anchored within [-0.1, 0.7] yields [0, 0.2, 0.4, 0.6], not the
+      // xMin-anchored [-0.1, 0.1, 0.3, 0.5, 0.7]
+      const rounded = xAxis.axisLabel.customValues.map((v) => Math.round(v * 100) / 100);
+      expect(rounded).toEqual([0, 0.2, 0.4, 0.6]);
+    });
+
+    it('hides min/max x-axis labels when bounds are auto-computed', () => {
+      // Auto-bounds land on tick multiples (±maxAbs * 1.1 with splitNumber 10),
+      // so labels would otherwise render right at the chart edges.
+      makeChart();
+      const xAxis = getOption().xAxis as {
+        axisLabel: { showMinLabel: boolean; showMaxLabel: boolean };
+      };
+      expect(xAxis.axisLabel.showMinLabel).toBe(false);
+      expect(xAxis.axisLabel.showMaxLabel).toBe(false);
+    });
+
+    it('shows every x-axis label when xAxisMin and xAxisMax are both explicit', () => {
+      makeChart({ xAxisMin: -0.1, xAxisMax: 0.7, xAxisInterval: 0.2 });
+      const xAxis = getOption().xAxis as {
+        axisLabel: { showMinLabel?: boolean; showMaxLabel?: boolean };
+      };
+      expect(xAxis.axisLabel.showMinLabel).toBeUndefined();
+      expect(xAxis.axisLabel.showMaxLabel).toBeUndefined();
+    });
+
+    it('overrides x-axis line style when xAxisLineStyle is provided', () => {
+      makeChart({ xAxisLineStyle: { width: 1, color: '#22252A' } });
+      const xAxis = getOption().xAxis as {
+        axisLine: { lineStyle: { width: number; color: string } };
+      };
+      expect(xAxis.axisLine.lineStyle.width).toBe(1);
+      expect(xAxis.axisLine.lineStyle.color).toBe('#22252A');
+    });
+
+    it('hides the y-axis line by default', () => {
+      makeChart();
+      const yAxis = getOption().yAxis as { axisLine: { show: boolean } };
+      expect(yAxis.axisLine.show).toBe(false);
+    });
+
+    it('shows and styles the y-axis line when yAxisLineStyle is provided', () => {
+      makeChart({ yAxisLineStyle: { width: 1, color: '#22252A' } });
+      const yAxis = getOption().yAxis as {
+        axisLine: { show: boolean; onZero: boolean; lineStyle: { width: number; color: string } };
+      };
+      expect(yAxis.axisLine.show).toBe(true);
+      // Anchored at the left edge, not at x=0
+      expect(yAxis.axisLine.onZero).toBe(false);
+      expect(yAxis.axisLine.lineStyle).toEqual({ width: 1, color: '#22252A' });
+    });
+
+    it('applies x-axis tick label style without affecting the y-axis', () => {
+      makeChart({
+        xAxisTickLabelStyle: { fontSize: '12px', fontWeight: 400, color: '#4A5056' },
+      });
+      const xAxis = getOption().xAxis as { axisLabel: { fontSize: string; color: string } };
+      const yAxis = getOption().yAxis as { axisLabel: { color: string } };
+      expect(xAxis.axisLabel.fontSize).toBe('12px');
+      expect(xAxis.axisLabel.color).toBe('#4A5056');
+      expect(yAxis.axisLabel.color).toBe('#000');
+    });
+
+    it('applies y-axis tick label style without affecting the x-axis', () => {
+      makeChart({
+        yAxisTickLabelStyle: { fontSize: '16px', fontWeight: 400, color: '#353A3F' },
+      });
+      const xAxis = getOption().xAxis as { axisLabel: { color: string } };
+      const yAxis = getOption().yAxis as { axisLabel: { fontSize: string; color: string } };
+      expect(yAxis.axisLabel.fontSize).toBe('16px');
+      expect(yAxis.axisLabel.color).toBe('#353A3F');
+      expect(xAxis.axisLabel.color).toBe('#000');
+    });
+
+    it('uses a single x-axis by default', () => {
+      makeChart();
+      expect(Array.isArray(getOption().xAxis)).toBe(false);
+    });
+
+    it('renders bottom and top x-axes when showXAxisLabelsOnTop is true', () => {
+      makeChart({ showXAxisLabelsOnTop: true });
+      const xAxes = getOption().xAxis as {
+        min: number;
+        max: number;
+        position?: string;
+        axisLine: { show: boolean };
+        axisTick: { show: boolean };
+      }[];
+      expect(Array.isArray(xAxes)).toBe(true);
+      expect(xAxes.length).toBe(2);
+      expect(xAxes[1].position).toBe('top');
+      expect(xAxes[0].min).toBe(xAxes[1].min);
+      expect(xAxes[0].max).toBe(xAxes[1].max);
+      // Top axis carries labels only -- no line or ticks
+      expect(xAxes[1].axisLine.show).toBe(false);
+      expect(xAxes[1].axisTick.show).toBe(false);
+    });
+
+    it('always hides axis split lines (grid lines come from gridLineSeries)', () => {
+      makeChart({
+        xAxisGridLineStyle: { width: 1, color: '#D0D4D9', type: 'dotted' },
+        yAxisGridLineStyle: { width: 1, color: '#F1F2F4', type: 'solid' },
+      });
+      const xAxis = getOption().xAxis as { splitLine: { show: boolean } };
+      const yAxis = getOption().yAxis as { splitLine: { show: boolean } };
+      expect(xAxis.splitLine.show).toBe(false);
+      expect(yAxis.splitLine.show).toBe(false);
+    });
+
+    it('omits gridLineSeries when no grid line styles are provided', () => {
+      makeChart();
+      const series = getOption().series as { type: string; data?: unknown[] }[];
+      // Default series: zero line + CI line + dots; no grid line series
+      expect(series.length).toBe(3);
+    });
+
+    it('inserts a grid line custom series when a grid line style is provided', () => {
+      makeChart({ yAxisGridLineStyle: { width: 1, color: '#F1F2F4', type: 'solid' } });
+      const series = getOption().series as { type: string }[];
+      // zero line + grid line + CI line + dots
+      expect(series.length).toBe(4);
+    });
+
+    it('configures a y-axis line axisPointer when rowHoverHighlightStyle is provided', () => {
+      makeChart({
+        rowHoverHighlightStyle: { backgroundColor: 'rgba(158, 158, 158, 0.15)', thickness: 13 },
+      });
+      const yAxis = getOption().yAxis as {
+        axisPointer: {
+          show: boolean;
+          type: string;
+          lineStyle: { width: number; color: string };
+        };
+      };
+      expect(yAxis.axisPointer.show).toBe(true);
+      expect(yAxis.axisPointer.type).toBe('line');
+      expect(yAxis.axisPointer.lineStyle.width).toBe(13);
+      expect(yAxis.axisPointer.lineStyle.color).toBe('rgba(158, 158, 158, 0.15)');
+    });
+
+    it('enables a top-level axisPointer with mousemove trigger for row hover', () => {
+      makeChart({
+        rowHoverHighlightStyle: { backgroundColor: 'rgba(0,0,0,0.1)', thickness: 10 },
+      });
+      const axisPointer = getOption().axisPointer as { show: boolean; triggerOn: string };
+      expect(axisPointer.show).toBe(true);
+      expect(axisPointer.triggerOn).toBe('mousemove');
+    });
+
+    it('does not configure axisPointer when rowHoverHighlightStyle is omitted', () => {
+      makeChart();
+      const yAxis = getOption().yAxis as { axisPointer: { show: boolean } };
+      expect(yAxis.axisPointer.show).toBe(false);
+      expect(getOption().axisPointer).toBeUndefined();
+    });
+
+    it('registers an updateAxisPointer listener when rowHoverHighlightStyle is provided', () => {
+      makeChart({
+        rowHoverHighlightStyle: { backgroundColor: 'rgba(0,0,0,0.1)', thickness: 13 },
+      });
+      expect(mockOn).toHaveBeenCalledWith('updateAxisPointer', expect.any(Function));
+    });
+
+    it('does not register an updateAxisPointer listener by default', () => {
+      makeChart();
+      expect(mockOn).not.toHaveBeenCalled();
+    });
+
+    it('configures rich text and an initial formatter on y-axis label when row hover is enabled', () => {
+      makeChart({
+        rowHoverHighlightStyle: { backgroundColor: 'rgba(0,0,0,0.1)', thickness: 13 },
+        yAxisTickLabelStyle: { fontSize: '18px', color: '#4A5056' },
+      });
+      const yAxis = getOption().yAxis as {
+        axisLabel: {
+          formatter: (cat: string) => string;
+          rich: { b: { fontWeight: number; fontSize: string; color: string } };
+        };
+      };
+      // No category is hovered initially, so the formatter returns the bare category
+      expect(yAxis.axisLabel.formatter('ACC')).toBe('ACC');
+      expect(yAxis.axisLabel.rich.b.fontWeight).toBe(700);
+      // Bold style inherits typography from yAxisTickLabelStyle
+      expect(yAxis.axisLabel.rich.b.fontSize).toBe('18px');
+      expect(yAxis.axisLabel.rich.b.color).toBe('#4A5056');
     });
   });
 });

--- a/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-chart.ts
+++ b/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-chart.ts
@@ -1,158 +1,27 @@
-import { CustomSeriesOption, ECharts, EChartsOption, ScatterSeriesOption } from 'echarts';
-import { CallbackDataParams } from 'echarts/types/dist/shared';
-import { DARK_TOOLTIP, DEFAULT_COLOR, DEFAULT_POINT_SIZE } from '../constants';
+import { ECharts, EChartsOption } from 'echarts';
+import { DARK_TOOLTIP } from '../constants';
 import { ForestPlotProps } from '../models';
-import { AXIS_STYLE, CI_LINE_WIDTH, GRID_TOP, TEXT_STYLE } from '../point-plot-defaults';
-import { GridCoordSys } from '../types';
-import { initChart, setNoDataOption } from '../utils';
-
-const CI_LABEL_GAP = 4;
-const CI_LABEL_STYLE = { fill: '#4a5056', fontSize: 14, textVerticalAlign: 'middle' };
-
-const ZERO_LINE_STYLE = { stroke: '#BCC0CA', lineWidth: 2, fill: 'none' };
-
-const X_AXIS_LABEL_TEXT_STYLE = { color: AXIS_STYLE.tickLabelColor, fontSize: 14 };
-const Y_AXIS_LABEL_TEXT_STYLE = { color: AXIS_STYLE.tickLabelColor, fontSize: 16 };
+import { AXIS_STYLE, GRID_TOP, TEXT_STYLE } from '../point-plot-defaults';
+import { buildTooltip, initChart, setNoDataOption } from '../utils';
+import { buildXAxis, buildYAxis, computeXBounds, computeXTickPositions } from './forest-plot-axis';
+import { RowHoverController } from './forest-plot-row-hover';
+import { buildSeries } from './forest-plot-series';
 
 const GRID_BOTTOM_WITHOUT_X_AXIS_TITLE = 40;
 const GRID_DEFAULT_MARGINS = GRID_TOP.withoutTitle + GRID_BOTTOM_WITHOUT_X_AXIS_TITLE;
 
 const GRID = { right: 80, containLabel: true };
 
-export function resolveItemColor(
-  itemColor: string | undefined,
-  propDefault: string | undefined,
-): string {
-  return itemColor || propDefault || DEFAULT_COLOR;
-}
+const TOP_X_AXIS_LABEL_HEIGHT = 30;
 
 export function computeInitialHeight(rowCount: number): string {
   // ~44px per row + GRID_DEFAULT_MARGINS; 490px floor
   return `${Math.max(rowCount * 44 + GRID_DEFAULT_MARGINS, 490)}px`;
 }
 
-// Symmetric bounds from max(|ciLeft|, |ciRight|) x1.1
-export function computeXBounds(props: ForestPlotProps): [number, number] {
-  if (props.xAxisMin !== undefined && props.xAxisMax !== undefined) {
-    return [props.xAxisMin, props.xAxisMax];
-  }
-  const maxAbs = props.items.reduce(
-    (acc, item) => Math.max(acc, Math.abs(item.ciLeft), Math.abs(item.ciRight)),
-    0,
-  );
-  const bound = maxAbs === 0 ? 1 : maxAbs * 1.1;
-  return [-bound, bound];
-}
-
-function ciLineSeries(props: ForestPlotProps): CustomSeriesOption {
-  const formatCILabel = props.ciLabelFormatter ?? ((value: number) => value.toPrecision(2));
-
-  return {
-    type: 'custom',
-    clip: false,
-    data: props.items.map((item) => ({
-      value: [item.ciLeft, item.ciRight, item.yAxisCategory],
-      itemStyle: { color: resolveItemColor(item.color, props.defaultLineColor) },
-    })),
-    renderItem: (_params, api) => {
-      const ciLeft = api.value(0) as number;
-      const ciRight = api.value(1) as number;
-      const yCategory = api.value(2) as string;
-      const [x1, y] = api.coord([ciLeft, yCategory]);
-      const [x2] = api.coord([ciRight, yCategory]);
-      const color = api.visual('color') as string;
-
-      return {
-        type: 'group',
-        children: [
-          // horizontal CI line
-          {
-            type: 'line',
-            shape: { x1, y1: y, x2, y2: y },
-            style: { stroke: color, lineWidth: CI_LINE_WIDTH },
-          },
-          // optional CI text labels
-          ...(props.showCILabels
-            ? [
-                {
-                  type: 'text' as const,
-                  style: {
-                    ...CI_LABEL_STYLE,
-                    text: formatCILabel(ciLeft),
-                    x: x1 - CI_LABEL_GAP,
-                    y,
-                    textAlign: 'right',
-                  },
-                },
-                {
-                  type: 'text' as const,
-                  style: {
-                    ...CI_LABEL_STYLE,
-                    text: formatCILabel(ciRight),
-                    x: x2 + CI_LABEL_GAP,
-                    y,
-                    textAlign: 'left',
-                  },
-                },
-              ]
-            : []),
-        ],
-      };
-    },
-    silent: true,
-    tooltip: { show: false },
-    z: 1,
-  };
-}
-
-// ECharts custom series requires at least one data point to trigger renderItem. We pass
-// [0, referenceCategory] so api.coord([0, referenceCategory]) gives the pixel x-position
-// for x=0. Any valid y-axis category works — only the x=0 position matters.
-function zeroLineSeries(yAxisCategories: string[]): CustomSeriesOption {
-  const referenceCategory = yAxisCategories[0];
-  return {
-    type: 'custom',
-    clip: false,
-    itemStyle: { color: 'transparent' },
-    renderItem: (params, api) => {
-      const [zeroX] = api.coord([0, referenceCategory]);
-      const gridBounds = params.coordSys as unknown as GridCoordSys;
-      return {
-        type: 'line',
-        shape: { x1: zeroX, y1: gridBounds.y, x2: zeroX, y2: gridBounds.y + gridBounds.height },
-        style: ZERO_LINE_STYLE,
-      };
-    },
-    data: [{ value: [0, referenceCategory] }],
-    silent: true,
-    z: 0,
-    tooltip: { show: false },
-  };
-}
-
-function dotSeries(props: ForestPlotProps): ScatterSeriesOption {
-  return {
-    type: 'scatter',
-    symbolSize: props.pointSize ?? DEFAULT_POINT_SIZE,
-    data: props.items.map((item) => ({
-      value: [item.value, item.yAxisCategory],
-      itemStyle: { color: resolveItemColor(item.color, props.defaultPointColor), opacity: 1 },
-    })),
-    tooltip: {
-      formatter: (rawParams) => {
-        const params = rawParams as CallbackDataParams;
-        const item = props.items[params.dataIndex];
-        return props.pointTooltipFormatter
-          ? props.pointTooltipFormatter(item)
-          : `Value: ${item.value}`;
-      },
-    },
-    z: 2,
-  };
-}
-
 export class ForestPlotChart {
   chart: ECharts | undefined;
+  private rowHoverController: RowHoverController | null = null;
 
   constructor(chartDom: HTMLDivElement | HTMLCanvasElement, props: ForestPlotProps) {
     // Height is set once at construction time based on the number of rows to render.
@@ -166,6 +35,8 @@ export class ForestPlotChart {
   }
 
   destroy() {
+    this.rowHoverController?.detach();
+    this.rowHoverController = null;
     this.chart?.dispose();
   }
 
@@ -181,54 +52,44 @@ export class ForestPlotChart {
       ...new Set(props.items.map((item) => item.yAxisCategory)),
     ];
     const [xMin, xMax] = computeXBounds(props);
-    const yAxisLabelTooltipFormatter = props.yAxisLabelTooltipFormatter;
+    // Tick positions are anchored to integer multiples of the interval (not to xMin),
+    // so an interval of 0.2 within [-0.1, 0.7] yields [0, 0.2, 0.4, 0.6] rather than
+    // [-0.1, 0.1, 0.3, 0.5, 0.7]. We pass these positions to ECharts via customValues
+    // so axis ticks align with our gridLineSeries.
+    const xAxisInterval = props.xAxisInterval ?? (xMax - xMin) / AXIS_STYLE.valueAxisSplitNumber;
+    const xTickPositions = computeXTickPositions(xMin, xMax, xAxisInterval);
+    const tooltip = buildTooltip(DARK_TOOLTIP, props.tooltipStyle);
+
+    // Detach the previous row-hover controller before re-rendering so its listener
+    // doesn't fire against stale yAxisCategories during setOption. A new controller
+    // (with fresh hover state) is created if row-hover is still enabled.
+    this.rowHoverController?.detach();
+    this.rowHoverController = props.rowHoverHighlightStyle
+      ? new RowHoverController(this.chart, yAxisCategories)
+      : null;
 
     const option: EChartsOption = {
       grid: {
         ...GRID,
-        top: props.title ? GRID_TOP.withTitle : GRID_TOP.withoutTitle,
+        top:
+          (props.title ? GRID_TOP.withTitle : GRID_TOP.withoutTitle) +
+          (props.showXAxisLabelsOnTop ? TOP_X_AXIS_LABEL_HEIGHT : 0),
         bottom: props.xAxisTitle ? AXIS_STYLE.titleGap : GRID_BOTTOM_WITHOUT_X_AXIS_TITLE,
       },
-      xAxis: {
-        type: 'value',
-        min: xMin,
-        max: xMax,
-        name: props.xAxisTitle,
-        nameLocation: 'middle',
-        nameGap: AXIS_STYLE.titleGap,
-        nameTextStyle: TEXT_STYLE.axisName,
-        axisLine: {
-          show: true,
-          lineStyle: AXIS_STYLE.line,
-        },
-        splitLine: { show: false },
-        splitNumber: AXIS_STYLE.valueAxisSplitNumber,
-        axisLabel: {
-          ...X_AXIS_LABEL_TEXT_STYLE,
-          formatter: (tickValue: number) => tickValue.toFixed(2),
-          showMinLabel: false,
-          showMaxLabel: false,
-        },
-      },
-      yAxis: {
-        type: 'category',
-        data: yAxisCategories,
-        inverse: true,
-        axisTick: { show: false },
-        // Hide the y-axis line; the custom zero line handles the x=0 marker
-        axisLine: { show: false },
-        triggerEvent: Boolean(yAxisLabelTooltipFormatter),
-        tooltip: {
-          ...DARK_TOOLTIP,
-          show: Boolean(yAxisLabelTooltipFormatter),
-          ...(yAxisLabelTooltipFormatter && {
-            formatter: (params: CallbackDataParams) => yAxisLabelTooltipFormatter(params.name),
-          }),
-        },
-        axisLabel: { ...Y_AXIS_LABEL_TEXT_STYLE, margin: 30 },
-      } as EChartsOption['yAxis'],
-      series: [zeroLineSeries(yAxisCategories), ciLineSeries(props), dotSeries(props)],
-      tooltip: DARK_TOOLTIP,
+      xAxis: buildXAxis(props, xMin, xMax, xTickPositions),
+      yAxis: buildYAxis(
+        props,
+        yAxisCategories,
+        tooltip,
+        this.rowHoverController?.getYAxisLabelFormatter(),
+      ),
+      series: buildSeries(props, yAxisCategories, xMin, xMax, xTickPositions),
+      tooltip,
+      // Top-level axisPointer enables the y-axis pointer to track the cursor on
+      // mousemove (instead of only on click or when a tooltip is active).
+      ...(props.rowHoverHighlightStyle && {
+        axisPointer: { show: true, triggerOn: 'mousemove' as const },
+      }),
       title: props.title
         ? [{ text: props.title, left: 'center', textStyle: TEXT_STYLE.title }]
         : [],
@@ -237,5 +98,7 @@ export class ForestPlotChart {
 
     // notMerge must be set to true to override any existing options set on the chart
     this.chart.setOption(option, true);
+
+    this.rowHoverController?.attach();
   }
 }

--- a/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-chart.ts
+++ b/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-chart.ts
@@ -56,7 +56,12 @@ export class ForestPlotChart {
     // so an interval of 0.2 within [-0.1, 0.7] yields [0, 0.2, 0.4, 0.6] rather than
     // [-0.1, 0.1, 0.3, 0.5, 0.7]. We pass these positions to ECharts via customValues
     // so axis ticks align with our gridLineSeries.
-    const xAxisInterval = props.xAxisInterval ?? (xMax - xMin) / AXIS_STYLE.valueAxisSplitNumber;
+    // Coerce non-positive values (e.g. an upstream `(xMax - xMin) / n` that resolved to 0
+    // on zero-range data) back to the default so we still render a labelled axis.
+    const xAxisInterval =
+      props.xAxisInterval && props.xAxisInterval > 0
+        ? props.xAxisInterval
+        : (xMax - xMin) / AXIS_STYLE.valueAxisSplitNumber;
     const xTickPositions = computeXTickPositions(xMin, xMax, xAxisInterval);
     const tooltip = buildTooltip(DARK_TOOLTIP, props.tooltipStyle);
 

--- a/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-chart.ts
+++ b/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-chart.ts
@@ -52,17 +52,19 @@ export class ForestPlotChart {
       ...new Set(props.items.map((item) => item.yAxisCategory)),
     ];
     const [xMin, xMax] = computeXBounds(props);
-    // Tick positions are anchored to integer multiples of the interval (not to xMin),
-    // so an interval of 0.2 within [-0.1, 0.7] yields [0, 0.2, 0.4, 0.6] rather than
-    // [-0.1, 0.1, 0.3, 0.5, 0.7]. We pass these positions to ECharts via customValues
-    // so axis ticks align with our gridLineSeries.
-    // Coerce non-positive values (e.g. an upstream `(xMax - xMin) / n` that resolved to 0
-    // on zero-range data) back to the default so we still render a labelled axis.
-    const xAxisInterval =
+    // When xAxisInterval is given, tick positions are anchored to integer multiples of
+    // the interval (not to xMin), so an interval of 0.2 within [-0.1, 0.7] yields
+    // [0, 0.2, 0.4, 0.6] rather than [-0.1, 0.1, 0.3, 0.5, 0.7]. We pass these positions
+    // to ECharts via customValues so axis ticks align with our gridLineSeries.
+    // When xAxisInterval is not provided (or is non-positive), we return an empty array
+    // and buildXAxis falls back to ECharts' splitNumber, which picks "nice" round tick
+    // values via its own algorithm. The grid-line series renders no vertical lines in
+    // that mode (it can't align with ticks it doesn't know about); consumers who set
+    // xAxisGridLineStyle should also set xAxisInterval.
+    const xTickPositions =
       props.xAxisInterval && props.xAxisInterval > 0
-        ? props.xAxisInterval
-        : (xMax - xMin) / AXIS_STYLE.valueAxisSplitNumber;
-    const xTickPositions = computeXTickPositions(xMin, xMax, xAxisInterval);
+        ? computeXTickPositions(xMin, xMax, props.xAxisInterval)
+        : [];
     const tooltip = buildTooltip(DARK_TOOLTIP, props.tooltipStyle);
 
     // Detach the previous row-hover controller before re-rendering so its listener

--- a/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-row-hover.spec.ts
+++ b/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-row-hover.spec.ts
@@ -1,0 +1,144 @@
+import { ECharts } from 'echarts';
+import { RowHoverController } from './forest-plot-row-hover';
+
+describe('RowHoverController', () => {
+  const yAxisCategories = ['ACC', 'CBE', 'DLPFC', 'TCX'];
+  let mockOn: jest.Mock;
+  let mockOff: jest.Mock;
+  let mockSetOption: jest.Mock;
+  let mockChart: ECharts;
+  let controller: RowHoverController;
+
+  beforeEach(() => {
+    mockOn = jest.fn();
+    mockOff = jest.fn();
+    mockSetOption = jest.fn();
+    mockChart = {
+      on: mockOn,
+      off: mockOff,
+      setOption: mockSetOption,
+    } as unknown as ECharts;
+    controller = new RowHoverController(mockChart, yAxisCategories);
+  });
+
+  describe('getYAxisLabelFormatter', () => {
+    it('returns the bare category when nothing is hovered', () => {
+      const fmt = controller.getYAxisLabelFormatter();
+      expect(fmt('ACC')).toBe('ACC');
+      expect(fmt('TCX')).toBe('TCX');
+    });
+  });
+
+  describe('attach', () => {
+    it('registers an updateAxisPointer listener', () => {
+      controller.attach();
+      expect(mockOn).toHaveBeenCalledTimes(1);
+      expect(mockOn).toHaveBeenCalledWith('updateAxisPointer', expect.any(Function));
+    });
+
+    it('detaches the previous listener when called again', () => {
+      controller.attach();
+      const firstListener = mockOn.mock.calls[0][1];
+      controller.attach();
+      expect(mockOff).toHaveBeenCalledWith('updateAxisPointer', firstListener);
+      expect(mockOn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('detach', () => {
+    it('removes the attached listener', () => {
+      controller.attach();
+      const listener = mockOn.mock.calls[0][1];
+      controller.detach();
+      expect(mockOff).toHaveBeenCalledWith('updateAxisPointer', listener);
+    });
+
+    it('is a no-op when nothing is attached', () => {
+      controller.detach();
+      expect(mockOff).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op on a second call', () => {
+      controller.attach();
+      controller.detach();
+      controller.detach();
+      expect(mockOff).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('updateAxisPointer listener', () => {
+    let listener: (event: unknown) => void;
+
+    beforeEach(() => {
+      controller.attach();
+      listener = mockOn.mock.calls[0][1];
+    });
+
+    it('translates a numeric axis-pointer value to a category by index', () => {
+      // value 2 -> yAxisCategories[2] -> 'DLPFC'
+      listener({ axesInfo: [{ axisDim: 'y', value: 2 }] });
+      expect(mockSetOption).toHaveBeenCalledTimes(1);
+      const fmt = mockSetOption.mock.calls[0][0].yAxis.axisLabel.formatter;
+      expect(fmt('DLPFC')).toBe('{b|DLPFC}');
+      expect(fmt('ACC')).toBe('ACC');
+    });
+
+    it('rounds fractional numeric values to the nearest index', () => {
+      // 1.6 -> Math.round = 2 -> 'DLPFC'
+      listener({ axesInfo: [{ axisDim: 'y', value: 1.6 }] });
+      const fmt = mockSetOption.mock.calls[0][0].yAxis.axisLabel.formatter;
+      expect(fmt('DLPFC')).toBe('{b|DLPFC}');
+    });
+
+    it('uses a string value directly when it matches a known category', () => {
+      listener({ axesInfo: [{ axisDim: 'y', value: 'CBE' }] });
+      const fmt = mockSetOption.mock.calls[0][0].yAxis.axisLabel.formatter;
+      expect(fmt('CBE')).toBe('{b|CBE}');
+    });
+
+    it('clears the hover when the string value is not in yAxisCategories', () => {
+      listener({ axesInfo: [{ axisDim: 'y', value: 'ACC' }] });
+      mockSetOption.mockClear();
+      listener({ axesInfo: [{ axisDim: 'y', value: 'UNKNOWN' }] });
+      expect(mockSetOption).toHaveBeenCalledTimes(1);
+      const fmt = mockSetOption.mock.calls[0][0].yAxis.axisLabel.formatter;
+      expect(fmt('ACC')).toBe('ACC');
+    });
+
+    it('clears the hover when the numeric value is out of range', () => {
+      listener({ axesInfo: [{ axisDim: 'y', value: 'ACC' }] });
+      mockSetOption.mockClear();
+      listener({ axesInfo: [{ axisDim: 'y', value: 99 }] });
+      expect(mockSetOption).toHaveBeenCalledTimes(1);
+      const fmt = mockSetOption.mock.calls[0][0].yAxis.axisLabel.formatter;
+      expect(fmt('ACC')).toBe('ACC');
+    });
+
+    it('clears the hover when axesInfo has no y-axis entry', () => {
+      listener({ axesInfo: [{ axisDim: 'y', value: 'ACC' }] });
+      mockSetOption.mockClear();
+      listener({ axesInfo: [{ axisDim: 'x', value: 0.5 }] });
+      expect(mockSetOption).toHaveBeenCalledTimes(1);
+      const fmt = mockSetOption.mock.calls[0][0].yAxis.axisLabel.formatter;
+      expect(fmt('ACC')).toBe('ACC');
+    });
+
+    it('ignores events with no y entry when nothing was previously hovered', () => {
+      // hoveredCategory stays null, so no re-render is needed.
+      listener({ axesInfo: [{ axisDim: 'x', value: 0.5 }] });
+      expect(mockSetOption).not.toHaveBeenCalled();
+    });
+
+    it('ignores events with missing axesInfo', () => {
+      listener({});
+      expect(mockSetOption).not.toHaveBeenCalled();
+    });
+
+    it('does not call setOption when the hovered category is unchanged', () => {
+      listener({ axesInfo: [{ axisDim: 'y', value: 'ACC' }] });
+      mockSetOption.mockClear();
+      listener({ axesInfo: [{ axisDim: 'y', value: 'ACC' }] });
+      expect(mockSetOption).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-row-hover.ts
+++ b/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-row-hover.ts
@@ -1,0 +1,54 @@
+import { ECharts } from 'echarts';
+import { UpdateAxisPointerEvent } from '../types';
+
+const UPDATE_AXIS_POINTER = 'updateAxisPointer';
+
+// Owns the "bolded label on the hovered row" interaction. ECharts' y-axis axisPointer
+// paints the highlight band on its own; this controller listens for the corresponding
+// updateAxisPointer event and rewrites the y-axis label formatter so the hovered
+// category renders via the rich-text `b` style.
+//
+// Lifecycle: construct -> getYAxisLabelFormatter() -> attach() after setOption ->
+// detach() before the next setOption or chart dispose.
+export class RowHoverController {
+  private hoveredCategory: string | null = null;
+  private listener: ((event: unknown) => void) | null = null;
+
+  constructor(
+    private readonly chart: ECharts,
+    private readonly yAxisCategories: string[],
+  ) {}
+
+  getYAxisLabelFormatter(): (cat: string) => string {
+    const hovered = this.hoveredCategory;
+    return (cat: string) => (cat === hovered ? `{b|${cat}}` : cat);
+  }
+
+  attach() {
+    this.detach();
+    this.listener = (rawEvent: unknown) => {
+      const event = rawEvent as UpdateAxisPointerEvent;
+      const yInfo = event.axesInfo?.find((a) => a.axisDim === 'y');
+      const raw = yInfo?.value;
+      let next: string | null = null;
+      if (typeof raw === 'number') {
+        next = this.yAxisCategories[Math.round(raw)] ?? null;
+      } else if (typeof raw === 'string') {
+        next = this.yAxisCategories.includes(raw) ? raw : null;
+      }
+      if (next === this.hoveredCategory) return;
+      this.hoveredCategory = next;
+      this.chart.setOption({
+        yAxis: { axisLabel: { formatter: this.getYAxisLabelFormatter() } },
+      });
+    };
+    this.chart.on(UPDATE_AXIS_POINTER, this.listener);
+  }
+
+  detach() {
+    if (this.listener) {
+      this.chart.off(UPDATE_AXIS_POINTER, this.listener);
+      this.listener = null;
+    }
+  }
+}

--- a/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-series.ts
+++ b/libs/explorers/charts/src/lib/forest-plot-chart/forest-plot-series.ts
@@ -1,0 +1,239 @@
+import { CustomSeriesOption, EChartsOption, ScatterSeriesOption } from 'echarts';
+import { DEFAULT_COLOR, DEFAULT_POINT_SIZE } from '../constants';
+import { ForestPlotProps } from '../models';
+import { GridLineStyle } from '../models/axis';
+import { CI_LINE_WIDTH } from '../point-plot-defaults';
+import { GridCoordSys } from '../types';
+
+const CI_LABEL_GAP = 4;
+const CI_LABEL_STYLE = { fill: '#4a5056', fontSize: 14, textVerticalAlign: 'middle' };
+
+const ZERO_LINE_STYLE = { stroke: '#BCC0CA', lineWidth: 2, fill: 'none' };
+
+export function resolveItemColor(
+  itemColor: string | undefined,
+  propDefault: string | undefined,
+): string {
+  return itemColor || propDefault || DEFAULT_COLOR;
+}
+
+export function ciLineSeries(props: ForestPlotProps): CustomSeriesOption {
+  const formatCILabel = props.ciLabelFormatter ?? ((value: number) => value.toPrecision(2));
+  const ciLineWidth = props.ciLineWidth ?? CI_LINE_WIDTH;
+
+  return {
+    type: 'custom',
+    clip: false,
+    data: props.items.map((item) => ({
+      value: [item.ciLeft, item.ciRight, item.yAxisCategory],
+      itemStyle: { color: resolveItemColor(item.color, props.defaultLineColor) },
+    })),
+    renderItem: (_params, api) => {
+      const ciLeft = api.value(0) as number;
+      const ciRight = api.value(1) as number;
+      const yCategory = api.value(2) as string;
+      const [x1, y] = api.coord([ciLeft, yCategory]);
+      const [x2] = api.coord([ciRight, yCategory]);
+      const color = api.visual('color') as string;
+
+      return {
+        type: 'group',
+        children: [
+          // horizontal CI line
+          {
+            type: 'line',
+            shape: { x1, y1: y, x2, y2: y },
+            style: { stroke: color, lineWidth: ciLineWidth },
+          },
+          // optional CI text labels
+          ...(props.showCILabels
+            ? [
+                {
+                  type: 'text' as const,
+                  style: {
+                    ...CI_LABEL_STYLE,
+                    text: formatCILabel(ciLeft),
+                    x: x1 - CI_LABEL_GAP,
+                    y,
+                    textAlign: 'right',
+                  },
+                },
+                {
+                  type: 'text' as const,
+                  style: {
+                    ...CI_LABEL_STYLE,
+                    text: formatCILabel(ciRight),
+                    x: x2 + CI_LABEL_GAP,
+                    y,
+                    textAlign: 'left',
+                  },
+                },
+              ]
+            : []),
+        ],
+      };
+    },
+    silent: true,
+    tooltip: { show: false },
+    z: 1,
+  };
+}
+
+// ECharts custom series requires at least one data point to trigger renderItem. We pass
+// [0, referenceCategory] so api.coord([0, referenceCategory]) gives the pixel x-position
+// for x=0. Any valid y-axis category works -- only the x=0 position matters.
+export function zeroLineSeries(yAxisCategories: string[]): CustomSeriesOption {
+  const referenceCategory = yAxisCategories[0];
+  return {
+    type: 'custom',
+    clip: false,
+    itemStyle: { color: 'transparent' },
+    renderItem: (params, api) => {
+      const [zeroX] = api.coord([0, referenceCategory]);
+      const gridBounds = params.coordSys as unknown as GridCoordSys;
+      return {
+        type: 'line',
+        shape: { x1: zeroX, y1: gridBounds.y, x2: zeroX, y2: gridBounds.y + gridBounds.height },
+        style: ZERO_LINE_STYLE,
+      };
+    },
+    data: [{ value: [0, referenceCategory] }],
+    silent: true,
+    z: 0,
+    tooltip: { show: false },
+  };
+}
+
+export function dotSeries(props: ForestPlotProps): ScatterSeriesOption {
+  return {
+    type: 'scatter',
+    symbolSize: props.pointSize ?? DEFAULT_POINT_SIZE,
+    data: props.items.map((item) => ({
+      value: [item.value, item.yAxisCategory],
+      itemStyle: { color: resolveItemColor(item.color, props.defaultPointColor), opacity: 1 },
+    })),
+    tooltip: {
+      formatter: (params) => {
+        const dataIndex = Array.isArray(params) ? params[0].dataIndex : params.dataIndex;
+        const item = props.items[dataIndex];
+        return props.pointTooltipFormatter
+          ? props.pointTooltipFormatter(item)
+          : `Value: ${item.value}`;
+      },
+    },
+    z: 2,
+  };
+}
+
+// Translates a GridLineStyle.type into a ZRender lineDash array. ECharts itself accepts
+// the friendly `type: 'solid' | 'dashed' | 'dotted'` enum on axis splitLine config, but
+// gridLineSeries renders shapes directly via ZRender (the underlying drawing layer),
+// which only accepts numeric [dashLengthPx, gapLengthPx] patterns. The lengths here are
+// tuned for ~1px stroke widths; if grid lines get thicker, these may need to grow too.
+function lineDashFor(type: GridLineStyle['type']): number[] | undefined {
+  switch (type) {
+    case 'dotted':
+      return [2, 4];
+    case 'dashed':
+      return [6, 4];
+    case 'solid':
+    default:
+      // ECharts treats absent lineDash as a continuous solid stroke.
+      return undefined;
+  }
+}
+
+// Renders horizontal grid lines at each y-axis category position and vertical grid
+// lines at each interior x-axis tick. Using a custom series (instead of axis splitLine)
+// gives us three things axis splitLine can't: (1) per-category alignment on a category
+// y-axis (axis splitLines fall between categories), (2) suppression of edge lines at
+// xMin/xMax, and (3) z-ordering below series without dragging the axis line down with it.
+export function gridLineSeries(
+  yAxisCategories: string[],
+  xMin: number,
+  xMax: number,
+  xTickPositions: number[],
+  xAxisGridLineStyle: GridLineStyle | undefined,
+  yAxisGridLineStyle: GridLineStyle | undefined,
+): CustomSeriesOption {
+  const referenceCategory = yAxisCategories[0];
+  // Skip any tick positions that land exactly on the plot edges; the axis lines
+  // already cover those.
+  const interiorXTicks = xTickPositions.filter((v) => v > xMin && v < xMax);
+  return {
+    type: 'custom',
+    clip: false,
+    silent: true,
+    tooltip: { show: false },
+    renderItem: (params, api) => {
+      const grid = params.coordSys as unknown as GridCoordSys;
+      // unknown[] keeps the inner shapes loose; ECharts' CustomElementOption union is
+      // narrower than what we need and forces an assertion on the return.
+      const children: unknown[] = [];
+
+      if (yAxisGridLineStyle) {
+        const yDash = lineDashFor(yAxisGridLineStyle.type);
+        yAxisCategories.forEach((cat) => {
+          const [, y] = api.coord([xMin, cat]);
+          children.push({
+            type: 'line',
+            shape: { x1: grid.x, y1: y, x2: grid.x + grid.width, y2: y },
+            style: {
+              stroke: yAxisGridLineStyle.color,
+              lineWidth: yAxisGridLineStyle.width,
+              ...(yDash && { lineDash: yDash }),
+            },
+          });
+        });
+      }
+
+      if (xAxisGridLineStyle) {
+        const xDash = lineDashFor(xAxisGridLineStyle.type);
+        interiorXTicks.forEach((xValue) => {
+          const [x] = api.coord([xValue, referenceCategory]);
+          children.push({
+            type: 'line',
+            shape: { x1: x, y1: grid.y, x2: x, y2: grid.y + grid.height },
+            style: {
+              stroke: xAxisGridLineStyle.color,
+              lineWidth: xAxisGridLineStyle.width,
+              ...(xDash && { lineDash: xDash }),
+            },
+          });
+        });
+      }
+
+      return { type: 'group', children } as ReturnType<
+        NonNullable<CustomSeriesOption['renderItem']>
+      >;
+    },
+    data: [{ value: [xMin, referenceCategory] }],
+    z: 0,
+  };
+}
+
+export function buildSeries(
+  props: ForestPlotProps,
+  yAxisCategories: string[],
+  xMin: number,
+  xMax: number,
+  xTickPositions: number[],
+): EChartsOption['series'] {
+  return [
+    ...(props.xAxisGridLineStyle || props.yAxisGridLineStyle
+      ? [
+          gridLineSeries(
+            yAxisCategories,
+            xMin,
+            xMax,
+            xTickPositions,
+            props.xAxisGridLineStyle,
+            props.yAxisGridLineStyle,
+          ),
+        ]
+      : []),
+    ...((props.showZeroLine ?? true) ? [zeroLineSeries(yAxisCategories)] : []),
+    ciLineSeries(props),
+    dotSeries(props),
+  ];
+}

--- a/libs/explorers/charts/src/lib/mocks/mock-forest-plot-data.ts
+++ b/libs/explorers/charts/src/lib/mocks/mock-forest-plot-data.ts
@@ -11,9 +11,13 @@ export const forestPlotItems: ForestPlotItem[] = [
   { yAxisCategory: 'TCX', value: 0.027, ciLeft: -0.099, ciRight: 0.153 },
 ];
 
-export const forestPlotItemsColoredByLine: ForestPlotItem[] = forestPlotItems.map((item, i) => ({
-  ...item,
-  color: ['#8b8ad1', '#56B4E9', '#009E73', '#E69F00', '#D55E00', '#CC79A7', '#0072B2', '#F0E442'][
-    i
-  ],
-}));
+export const forestPlotItemsColoredByLine: ForestPlotItem[] = [
+  { yAxisCategory: 'ENDO', value: 0.35, ciLeft: 0.29, ciRight: 0.41, color: '#FD7446' },
+  { yAxisCategory: 'MURAL', value: 0.46, ciLeft: 0.36, ciRight: 0.56, color: '#FD8CC1' },
+  { yAxisCategory: 'IMMUNE', value: 0.54, ciLeft: 0.44, ciRight: 0.64, color: '#C80813' },
+  { yAxisCategory: 'ASTRO', value: 0.28, ciLeft: 0.21, ciRight: 0.35, color: '#D2AF81' },
+  { yAxisCategory: 'OPC', value: 0.38, ciLeft: 0.3, ciRight: 0.46, color: '#FED439' },
+  { yAxisCategory: 'OLIGO', value: 0.43, ciLeft: 0.35, ciRight: 0.51, color: '#AEC365' },
+  { yAxisCategory: 'IN', value: 0.18, ciLeft: 0.1, ciRight: 0.26, color: '#1A9993' },
+  { yAxisCategory: 'EN', value: 0.48, ciLeft: 0.37, ciRight: 0.59, color: '#197EC0' },
+];

--- a/libs/explorers/charts/src/lib/models/axis.ts
+++ b/libs/explorers/charts/src/lib/models/axis.ts
@@ -1,0 +1,16 @@
+export type AxisLineStyle = {
+  width?: number;
+  color?: string;
+};
+
+export type AxisTickLabelStyle = {
+  fontSize?: string;
+  fontWeight?: 'normal' | 'bold' | 'bolder' | 'lighter' | number;
+  color?: string;
+};
+
+export type GridLineStyle = {
+  width: number;
+  color: string;
+  type: 'solid' | 'dashed' | 'dotted';
+};

--- a/libs/explorers/charts/src/lib/models/boxplot.ts
+++ b/libs/explorers/charts/src/lib/models/boxplot.ts
@@ -1,10 +1,10 @@
-import { EChartsOption, SeriesOption } from 'echarts';
+import type { SeriesOption } from 'echarts';
 import type { BoxplotSeriesOption } from 'echarts/charts';
 import type { TitleComponentOption } from 'echarts/components';
 import type { CallbackDataParams } from 'echarts/types/dist/shared';
 import type { AxisLineStyle, AxisTickLabelStyle } from './axis';
 import type { BaseChartTheme, ChartStyle } from './chart';
-import type { TooltipStyle } from './tooltip';
+import type { TooltipOption, TooltipStyle } from './tooltip';
 
 export type CategoryPoint = {
   // x-axis category for this point
@@ -106,7 +106,7 @@ export interface BoxplotChartTheme extends BaseChartTheme {
   yAxisTitleTextStyle: TitleComponentOption['textStyle'];
   yAxisSplitLine: { show: boolean };
   yAxisTickLabelMaxWidth: number;
-  tooltip: EChartsOption['tooltip'];
+  tooltip: TooltipOption;
   grid: {
     left: number;
     right: number;

--- a/libs/explorers/charts/src/lib/models/boxplot.ts
+++ b/libs/explorers/charts/src/lib/models/boxplot.ts
@@ -2,9 +2,10 @@ import type { SeriesOption } from 'echarts';
 import type { BoxplotSeriesOption } from 'echarts/charts';
 import type { TitleComponentOption } from 'echarts/components';
 import type { CallbackDataParams } from 'echarts/types/dist/shared';
+import type { TooltipOption } from '../types';
 import type { AxisLineStyle, AxisTickLabelStyle } from './axis';
 import type { BaseChartTheme, ChartStyle } from './chart';
-import type { TooltipOption, TooltipStyle } from './tooltip';
+import type { TooltipStyle } from './tooltip';
 
 export type CategoryPoint = {
   // x-axis category for this point

--- a/libs/explorers/charts/src/lib/models/boxplot.ts
+++ b/libs/explorers/charts/src/lib/models/boxplot.ts
@@ -2,7 +2,9 @@ import { EChartsOption, SeriesOption } from 'echarts';
 import type { BoxplotSeriesOption } from 'echarts/charts';
 import type { TitleComponentOption } from 'echarts/components';
 import type { CallbackDataParams } from 'echarts/types/dist/shared';
+import type { AxisLineStyle, AxisTickLabelStyle } from './axis';
 import type { BaseChartTheme, ChartStyle } from './chart';
+import type { TooltipStyle } from './tooltip';
 
 export type CategoryPoint = {
   // x-axis category for this point
@@ -82,23 +84,14 @@ export interface BoxplotProps {
   axisTickLabelStyle?: AxisTickLabelStyle;
   /* if defined, overrides the axis line stroke on both the category x-axis and the y-axis. */
   axisLineStyle?: AxisLineStyle;
+  /* if defined, overrides individual fields on the default tooltip styling. */
+  tooltipStyle?: TooltipStyle;
 }
 
 export type BoxplotBoxStyle = {
   fillColor?: string;
   borderColor?: string;
   borderWidth?: number;
-};
-
-export type AxisTickLabelStyle = {
-  fontSize?: string;
-  fontWeight?: 'normal' | 'bold' | 'bolder' | 'lighter' | number;
-  color?: string;
-};
-
-export type AxisLineStyle = {
-  width?: number;
-  color?: string;
 };
 
 export interface BoxplotChartTheme extends BaseChartTheme {

--- a/libs/explorers/charts/src/lib/models/forest-plot.ts
+++ b/libs/explorers/charts/src/lib/models/forest-plot.ts
@@ -1,3 +1,6 @@
+import type { AxisLineStyle, AxisTickLabelStyle, GridLineStyle } from './axis';
+import type { TooltipStyle } from './tooltip';
+
 export type ForestPlotItem = {
   yAxisCategory: string; // e.g. "ACC", "CBE"
   value: number; // center point (log fold change)
@@ -6,13 +9,19 @@ export type ForestPlotItem = {
   color?: string; // optional per-item color override
 };
 
+export type RowHoverHighlightStyle = {
+  backgroundColor: string;
+  /** Band thickness in pixels. Centered on the row tick; keep it smaller than the row pitch so adjacent rows don't overlap. */
+  thickness: number;
+};
+
 export interface ForestPlotProps {
   items: ForestPlotItem[];
   title?: string;
   xAxisTitle?: string;
   /**
-   * Explicit x-axis bounds. **Both must be provided together** — if only one is set,
-   * both are ignored and bounds are auto-calculated symmetrically from CI data (×1.1).
+   * Explicit x-axis bounds. **Both must be provided together** -- if only one is set,
+   * both are ignored and bounds are auto-calculated symmetrically from CI data (*1.1).
    */
   xAxisMin?: number;
   xAxisMax?: number;
@@ -23,8 +32,42 @@ export interface ForestPlotProps {
   defaultLineColor?: string;
   defaultPointColor?: string;
   pointSize?: number;
+  /** Stroke width of each CI (stick) line in pixels. Defaults to CI_LINE_WIDTH (1.5px). */
+  ciLineWidth?: number;
   showCILabels?: boolean; // show ciLeft/ciRight values as text next to line
   // Optional formatter for CI label text; defaults to toPrecision(2)
   ciLabelFormatter?: (value: number) => string;
   noDataStyle?: 'textOnly' | 'grayBackground';
+  /** If false, hides the vertical reference line at x=0. Defaults to true. */
+  showZeroLine?: boolean;
+  /**
+   * Explicit step between x-axis ticks. Ticks fall on multiples of the interval (anchored
+   * to 0), so they land on round values regardless of `xAxisMin` -- e.g. interval 0.2
+   * within [-0.1, 0.7] yields ticks at 0, 0.2, 0.4, 0.6. Defaults to `(xMax - xMin) / 10`.
+   */
+  xAxisInterval?: number;
+  /** Number of decimal places to render on each x-axis tick label. Defaults to 2. */
+  xAxisLabelPrecision?: number;
+  /** If defined, overrides the x-axis line stroke. */
+  xAxisLineStyle?: AxisLineStyle;
+  /**
+   * If defined, draws a styled y-axis frame line at the left edge of the plot (hidden by
+   * default). The x=0 reference line is a separate concept controlled via `showZeroLine`
+   * -- the frame line is always anchored to the left edge, never to x=0.
+   */
+  yAxisLineStyle?: AxisLineStyle;
+  /** If defined, overrides x-axis tick label typography. */
+  xAxisTickLabelStyle?: AxisTickLabelStyle;
+  /** If defined, overrides y-axis tick label typography. */
+  yAxisTickLabelStyle?: AxisTickLabelStyle;
+  /** If true, mirrors x-axis tick labels on the top of the plot. */
+  showXAxisLabelsOnTop?: boolean;
+  /** If defined, draws a vertical grid line at each x-axis tick. */
+  xAxisGridLineStyle?: GridLineStyle;
+  /** If defined, draws a horizontal grid line at each y-axis tick. */
+  yAxisGridLineStyle?: GridLineStyle;
+  /** If defined, enables row hover highlighting with the given style. */
+  rowHoverHighlightStyle?: RowHoverHighlightStyle;
+  /** If defined, overrides individual fields on the default tooltip styling. */
+  tooltipStyle?: TooltipStyle;
 }

--- a/libs/explorers/charts/src/lib/models/forest-plot.ts
+++ b/libs/explorers/charts/src/lib/models/forest-plot.ts
@@ -44,6 +44,7 @@ export interface ForestPlotProps {
    * Explicit step between x-axis ticks. Ticks fall on multiples of the interval (anchored
    * to 0), so they land on round values regardless of `xAxisMin` -- e.g. interval 0.2
    * within [-0.1, 0.7] yields ticks at 0, 0.2, 0.4, 0.6. Defaults to `(xMax - xMin) / 10`.
+   * Non-positive values fall through to the default.
    */
   xAxisInterval?: number;
   /** Number of decimal places to render on each x-axis tick label. Defaults to 2. */

--- a/libs/explorers/charts/src/lib/models/forest-plot.ts
+++ b/libs/explorers/charts/src/lib/models/forest-plot.ts
@@ -43,8 +43,10 @@ export interface ForestPlotProps {
   /**
    * Explicit step between x-axis ticks. Ticks fall on multiples of the interval (anchored
    * to 0), so they land on round values regardless of `xAxisMin` -- e.g. interval 0.2
-   * within [-0.1, 0.7] yields ticks at 0, 0.2, 0.4, 0.6. Defaults to `(xMax - xMin) / 10`.
-   * Non-positive values fall through to the default.
+   * within [-0.1, 0.7] yields ticks at 0, 0.2, 0.4, 0.6. When omitted (or non-positive),
+   * ECharts' built-in "nice number" algorithm picks the tick spacing automatically.
+   * Set this when you need ticks at specific positions (e.g. to align with a grid line
+   * style, or to enforce a stride that ECharts would otherwise round to a coarser value).
    */
   xAxisInterval?: number;
   /** Number of decimal places to render on each x-axis tick label. Defaults to 2. */

--- a/libs/explorers/charts/src/lib/models/index.ts
+++ b/libs/explorers/charts/src/lib/models/index.ts
@@ -11,4 +11,4 @@ export type { CandlestickItem, CandlestickProps } from './candlestick';
 export type { ChartStyle } from './chart';
 export type { ForestPlotItem, ForestPlotProps, RowHoverHighlightStyle } from './forest-plot';
 export type { LegendProps, PointStyle } from './legend';
-export type { TooltipStyle } from './tooltip';
+export type { TooltipOption, TooltipStyle } from './tooltip';

--- a/libs/explorers/charts/src/lib/models/index.ts
+++ b/libs/explorers/charts/src/lib/models/index.ts
@@ -11,4 +11,4 @@ export type { CandlestickItem, CandlestickProps } from './candlestick';
 export type { ChartStyle } from './chart';
 export type { ForestPlotItem, ForestPlotProps, RowHoverHighlightStyle } from './forest-plot';
 export type { LegendProps, PointStyle } from './legend';
-export type { TooltipOption, TooltipStyle } from './tooltip';
+export type { TooltipStyle } from './tooltip';

--- a/libs/explorers/charts/src/lib/models/index.ts
+++ b/libs/explorers/charts/src/lib/models/index.ts
@@ -1,6 +1,5 @@
+export type { AxisLineStyle, AxisTickLabelStyle, GridLineStyle } from './axis';
 export type {
-  AxisLineStyle,
-  AxisTickLabelStyle,
   BoxplotBoxStyle,
   BoxplotProps,
   CategoryAsValueBoxplotSummary,
@@ -10,5 +9,6 @@ export type {
 } from './boxplot';
 export type { CandlestickItem, CandlestickProps } from './candlestick';
 export type { ChartStyle } from './chart';
-export type { ForestPlotItem, ForestPlotProps } from './forest-plot';
+export type { ForestPlotItem, ForestPlotProps, RowHoverHighlightStyle } from './forest-plot';
 export type { LegendProps, PointStyle } from './legend';
+export type { TooltipStyle } from './tooltip';

--- a/libs/explorers/charts/src/lib/models/tooltip.ts
+++ b/libs/explorers/charts/src/lib/models/tooltip.ts
@@ -1,10 +1,12 @@
 import type { EChartsOption } from 'echarts';
 
 // EChartsOption['tooltip'] is `TooltipOption | TooltipOption[] | undefined`. We never
-// use the array form, so narrow to the single-object case. Importing from
+// use the array or undefined form, so narrow to the single-object case. NonNullable
+// strips undefined before Exclude removes the array variant (Exclude alone leaves
+// `undefined` since it isn't assignable to `unknown[]`). Importing from
 // `echarts/components` instead triggers nominal-type mismatches when callers assign
 // the result back into EChartsOption['tooltip'].
-export type TooltipOption = Exclude<EChartsOption['tooltip'], unknown[]>;
+export type TooltipOption = Exclude<NonNullable<EChartsOption['tooltip']>, unknown[]>;
 
 /**
  * Tooltip overrides. Any field provided replaces the corresponding value on the

--- a/libs/explorers/charts/src/lib/models/tooltip.ts
+++ b/libs/explorers/charts/src/lib/models/tooltip.ts
@@ -1,0 +1,11 @@
+/**
+ * Tooltip overrides. Any field provided replaces the corresponding value on the
+ * chart's default tooltip; everything else (confine, extraCssText, max-width, etc.)
+ * is inherited.
+ */
+export type TooltipStyle = {
+  backgroundColor?: string;
+  /** Text color. */
+  color?: string;
+  borderColor?: string;
+};

--- a/libs/explorers/charts/src/lib/models/tooltip.ts
+++ b/libs/explorers/charts/src/lib/models/tooltip.ts
@@ -1,3 +1,11 @@
+import type { EChartsOption } from 'echarts';
+
+// EChartsOption['tooltip'] is `TooltipOption | TooltipOption[] | undefined`. We never
+// use the array form, so narrow to the single-object case. Importing from
+// `echarts/components` instead triggers nominal-type mismatches when callers assign
+// the result back into EChartsOption['tooltip'].
+export type TooltipOption = Exclude<EChartsOption['tooltip'], unknown[]>;
+
 /**
  * Tooltip overrides. Any field provided replaces the corresponding value on the
  * chart's default tooltip; everything else (confine, extraCssText, max-width, etc.)

--- a/libs/explorers/charts/src/lib/models/tooltip.ts
+++ b/libs/explorers/charts/src/lib/models/tooltip.ts
@@ -1,13 +1,3 @@
-import type { EChartsOption } from 'echarts';
-
-// EChartsOption['tooltip'] is `TooltipOption | TooltipOption[] | undefined`. We never
-// use the array or undefined form, so narrow to the single-object case. NonNullable
-// strips undefined before Exclude removes the array variant (Exclude alone leaves
-// `undefined` since it isn't assignable to `unknown[]`). Importing from
-// `echarts/components` instead triggers nominal-type mismatches when callers assign
-// the result back into EChartsOption['tooltip'].
-export type TooltipOption = Exclude<NonNullable<EChartsOption['tooltip']>, unknown[]>;
-
 /**
  * Tooltip overrides. Any field provided replaces the corresponding value on the
  * chart's default tooltip; everything else (confine, extraCssText, max-width, etc.)

--- a/libs/explorers/charts/src/lib/types.ts
+++ b/libs/explorers/charts/src/lib/types.ts
@@ -6,3 +6,14 @@
  * Usage: `const grid = params.coordSys as unknown as GridCoordSys;`
  */
 export type GridCoordSys = { x: number; y: number; width: number; height: number };
+
+/**
+ * Partial shape of the `updateAxisPointer` event payload emitted by ECharts when the axis
+ * pointer moves. ECharts types event listeners loosely, so we narrow to the `axesInfo`
+ * field via cast.
+ *
+ * Usage: `const event = rawEvent as UpdateAxisPointerEvent;`
+ */
+export type UpdateAxisPointerEvent = {
+  axesInfo?: { axisDim: string; value: string | number }[];
+};

--- a/libs/explorers/charts/src/lib/types.ts
+++ b/libs/explorers/charts/src/lib/types.ts
@@ -1,3 +1,5 @@
+import type { EChartsOption } from 'echarts';
+
 /**
  * Pixel bounds of the ECharts grid, available at render time via `params.coordSys` in a custom
  * series `renderItem` callback. ECharts only types `coordSys` as `{ type: string }` — the
@@ -17,3 +19,13 @@ export type GridCoordSys = { x: number; y: number; width: number; height: number
 export type UpdateAxisPointerEvent = {
   axesInfo?: { axisDim: string; value: string | number }[];
 };
+
+/**
+ * EChartsOption['tooltip'] is `TooltipOption | TooltipOption[] | undefined`. We never use
+ * the array or undefined form, so narrow to the single-object case. NonNullable strips
+ * `undefined` before Exclude removes the array variant (Exclude alone would leave
+ * `undefined` since it isn't assignable to `unknown[]`). Importing from
+ * `echarts/components` instead triggers nominal-type mismatches when callers assign the
+ * result back into `EChartsOption['tooltip']`.
+ */
+export type TooltipOption = Exclude<NonNullable<EChartsOption['tooltip']>, unknown[]>;

--- a/libs/explorers/charts/src/lib/utils/index.ts
+++ b/libs/explorers/charts/src/lib/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './boxplot-utils';
 export * from './chart-utils';
+export * from './tooltip-utils';

--- a/libs/explorers/charts/src/lib/utils/tooltip-utils.ts
+++ b/libs/explorers/charts/src/lib/utils/tooltip-utils.ts
@@ -1,0 +1,20 @@
+import { EChartsOption } from 'echarts';
+import { TooltipStyle } from '../models';
+
+// Merges TooltipStyle overrides onto a base tooltip config. Fields not present
+// on `style` fall through, so callers only need to specify what they want to
+// change (e.g. just backgroundColor) and everything else (confine, extraCssText,
+// max-width, etc.) is inherited from `base`.
+export function buildTooltip(
+  base: EChartsOption['tooltip'],
+  style: TooltipStyle | undefined,
+): EChartsOption['tooltip'] {
+  if (!style) return base;
+  const baseTextStyle = (base as { textStyle?: object } | undefined)?.textStyle;
+  return {
+    ...base,
+    ...(style.backgroundColor !== undefined && { backgroundColor: style.backgroundColor }),
+    ...(style.borderColor !== undefined && { borderColor: style.borderColor }),
+    ...(style.color !== undefined && { textStyle: { ...baseTextStyle, color: style.color } }),
+  };
+}

--- a/libs/explorers/charts/src/lib/utils/tooltip-utils.ts
+++ b/libs/explorers/charts/src/lib/utils/tooltip-utils.ts
@@ -1,20 +1,15 @@
-import { EChartsOption } from 'echarts';
-import { TooltipStyle } from '../models';
+import { TooltipOption, TooltipStyle } from '../models';
 
 // Merges TooltipStyle overrides onto a base tooltip config. Fields not present
 // on `style` fall through, so callers only need to specify what they want to
 // change (e.g. just backgroundColor) and everything else (confine, extraCssText,
 // max-width, etc.) is inherited from `base`.
-export function buildTooltip(
-  base: EChartsOption['tooltip'],
-  style: TooltipStyle | undefined,
-): EChartsOption['tooltip'] {
+export function buildTooltip(base: TooltipOption, style: TooltipStyle | undefined): TooltipOption {
   if (!style) return base;
-  const baseTextStyle = (base as { textStyle?: object } | undefined)?.textStyle;
   return {
     ...base,
     ...(style.backgroundColor !== undefined && { backgroundColor: style.backgroundColor }),
     ...(style.borderColor !== undefined && { borderColor: style.borderColor }),
-    ...(style.color !== undefined && { textStyle: { ...baseTextStyle, color: style.color } }),
+    ...(style.color !== undefined && { textStyle: { ...base?.textStyle, color: style.color } }),
   };
 }

--- a/libs/explorers/charts/src/lib/utils/tooltip-utils.ts
+++ b/libs/explorers/charts/src/lib/utils/tooltip-utils.ts
@@ -1,4 +1,5 @@
-import { TooltipOption, TooltipStyle } from '../models';
+import { TooltipStyle } from '../models';
+import { TooltipOption } from '../types';
 
 // Merges TooltipStyle overrides onto a base tooltip config. Fields not present
 // on `style` fall through, so callers only need to specify what they want to


### PR DESCRIPTION
## Description

The QTL explorer renders a forest plot with a different visual treatment than the existing Agora usage: explicit axis lines and tick label typography, a top axis label mirror, dotted/solid grid lines, a row-hover highlight band with a bolded label, and a configurable tooltip palette. This change extends the framework-agnostic `ForestPlotChart` (and its Angular wrapper) with the styling hooks needed to render that QTL variant from the same component, so both products share a single chart implementation instead of forking it.

## Related Issue

- [QTL-40](https://sagebionetworks.jira.com/browse/QTL-40)

## Changelog

- Split `forest-plot-chart.ts` into focused modules (`forest-plot-axis`, `forest-plot-series`, `forest-plot-row-hover`) so axis, series, and hover concerns are separately testable
- Add `ForestPlotProps` styling inputs: `showZeroLine`, `xAxisInterval`, `xAxisLabelPrecision`, `xAxisLineStyle`, `yAxisLineStyle`, `xAxisTickLabelStyle`, `yAxisTickLabelStyle`, `showXAxisLabelsOnTop`, `xAxisGridLineStyle`, `yAxisGridLineStyle`, `rowHoverHighlightStyle`, and `tooltipStyle`
- Anchor x-axis ticks to multiples of `xAxisInterval` (independent of `xAxisMin`) so labels land on round values; when `xAxisInterval` is omitted or non-positive, fall back to ECharts' built-in `splitNumber` algorithm so the default Agora-style story keeps its "nice number" tick spacing
- Render grid lines and the x=0 reference via custom series so they align with category ticks, sit below data, and skip the plot edges
- Add a `RowHoverController` that drives a y-axis axis-pointer band and rewrites the y-axis label formatter to bold the hovered row
- Extract `TooltipStyle` and a `buildTooltip` helper, then wire it through `BoxplotChart` so both charts accept the same tooltip override shape
- Update the `forest-plot` Storybook `Styled` story (and the QTL-colored mock items) to exercise the new styling props end-to-end

## Testing

- Open the charts-angular Storybook (`nx start explorers-charts-angular`, port 4400) and load `directives/sageForestPlot > Styled`; confirm the QTL look: dotted vertical grid lines, solid horizontal grid lines, x-axis tick labels on both the top and bottom, no x=0 zero line, axis frame lines at the left and bottom edges, and per-row colored dots/CI lines
- On the `Styled` story, hover over a row and confirm a grey horizontal band fills the row, the y-axis label becomes bold, and adjacent rows are not affected; moving off the chart clears the highlight
- On the `Styled` story, confirm x-axis tick labels read `0.0, 0.2, 0.4, 0.6` (anchored to multiples of `xAxisInterval`, not to `xAxisMin = -0.1`) and that no labels clip at the chart edges
- Load `directives/sageForestPlot > Default` and verify the Agora-style rendering is unchanged: visible x=0 reference line, CI numeric labels, single bottom axis, default tooltip styling, no row-hover band, and ECharts-picked "nice number" x-axis ticks (e.g. `-0.18, -0.15, ... 0.18` for the default mock data)
- Open `directives/sageBoxplot > Styled` and confirm the tooltip background reflects the new `tooltipStyle` override (`#22252A`)
- Resize the browser to confirm the row-hover band thickness stays smaller than the row pitch and does not overlap neighboring rows

### Preview

`nx start explorers-charts-angular`

New forest plot in QTL-style: 

<img width="1084" height="460" alt="image" src="https://github.com/user-attachments/assets/fb3ccdfc-bd80-414b-abd4-7f9ec6f7a831" />

Pre-existing forest plot and boxplot are unchanged:

| feature | before | after
:---: | :---: | :---: 
sageForestPlot > Default  | <img width="1071" height="503" alt="image" src="https://github.com/user-attachments/assets/bc5ebc46-eb72-4ef0-a815-e39e3c1a7c05" /> | <img width="1029" height="485" alt="image" src="https://github.com/user-attachments/assets/56ad0f23-c659-4010-b016-a78871a1d819" />
sageBoxplot > Static Summary | <img width="1186" height="374" alt="image" src="https://github.com/user-attachments/assets/4ff8e9c2-7f26-4725-a130-c8633c76f60a" /> | <img width="1175" height="390" alt="image" src="https://github.com/user-attachments/assets/327f1fcd-152e-4fd8-aa8a-92eda6b933db" />

`agora-build-images && agora-docker-start` -> `/genes/ENSG00000171862/evidence/rna`

Agora forest plot is unchanged: 

dev | pr 
:---: | :---: 
<img width="1079" height="582" alt="image" src="https://github.com/user-attachments/assets/9b8cd1e3-9f53-4270-b52b-dcf54445119f" /> | <img width="989" height="559" alt="image" src="https://github.com/user-attachments/assets/02a6ff1f-d03e-4dbd-8cd2-5106d5c5cfca" /> 





[QTL-40]: https://sagebionetworks.jira.com/browse/QTL-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ