### PR TITLE
feat(agora): redirect requests to the old nominated targets route to the new one (AG-2036)

### DIFF
--- a/apps/agora/app/e2e/nominated-targets.spec.ts
+++ b/apps/agora/app/e2e/nominated-targets.spec.ts
@@ -43,6 +43,11 @@ test.describe('legacy url redirects', () => {
     await page.goto('/genes/(genes-router:genes-list)');
     await expect(page).toHaveURL(`${baseURL}/comparison/targets`);
   });
+
+  test('redirects /genes/nominated-targets to /comparison/targets', async ({ page }) => {
+    await page.goto('/genes/nominated-targets');
+    await expect(page).toHaveURL(`${baseURL}/comparison/targets`);
+  });
 });
 
 test.describe('nominated targets - comparison tool', () => {

--- a/apps/agora/app/src/app/app.routes.ts
+++ b/apps/agora/app/src/app/app.routes.ts
@@ -105,6 +105,11 @@ export const routes: Route[] = [
     },
   },
   {
+    path: 'genes/nominated-targets',
+    redirectTo: ROUTE_PATHS.NOMINATED_TARGETS,
+    pathMatch: 'full',
+  },
+  {
     path: 'genes/genes-router:genes-list',
     redirectTo: ROUTE_PATHS.NOMINATED_TARGETS,
     pathMatch: 'full',


### PR DESCRIPTION
## Description

The Nominated Targets page moved from `/genes/nominated-targets` to `/comparison/targets`, but existing external links and user bookmarks still point at the old URL and currently fall through to the wildcard route, landing on the Not Found page. This PR adds a client-side redirect so legacy URLs continue to work, preserving inbound traffic to the comparison tool.

## Related Issue

- [AG-2036](https://sagebionetworks.jira.com/browse/AG-2036)

## Changelog

- Redirect `/genes/nominated-targets` to `/comparison/targets` in the Agora app router

## Testing

- Visit `/genes/nominated-targets` in the running Agora app and confirm the browser is redirected to `/comparison/targets` and the Nominated Targets comparison tool loads
- Visit `/comparison/targets` directly and confirm the page still loads as before (no regression)
- Visit an unrelated unknown path such as `/genes/foo-bar` and confirm it still falls through to the Not Found page (the new redirect isn't over-matching)

## Preview 

https://github.com/user-attachments/assets/8308e2d8-2182-4e2d-ae6b-b00b313ef917

[AG-2036]: https://sagebionetworks.jira.com/browse/AG-2036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ