### PR TITLE
fix(agora): update header copy (AG-2057)

### DIFF
--- a/libs/agora/genes/src/lib/components/gene-nominations/gene-nominations.component.html
+++ b/libs/agora/genes/src/lib/components/gene-nominations/gene-nominations.component.html
@@ -59,7 +59,7 @@
             </div>
             <div class="mb-xl">
               @if (nomination.validation_study_details) {
-                <h3>Planned Experimental Validation</h3>
+                <h3>Planned experimental validation</h3>
                 <p class="mb-xl validation-study-details">
                   {{ nomination.validation_study_details }}
                 </p>
@@ -67,11 +67,11 @@
               @if (nomination.data_synapseid) {
                 <a
                   class="link"
-                href="https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage?Study={{
-                  nomination.data_synapseid
-                }}"
+                  href="https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage?Study={{
+                    nomination.data_synapseid
+                  }}"
                   target="_blank"
-                  >
+                >
                   Learn more about the target nomination process
                 </a>
               }


### PR DESCRIPTION
## Description

The "Planned Experimental Validation" header on the Nominations tab of gene details pages was title-cased, while every other header on those pages uses sentence case (e.g., "Initial date of nomination").

## Related Issue

- [AG-2057](https://sagebionetworks.jira.com/browse/AG-2057) — Update Gene Details header text casing for consistency

## Changelog

- Update "Planned Experimental Validation" header to sentence case on the gene details Nominations tab


## Testing

- Open the Agora app and navigate to the 'PLEC' details page and click on the Nominations tab - look for the updated header copy

| Before                   | After                   |
| ------------------------ | ----------------------- |
| <img width="694" height="194" alt="image" src="https://github.com/user-attachments/assets/60320284-d2c7-46a1-9938-587d13191244" /> | <img width="692" height="222" alt="image" src="https://github.com/user-attachments/assets/04797ded-3cc4-41fe-b1a4-51a86847bb92" /> |


[AG-2057]: https://sagebionetworks.jira.com/browse/AG-2057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ