### PR TITLE
feat(qtl): add eqtl comparison tool sidebar panel (QTL-35)

### DIFF
--- a/apps/qtl/app/src/app/app.routes.ts
+++ b/apps/qtl/app/src/app/app.routes.ts
@@ -48,6 +48,16 @@ export const routes: Route[] = [
     },
   },
   {
+    path: ROUTE_PATHS.EQTL,
+    loadChildren: () =>
+      import('@sagebionetworks/qtl/eqtl-comparison-tool').then((routes) => routes.routes),
+    data: {
+      // TODO: update based on values in QTL-34
+      title: 'eQTL Comparison',
+      description: '',
+    },
+  },
+  {
     path: ROUTE_PATHS.TERMS_OF_SERVICE,
     loadChildren: () =>
       import('@sagebionetworks/explorers/shared').then((routes) => routes.termsOfServiceRoute),

--- a/libs/qtl/config/src/lib/constants.ts
+++ b/libs/qtl/config/src/lib/constants.ts
@@ -17,6 +17,8 @@ export const ROUTE_PATHS = {
   HOME: '',
   ABOUT: 'about',
   NEWS: 'news',
+  // TODO: update based on values in QTL-34
+  EQTL: 'comparison/eqtl',
   TERMS_OF_SERVICE: 'terms-of-service',
   NOT_FOUND: 'not-found',
   ERROR: 'error',
@@ -24,46 +26,118 @@ export const ROUTE_PATHS = {
 
 export interface CellClass {
   color: string;
+  mutedColor?: string;
   short: string;
 }
 
 export const CELL_CLASSES = {
-  'Immune Cell': { color: '#C80813', short: 'Immune' },
-  Astrocyte: { color: '#D2AF81', short: 'Astro' },
-  'Oligodendrocyte Progenitor Cell': { color: '#FED439', short: 'OPC' },
-  Oligodendrocyte: { color: '#AEC365', short: 'Oligo' },
-  'Inhibitory Neuron': { color: '#1A9993', short: 'IN' },
-  'Excitatory Neuron': { color: '#197EC0', short: 'EN' },
-  Endothelial: { color: '#FD7446', short: 'Endo' },
-  'Vascular Cell': { color: '#FD8CC1', short: 'Mural' },
+  'Immune Cell': { color: '#C80813', mutedColor: '#E38389', short: 'Immune' },
+  Astrocyte: { color: '#D2AF81', mutedColor: '#E9D7C0', short: 'Astro' },
+  'Oligodendrocyte Progenitor Cell': { color: '#FED439', mutedColor: '#FFE99C', short: 'OPC' },
+  Oligodendrocyte: { color: '#AEC365', mutedColor: '#D7E1B2', short: 'Oligo' },
+  'Inhibitory Neuron': { color: '#1A9993', mutedColor: '#8CCCC9', short: 'IN' },
+  'Excitatory Neuron': { color: '#197EC0', mutedColor: '#8CBEDF', short: 'EN' },
+  Endothelial: { color: '#FD7446', mutedColor: '#FEB9A2', short: 'Endo' },
+  'Vascular Cell': { color: '#FD8CC1', mutedColor: '#FEC5E0', short: 'Mural' },
 } as const satisfies Record<string, CellClass>;
 
-export const CELL_CLASSES_FULL = {
-  ...CELL_CLASSES,
-  'Adaptive Immune Cell': { color: '#6F4E37', short: 'Adaptive' },
-  'Layer 2-3 Intratelencephalic Excitatory Neuron': { color: '#659EC7', short: 'L2/3 IT' },
-  'Layer 3-5 Intratelencephalic Excitatory Neuron 1': { color: '#95B9C7', short: 'L3/5 IT 1' },
-  'Layer 3-5 Intratelencephalic Excitatory Neuron 2': { color: '#6495ED', short: 'L3/5 IT 2' },
-  'Layer 3-5 Intratelencephalic Excitatory Neuron 3': { color: '#79BAEC', short: 'L3/5 IT 3' },
-  'Layer 5 Extratelencephalic Excitatory Neuron': { color: '#4863A0', short: 'L5 ET' },
-  'Layer 5-6 Near-Projecting Excitatory Neuron': { color: '#0020C2', short: 'L5/6 NP' },
-  'Layer 6 Corticothalamic Excitatory Neuron': { color: '#3BB9FF', short: 'L6 CT' },
-  'Layer 6 Excitatory Neuron 1': { color: '#B4CFEC', short: 'L6 IT 1' },
-  'Layer 6 Excitatory Neuron 2': { color: '#1589FF', short: 'L6 IT 2' },
-  'Layer 6B Excitatory Neuron': { color: '#488AC7', short: 'L6B' },
-  'ADARB2 Inhibitory Neuron': { color: '#4E8975', short: 'ADARB2' },
-  'Neurogliaform cell (LAMP5 RELN Inhibitory Neuron)': { color: '#3B9C9C', short: 'RELN' },
-  'VIP Inhibitory Neuron': { color: '#89C35C', short: 'VIP' },
-  'Ivy cell (LAMP5 LHX6 Inhibitory Neuron)': { color: '#7BCCB5', short: 'LHX6' },
-  'Basket Cell (PVALB Inhibitory Neuron)': { color: '#B2C248', short: 'PVALB' },
-  'Chandelier Cell (PVALB CHC Inhibitory Neuron)': { color: '#008080', short: 'CHC' },
+export interface CellSubclass extends CellClass {
+  cellClass: keyof typeof CELL_CLASSES;
+}
+
+export const CELL_SUBCLASSES = {
+  Astrocyte: { ...CELL_CLASSES.Astrocyte, cellClass: 'Astrocyte' },
+  'Oligodendrocyte Progenitor Cell': {
+    ...CELL_CLASSES['Oligodendrocyte Progenitor Cell'],
+    cellClass: 'Oligodendrocyte Progenitor Cell',
+  },
+  Oligodendrocyte: { ...CELL_CLASSES.Oligodendrocyte, cellClass: 'Oligodendrocyte' },
+  Endothelial: { ...CELL_CLASSES.Endothelial, cellClass: 'Endothelial' },
+  'Adaptive Immune Cell': { color: '#6F4E37', short: 'Adaptive', cellClass: 'Immune Cell' },
+  'Layer 2-3 Intratelencephalic Excitatory Neuron': {
+    color: '#659EC7',
+    short: 'L2/3 IT',
+    cellClass: 'Excitatory Neuron',
+  },
+  'Layer 3-5 Intratelencephalic Excitatory Neuron 1': {
+    color: '#95B9C7',
+    short: 'L3/5 IT 1',
+    cellClass: 'Excitatory Neuron',
+  },
+  'Layer 3-5 Intratelencephalic Excitatory Neuron 2': {
+    color: '#6495ED',
+    short: 'L3/5 IT 2',
+    cellClass: 'Excitatory Neuron',
+  },
+  'Layer 3-5 Intratelencephalic Excitatory Neuron 3': {
+    color: '#79BAEC',
+    short: 'L3/5 IT 3',
+    cellClass: 'Excitatory Neuron',
+  },
+  'Layer 5 Extratelencephalic Excitatory Neuron': {
+    color: '#4863A0',
+    short: 'L5 ET',
+    cellClass: 'Excitatory Neuron',
+  },
+  'Layer 5-6 Near-Projecting Excitatory Neuron': {
+    color: '#0020C2',
+    short: 'L5/6 NP',
+    cellClass: 'Excitatory Neuron',
+  },
+  'Layer 6 Corticothalamic Excitatory Neuron': {
+    color: '#3BB9FF',
+    short: 'L6 CT',
+    cellClass: 'Excitatory Neuron',
+  },
+  'Layer 6 Excitatory Neuron 1': {
+    color: '#B4CFEC',
+    short: 'L6 IT 1',
+    cellClass: 'Excitatory Neuron',
+  },
+  'Layer 6 Excitatory Neuron 2': {
+    color: '#1589FF',
+    short: 'L6 IT 2',
+    cellClass: 'Excitatory Neuron',
+  },
+  'Layer 6B Excitatory Neuron': {
+    color: '#488AC7',
+    short: 'L6B',
+    cellClass: 'Excitatory Neuron',
+  },
+  'ADARB2 Inhibitory Neuron': {
+    color: '#4E8975',
+    short: 'ADARB2',
+    cellClass: 'Inhibitory Neuron',
+  },
+  'Neurogliaform cell (LAMP5 RELN Inhibitory Neuron)': {
+    color: '#3B9C9C',
+    short: 'RELN',
+    cellClass: 'Inhibitory Neuron',
+  },
+  'VIP Inhibitory Neuron': { color: '#89C35C', short: 'VIP', cellClass: 'Inhibitory Neuron' },
+  'Ivy cell (LAMP5 LHX6 Inhibitory Neuron)': {
+    color: '#7BCCB5',
+    short: 'LHX6',
+    cellClass: 'Inhibitory Neuron',
+  },
+  'Basket Cell (PVALB Inhibitory Neuron)': {
+    color: '#B2C248',
+    short: 'PVALB',
+    cellClass: 'Inhibitory Neuron',
+  },
+  'Chandelier Cell (PVALB CHC Inhibitory Neuron)': {
+    color: '#008080',
+    short: 'CHC',
+    cellClass: 'Inhibitory Neuron',
+  },
   'Martinotti and Non-Martinotti cell (SST Inhibitory Neuron)': {
     color: '#728C00',
     short: 'SST',
+    cellClass: 'Inhibitory Neuron',
   },
-  'Perivascular Macrophage': { color: '#C11B17', short: 'PVM' },
-  Microglia: { color: '#F75D59', short: 'Micro' },
-  Pericyte: { color: '#E0B0FF', short: 'PC' },
-  'Smooth Muscle Cell': { color: '#4E387E', short: 'SMC' },
-  'Vascular Leptomeningeal Cell': { color: '#B93B8F', short: 'VLMC' },
-} as const satisfies Record<string, CellClass>;
+  'Perivascular Macrophage': { color: '#C11B17', short: 'PVM', cellClass: 'Immune Cell' },
+  Microglia: { color: '#F75D59', short: 'Micro', cellClass: 'Immune Cell' },
+  Pericyte: { color: '#E0B0FF', short: 'PC', cellClass: 'Vascular Cell' },
+  'Smooth Muscle Cell': { color: '#4E387E', short: 'SMC', cellClass: 'Vascular Cell' },
+  'Vascular Leptomeningeal Cell': { color: '#B93B8F', short: 'VLMC', cellClass: 'Vascular Cell' },
+} as const satisfies Record<string, CellSubclass>;

--- a/libs/qtl/eqtl-comparison-tool/src/lib/components/sidebar/sidebar.component.html
+++ b/libs/qtl/eqtl-comparison-tool/src/lib/components/sidebar/sidebar.component.html
@@ -1,0 +1,52 @@
+<div class="sidebar-chiclets">
+  <qtl-metadata-chiclet
+    backgroundColor="var(--color-variant-muted)"
+    label="variant"
+    [value]="data.variant_id"
+  />
+  <qtl-metadata-chiclet
+    backgroundColor="var(--color-gene-muted)"
+    label="gene"
+    [value]="data.hgnc_symbol"
+  />
+  <qtl-metadata-chiclet
+    [backgroundColor]="cellTypeBackgroundColor"
+    label="cell type"
+    [value]="data.cell_type"
+  />
+</div>
+
+<div role="tablist" class="sidebar-tabs">
+  @for (tab of tabs; track tab.value) {
+    <button
+      [id]="'tab-' + tab.value"
+      role="tab"
+      type="button"
+      [class.active]="activeTab() === tab.value"
+      [attr.aria-selected]="activeTab() === tab.value"
+      [attr.aria-controls]="'tabpanel-' + tab.value"
+      (click)="activeTab.set(tab.value)"
+    >
+      {{ tab.label }}
+    </button>
+  }
+</div>
+<hr class="sidebar-divider" />
+<div
+  role="tabpanel"
+  class="sidebar-tabpanel"
+  [id]="'tabpanel-' + activeTab()"
+  [attr.aria-labelledby]="'tab-' + activeTab()"
+>
+  @switch (activeTab()) {
+    @case ('impact') {
+      <p>Impact panel content -- see QTL-37.</p>
+    }
+    @case ('traits') {
+      <p>Traits panel content -- see QTL-43.</p>
+    }
+    @case ('resources') {
+      <p>Resources panel content -- see QTL-44.</p>
+    }
+  }
+</div>

--- a/libs/qtl/eqtl-comparison-tool/src/lib/components/sidebar/sidebar.component.html
+++ b/libs/qtl/eqtl-comparison-tool/src/lib/components/sidebar/sidebar.component.html
@@ -17,15 +17,18 @@
 </div>
 
 <div role="tablist" class="sidebar-tabs">
-  @for (tab of tabs; track tab.value) {
+  @for (tab of tabs; track tab.value; let i = $index) {
     <button
+      #tabButton
       [id]="'tab-' + tab.value"
       role="tab"
       type="button"
       [class.active]="activeTab() === tab.value"
       [attr.aria-selected]="activeTab() === tab.value"
       [attr.aria-controls]="'tabpanel-' + tab.value"
+      [attr.tabindex]="activeTab() === tab.value ? 0 : -1"
       (click)="activeTab.set(tab.value)"
+      (keydown)="onTabKeydown($event, i)"
     >
       {{ tab.label }}
     </button>

--- a/libs/qtl/eqtl-comparison-tool/src/lib/components/sidebar/sidebar.component.scss
+++ b/libs/qtl/eqtl-comparison-tool/src/lib/components/sidebar/sidebar.component.scss
@@ -1,0 +1,47 @@
+@use 'explorers/styles/src/mixins' as mixins;
+
+:host {
+  --panel-padding-y: 16px;
+  --panel-padding-x: 20px;
+
+  display: block;
+}
+
+.sidebar-chiclets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: var(--panel-padding-y) var(--panel-padding-x) 0;
+  margin-bottom: 12px;
+}
+
+.sidebar-tabs {
+  display: flex;
+  gap: 28px;
+  padding: 0 var(--panel-padding-x) 16px;
+
+  button {
+    @include mixins.reset-button;
+
+    cursor: pointer;
+    color: var(--color-gray-900);
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 20px;
+    border-bottom: 3px solid transparent;
+
+    &.active {
+      border-bottom-color: var(--color-accent-lavender-600);
+    }
+  }
+}
+
+.sidebar-divider {
+  border: 0;
+  border-top: 1px solid var(--color-gray-300);
+  margin: 0;
+}
+
+.sidebar-tabpanel {
+  padding: 16px var(--panel-padding-x) var(--panel-padding-y);
+}

--- a/libs/qtl/eqtl-comparison-tool/src/lib/components/sidebar/sidebar.component.spec.ts
+++ b/libs/qtl/eqtl-comparison-tool/src/lib/components/sidebar/sidebar.component.spec.ts
@@ -1,5 +1,6 @@
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { render, screen } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
 import { SidebarComponent } from './sidebar.component';
 
 async function setup() {
@@ -24,5 +25,45 @@ describe('SidebarComponent', () => {
     expect(screen.getByRole('tab', { name: 'Impact' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Traits' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Resources' })).toBeInTheDocument();
+  });
+
+  it('puts only the active tab in the tab order (roving tabindex)', async () => {
+    await setup();
+    expect(screen.getByRole('tab', { name: 'Impact' })).toHaveAttribute('tabindex', '0');
+    expect(screen.getByRole('tab', { name: 'Traits' })).toHaveAttribute('tabindex', '-1');
+    expect(screen.getByRole('tab', { name: 'Resources' })).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('moves focus and activation to the next tab on ArrowRight (wrapping at the end)', async () => {
+    const user = userEvent.setup();
+    await setup();
+
+    const impact = screen.getByRole('tab', { name: 'Impact' });
+    const traits = screen.getByRole('tab', { name: 'Traits' });
+    const resources = screen.getByRole('tab', { name: 'Resources' });
+
+    impact.focus();
+    await user.keyboard('{ArrowRight}');
+    expect(traits).toHaveFocus();
+    expect(traits).toHaveAttribute('aria-selected', 'true');
+
+    await user.keyboard('{ArrowRight}');
+    expect(resources).toHaveFocus();
+
+    await user.keyboard('{ArrowRight}');
+    expect(impact).toHaveFocus();
+  });
+
+  it('jumps to the last tab on End and the first tab on Home', async () => {
+    const user = userEvent.setup();
+    await setup();
+
+    screen.getByRole('tab', { name: 'Impact' }).focus();
+
+    await user.keyboard('{End}');
+    expect(screen.getByRole('tab', { name: 'Resources' })).toHaveFocus();
+
+    await user.keyboard('{Home}');
+    expect(screen.getByRole('tab', { name: 'Impact' })).toHaveFocus();
   });
 });

--- a/libs/qtl/eqtl-comparison-tool/src/lib/components/sidebar/sidebar.component.spec.ts
+++ b/libs/qtl/eqtl-comparison-tool/src/lib/components/sidebar/sidebar.component.spec.ts
@@ -1,0 +1,28 @@
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { render, screen } from '@testing-library/angular';
+import { SidebarComponent } from './sidebar.component';
+
+async function setup() {
+  return render(SidebarComponent, {
+    providers: [provideNoopAnimations()],
+  });
+}
+
+describe('SidebarComponent', () => {
+  it('renders all three chiclets with the expected label/value pairs', async () => {
+    await setup();
+    expect(screen.getByText('variant:')).toBeInTheDocument();
+    expect(screen.getByText(/rs29475839/)).toBeInTheDocument();
+    expect(screen.getByText('gene:')).toBeInTheDocument();
+    expect(screen.getByText(/PAK1/)).toBeInTheDocument();
+    expect(screen.getByText('cell type:')).toBeInTheDocument();
+    expect(screen.getByText(/Astrocyte/)).toBeInTheDocument();
+  });
+
+  it('renders all three tab headers', async () => {
+    await setup();
+    expect(screen.getByRole('tab', { name: 'Impact' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Traits' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Resources' })).toBeInTheDocument();
+  });
+});

--- a/libs/qtl/eqtl-comparison-tool/src/lib/components/sidebar/sidebar.component.ts
+++ b/libs/qtl/eqtl-comparison-tool/src/lib/components/sidebar/sidebar.component.ts
@@ -1,0 +1,31 @@
+import { Component, signal } from '@angular/core';
+import { CELL_CLASSES } from '@sagebionetworks/qtl/config';
+import { MetadataChicletComponent } from '@sagebionetworks/qtl/ui';
+import { getCellTypeMutedColor } from '@sagebionetworks/qtl/util';
+
+type SidebarTab = 'impact' | 'traits' | 'resources';
+
+@Component({
+  selector: 'qtl-eqtl-comparison-tool-sidebar',
+  imports: [MetadataChicletComponent],
+  templateUrl: './sidebar.component.html',
+  styleUrls: ['./sidebar.component.scss'],
+})
+export class SidebarComponent {
+  // TODO: update with dynamically fetched sidebar data
+  protected readonly data = {
+    variant_id: 'rs29475839',
+    hgnc_symbol: 'PAK1',
+    cell_type: 'Astrocyte' as keyof typeof CELL_CLASSES,
+  };
+
+  protected readonly cellTypeBackgroundColor = getCellTypeMutedColor(this.data.cell_type);
+
+  protected readonly tabs: { value: SidebarTab; label: string }[] = [
+    { value: 'impact', label: 'Impact' },
+    { value: 'traits', label: 'Traits' },
+    { value: 'resources', label: 'Resources' },
+  ];
+
+  protected readonly activeTab = signal<SidebarTab>('impact');
+}

--- a/libs/qtl/eqtl-comparison-tool/src/lib/components/sidebar/sidebar.component.ts
+++ b/libs/qtl/eqtl-comparison-tool/src/lib/components/sidebar/sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, signal } from '@angular/core';
+import { Component, ElementRef, signal, viewChildren } from '@angular/core';
 import { CELL_CLASSES } from '@sagebionetworks/qtl/config';
 import { MetadataChicletComponent } from '@sagebionetworks/qtl/ui';
 import { getCellTypeMutedColor } from '@sagebionetworks/qtl/util';
@@ -28,4 +28,32 @@ export class SidebarComponent {
   ];
 
   protected readonly activeTab = signal<SidebarTab>('impact');
+
+  private readonly tabButtons = viewChildren<ElementRef<HTMLButtonElement>>('tabButton');
+
+  protected onTabKeydown(event: KeyboardEvent, index: number): void {
+    const last = this.tabs.length - 1;
+    let nextIndex: number | null = null;
+
+    switch (event.key) {
+      case 'ArrowRight':
+        nextIndex = index === last ? 0 : index + 1;
+        break;
+      case 'ArrowLeft':
+        nextIndex = index === 0 ? last : index - 1;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = last;
+        break;
+    }
+
+    if (nextIndex === null) return;
+
+    event.preventDefault();
+    this.activeTab.set(this.tabs[nextIndex].value);
+    this.tabButtons()[nextIndex]?.nativeElement.focus();
+  }
 }

--- a/libs/qtl/eqtl-comparison-tool/src/lib/eqtl-comparison-tool.component.html
+++ b/libs/qtl/eqtl-comparison-tool/src/lib/eqtl-comparison-tool.component.html
@@ -1,0 +1,3 @@
+<explorers-comparison-tool [isLoading]="false" [hasSidebar]="true">
+  <qtl-eqtl-comparison-tool-sidebar ctSidebar />
+</explorers-comparison-tool>

--- a/libs/qtl/eqtl-comparison-tool/src/lib/eqtl-comparison-tool.component.spec.ts
+++ b/libs/qtl/eqtl-comparison-tool/src/lib/eqtl-comparison-tool.component.spec.ts
@@ -1,8 +1,20 @@
-import { render } from '@testing-library/angular';
+import { provideHttpClient } from '@angular/common/http';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideExplorersConfig, SvgIconService } from '@sagebionetworks/explorers/services';
+import { provideLoadingIconColors, SvgIconServiceStub } from '@sagebionetworks/explorers/testing';
+import { render, screen } from '@testing-library/angular';
 import { EqtlComparisonToolComponent } from './eqtl-comparison-tool.component';
 
 async function setup() {
-  const { fixture } = await render(EqtlComparisonToolComponent);
+  const { fixture } = await render(EqtlComparisonToolComponent, {
+    providers: [
+      provideHttpClient(),
+      provideNoopAnimations(),
+      provideLoadingIconColors(),
+      provideExplorersConfig({ visualizationOverviewPanes: [] }),
+      { provide: SvgIconService, useClass: SvgIconServiceStub },
+    ],
+  });
 
   const component = fixture.componentInstance;
   return { component, fixture };
@@ -12,5 +24,15 @@ describe('EqtlComparisonToolComponent', () => {
   it('should create', async () => {
     const { component } = await setup();
     expect(component).toBeTruthy();
+  });
+
+  it('renders the sidebar chiclets and tabs', async () => {
+    await setup();
+    expect(screen.getByText('variant:')).toBeInTheDocument();
+    expect(screen.getByText('gene:')).toBeInTheDocument();
+    expect(screen.getByText('cell type:')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Impact' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Traits' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Resources' })).toBeInTheDocument();
   });
 });

--- a/libs/qtl/eqtl-comparison-tool/src/lib/eqtl-comparison-tool.component.ts
+++ b/libs/qtl/eqtl-comparison-tool/src/lib/eqtl-comparison-tool.component.ts
@@ -1,9 +1,32 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { ComparisonToolComponent } from '@sagebionetworks/explorers/comparison-tool';
+import {
+  ComparisonToolService,
+  provideComparisonToolFilterService,
+  provideComparisonToolService,
+} from '@sagebionetworks/explorers/services';
+import { MessageService } from 'primeng/api';
+import { of } from 'rxjs';
+import { SidebarComponent } from './components/sidebar/sidebar.component';
 
 @Component({
   selector: 'qtl-eqtl-comparison-tool',
-  imports: [],
+  imports: [ComparisonToolComponent, SidebarComponent],
+  providers: [
+    MessageService,
+    ...provideComparisonToolService(),
+    ...provideComparisonToolFilterService(),
+  ],
   templateUrl: './eqtl-comparison-tool.component.html',
   styleUrls: ['./eqtl-comparison-tool.component.scss'],
 })
-export class EqtlComparisonToolComponent {}
+export class EqtlComparisonToolComponent {
+  private readonly comparisonToolService = inject(ComparisonToolService);
+
+  constructor() {
+    this.comparisonToolService.connect({
+      config$: of([]),
+      queryParams$: of({}),
+    });
+  }
+}

--- a/libs/qtl/eqtl-comparison-tool/src/test-setup.ts
+++ b/libs/qtl/eqtl-comparison-tool/src/test-setup.ts
@@ -1,3 +1,17 @@
 import '@testing-library/jest-dom';
 import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
 setupZoneTestEnv();
+
+const originalResizeObserver = global.ResizeObserver;
+
+beforeEach(() => {
+  global.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn(),
+  }));
+});
+
+afterEach(() => {
+  global.ResizeObserver = originalResizeObserver;
+});

--- a/libs/qtl/styles/src/lib/_general.scss
+++ b/libs/qtl/styles/src/lib/_general.scss
@@ -8,7 +8,7 @@
   --footer-versions-color: rgb(255 255 255 / 70%);
   --header-padding-y: 24px;
   --header-padding-x: 60px;
-  --header-link-color: #6e76ae;
+  --header-link-color: var(--color-accent-lavender-600);
 
   @media (width < #{variables.$lg-breakpoint}) {
     --footer-background: linear-gradient(0deg, rgb(0 0 0 / 40%) 0%, rgb(0 0 0 / 40%) 100%),

--- a/libs/qtl/styles/src/lib/_variables.scss
+++ b/libs/qtl/styles/src/lib/_variables.scss
@@ -7,4 +7,9 @@ $main-colors: (
   secondary: #2c5182,
 
   action-primary: #2c5182,
+
+  accent-lavender-600: #6e76ae,
+
+  variant-muted: #c8e6e9,
+  gene-muted: #d9e5f4,
 );

--- a/libs/qtl/ui/.eslintrc.json
+++ b/libs/qtl/ui/.eslintrc.json
@@ -1,0 +1,41 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "env": {
+    "jest": true
+  },
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates",
+        "plugin:jest/recommended"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "qtl",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "qtl",
+            "style": "kebab-case"
+          }
+        ],
+        "@angular-eslint/prefer-standalone": "off"
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/qtl/ui/README.md
+++ b/libs/qtl/ui/README.md
@@ -1,0 +1,7 @@
+# qtl-ui
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test qtl-ui` to execute the unit tests.

--- a/libs/qtl/ui/jest.config.ts
+++ b/libs/qtl/ui/jest.config.ts
@@ -1,0 +1,23 @@
+/* eslint-disable */
+export default {
+  displayName: 'qtl-ui',
+  preset: '../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {},
+  coverageDirectory: '../../../coverage/libs/qtl/ui',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$))'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/qtl/ui/project.json
+++ b/libs/qtl/ui/project.json
@@ -1,0 +1,27 @@
+{
+  "name": "qtl-ui",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/qtl/ui/src",
+  "prefix": "qtl",
+  "tags": ["type:feature", "scope:qtl", "language:typescript"],
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/libs/qtl/ui"],
+      "options": {
+        "jestConfig": "libs/qtl/ui/jest.config.ts",
+        "tsConfig": "libs/qtl/ui/tsconfig.spec.json"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    },
+    "lint-fix": {
+      "executor": "@nx/eslint:lint",
+      "options": {
+        "fix": true
+      }
+    }
+  }
+}

--- a/libs/qtl/ui/src/index.ts
+++ b/libs/qtl/ui/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/metadata-chiclet/metadata-chiclet.component';

--- a/libs/qtl/ui/src/lib/metadata-chiclet/metadata-chiclet.component.html
+++ b/libs/qtl/ui/src/lib/metadata-chiclet/metadata-chiclet.component.html
@@ -1,0 +1,9 @@
+<explorers-chiclet
+  [backgroundColor]="backgroundColor()"
+  textColor="var(--color-gray-900)"
+  fontSize="14px"
+  borderRadius="3px"
+  padding="6px"
+>
+  <b>{{ label() }}:</b>&nbsp;{{ value() }}
+</explorers-chiclet>

--- a/libs/qtl/ui/src/lib/metadata-chiclet/metadata-chiclet.component.spec.ts
+++ b/libs/qtl/ui/src/lib/metadata-chiclet/metadata-chiclet.component.spec.ts
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/angular';
+import { MetadataChicletComponent } from './metadata-chiclet.component';
+
+async function setup({
+  backgroundColor = 'var(--color-gray-300)',
+  label = 'variant',
+  value = 'rs29475839',
+} = {}) {
+  return render(MetadataChicletComponent, {
+    componentInputs: { backgroundColor, label, value },
+  });
+}
+
+describe('MetadataChicletComponent', () => {
+  it('renders the label with a trailing colon', async () => {
+    await setup({ label: 'gene' });
+    expect(screen.getByText('gene:')).toBeInTheDocument();
+  });
+
+  it('renders the value', async () => {
+    await setup({ value: 'PAK1' });
+    expect(screen.getByText(/PAK1/)).toBeInTheDocument();
+  });
+});

--- a/libs/qtl/ui/src/lib/metadata-chiclet/metadata-chiclet.component.ts
+++ b/libs/qtl/ui/src/lib/metadata-chiclet/metadata-chiclet.component.ts
@@ -1,0 +1,14 @@
+import { Component, input } from '@angular/core';
+import { ChicletComponent } from '@sagebionetworks/explorers/ui';
+
+@Component({
+  selector: 'qtl-metadata-chiclet',
+  imports: [ChicletComponent],
+  templateUrl: './metadata-chiclet.component.html',
+  styleUrls: ['./metadata-chiclet.component.scss'],
+})
+export class MetadataChicletComponent {
+  backgroundColor = input.required<string>();
+  label = input.required<string>();
+  value = input.required<string>();
+}

--- a/libs/qtl/ui/src/test-setup.ts
+++ b/libs/qtl/ui/src/test-setup.ts
@@ -1,0 +1,78 @@
+import '@testing-library/jest-dom';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();
+
+const originalClientHeightDescriptor = Object.getOwnPropertyDescriptor(
+  window.HTMLElement.prototype,
+  'clientHeight',
+);
+const originalClientWidthDescriptor = Object.getOwnPropertyDescriptor(
+  window.HTMLElement.prototype,
+  'clientWidth',
+);
+
+const observeMock = jest.fn();
+const unobserveMock = jest.fn();
+const disconnectMock = jest.fn();
+const originalResizeObserver = global.ResizeObserver;
+
+const originalGetBBoxDescriptor = Object.getOwnPropertyDescriptor(
+  global.SVGElement.prototype,
+  'getBBox',
+);
+
+beforeEach(() => {
+  /**
+   * Mock clientHeight and clientWidth -- Apache Echarts expects a non-zero value to be returned, but
+   * jsdom will always return 0. See https://github.com/jsdom/jsdom/issues/2342 and
+   * https://github.com/jsdom/jsdom/issues/2310. */
+  Object.defineProperty(window.HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    value: jest.fn().mockReturnValue(500),
+  });
+  Object.defineProperty(window.HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    value: jest.fn().mockReturnValue(100),
+  });
+
+  global.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: observeMock,
+    unobserve: unobserveMock,
+    disconnect: disconnectMock,
+  }));
+
+  Object.defineProperty(global.SVGElement.prototype, 'getBBox', {
+    writable: true,
+    value: jest.fn().mockReturnValue({
+      x: 0,
+      y: 0,
+    }),
+  });
+});
+
+afterEach(() => {
+  if (originalClientHeightDescriptor) {
+    Object.defineProperty(
+      window.HTMLElement.prototype,
+      'clientHeight',
+      originalClientHeightDescriptor,
+    );
+  }
+
+  if (originalClientWidthDescriptor) {
+    Object.defineProperty(
+      window.HTMLElement.prototype,
+      'clientWidth',
+      originalClientWidthDescriptor,
+    );
+  }
+
+  global.ResizeObserver = originalResizeObserver;
+  observeMock.mockClear();
+  unobserveMock.mockClear();
+  disconnectMock.mockClear();
+
+  if (originalGetBBoxDescriptor) {
+    Object.defineProperty(global.SVGElement.prototype, 'getBBox', originalGetBBoxDescriptor);
+  }
+});

--- a/libs/qtl/ui/tsconfig.json
+++ b/libs/qtl/ui/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "target": "es2024",
+    "esModuleInterop": true
+  },
+  "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/qtl/ui/tsconfig.lib.json
+++ b/libs/qtl/ui/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/qtl/ui/tsconfig.spec.json
+++ b/libs/qtl/ui/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2024",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts", "jest.config.ts"]
+}

--- a/libs/qtl/util/src/index.ts
+++ b/libs/qtl/util/src/index.ts
@@ -1,1 +1,2 @@
+export * from './lib/cell-classes';
 export * from './lib/navigation-links';

--- a/libs/qtl/util/src/lib/cell-classes.spec.ts
+++ b/libs/qtl/util/src/lib/cell-classes.spec.ts
@@ -1,0 +1,18 @@
+import { CELL_CLASSES } from '@sagebionetworks/qtl/config';
+import { getCellTypeMutedColor } from './cell-classes';
+
+describe('getCellTypeMutedColor', () => {
+  it('returns the cell type muted color when defined', () => {
+    expect(getCellTypeMutedColor('Astrocyte')).toBe(CELL_CLASSES.Astrocyte.mutedColor);
+  });
+
+  it('falls back to the gray CSS variable when mutedColor is undefined', () => {
+    const original = CELL_CLASSES['Immune Cell'].mutedColor;
+    (CELL_CLASSES['Immune Cell'] as { mutedColor?: string }).mutedColor = undefined;
+    try {
+      expect(getCellTypeMutedColor('Immune Cell')).toBe('var(--color-gray-300)');
+    } finally {
+      (CELL_CLASSES['Immune Cell'] as { mutedColor?: string }).mutedColor = original;
+    }
+  });
+});

--- a/libs/qtl/util/src/lib/cell-classes.ts
+++ b/libs/qtl/util/src/lib/cell-classes.ts
@@ -1,0 +1,5 @@
+import { CELL_CLASSES } from '@sagebionetworks/qtl/config';
+
+export function getCellTypeMutedColor(cellType: keyof typeof CELL_CLASSES): string {
+  return CELL_CLASSES[cellType].mutedColor ?? 'var(--color-gray-300)';
+}

--- a/libs/qtl/util/src/lib/navigation-links.ts
+++ b/libs/qtl/util/src/lib/navigation-links.ts
@@ -7,6 +7,10 @@ export const headerLinks: NavigationLink[] = [
     routerLink: [ROUTE_PATHS.HOME],
     activeOptions: { exact: true },
   },
+  {
+    label: 'eQTL Explorer',
+    routerLink: [ROUTE_PATHS.EQTL],
+  },
 ];
 
 export const footerLinks: NavigationLink[] = [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -93,6 +93,7 @@
       "@sagebionetworks/qtl/home": ["libs/qtl/home/src/index.ts"],
       "@sagebionetworks/qtl/storybook": ["libs/qtl/storybook/src/index.ts"],
       "@sagebionetworks/qtl/themes": ["libs/qtl/themes/src/index.ts"],
+      "@sagebionetworks/qtl/ui": ["libs/qtl/ui/src/index.ts"],
       "@sagebionetworks/qtl/util": ["libs/qtl/util/src/index.ts"],
       "@sagebionetworks/results-visualization-framework/ui": [
         "libs/results-visualization-framework/ui/src/index.ts"


### PR DESCRIPTION
## Description

Introduces the sidebar panel for the eQTL comparison tool, which surfaces the active variant / gene / cell-type context alongside three placeholder tabs (Impact, Traits, Resources) that will be filled in by follow-up tickets. The eQTL route is now reachable from the header so the panel can be exercised end-to-end. Along the way, this adds a new `@sagebionetworks/qtl/ui` library with the reusable `MetadataChicletComponent`, expands cell-class metadata with muted colors, and exposes a `getCellTypeMutedColor` helper so the sidebar (and future visualizations) can theme by cell type.

## Related Issue

- [QTL-35](https://sagebionetworks.jira.com/browse/QTL-35)

## Changelog

- Add `EqtlComparisonToolComponent` sidebar with variant/gene/cell-type chiclets and tablist (Impact, Traits, Resources)
- Add `qtl/ui` library with the reusable `MetadataChicletComponent`
- Add `getCellTypeMutedColor` helper and `mutedColor` field on `CELL_CLASSES`
- Refactor `CELL_CLASSES_FULL` into `CELL_SUBCLASSES` with an explicit `cellClass` link to its parent class to align with design
- Register the eQTL route (`comparison/eqtl`) and add an "eQTL Explorer" header link
- Add `accent-lavender-600`, `variant-muted`, and `gene-muted` CSS variables and reuse the lavender token for the header link color

## Testing

- Start the qtl stack and dev server (`qtl-build-images && qtl-docker-start`), then navigate to `/comparison/eqtl` (or click the "eQTL Explorer" header link) and confirm the comparison tool renders with the sidebar visible
- Confirm the three chiclets show `variant: rs29475839`, `gene: PAK1`, and `cell type: Astrocyte`, with the cell-type chiclet using the Astrocyte muted color
- Click each of the Impact, Traits, and Resources tabs and confirm the active tab gets the lavender underline and the panel body switches to the matching placeholder text (referencing QTL-37, QTL-43, QTL-44)
- Confirm only one tab is marked `aria-selected="true"` at a time and that the active tabpanel's `aria-labelledby` points at the active tab's id (keyboard / screen-reader sanity check)
- Confirm the header "eQTL Explorer" link uses the new lavender accent color and that no other qtl page styling regressed

### Preview

<img width="4064" height="2334" alt="QTL-35" src="https://github.com/user-attachments/assets/67bf3a1f-9b9d-4c79-9524-f6068e40eedc" />

[QTL-35]: https://sagebionetworks.jira.com/browse/QTL-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ