### PR TITLE
feat(explorers): constrain Caffeine cache size with maximumSize (MG-915)

### DIFF
--- a/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/configuration/CacheConfiguration.java
+++ b/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/configuration/CacheConfiguration.java
@@ -26,7 +26,7 @@ public class CacheConfiguration {
 
     // Configure cache
     // Enable cache statistics for monitoring
-    cacheManager.setCaffeine(Caffeine.newBuilder().recordStats());
+    cacheManager.setCaffeine(Caffeine.newBuilder().maximumSize(10_000).recordStats());
 
     // Define the cache names used by query services
     cacheManager.setCacheNames(

--- a/apps/agora/api-next/src/main/resources/application.yml
+++ b/apps/agora/api-next/src/main/resources/application.yml
@@ -22,7 +22,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health, metrics
   endpoint:
     health:
       probes:

--- a/apps/agora/api-next/src/test/java/org/sagebionetworks/agora/api/next/configuration/CacheConfigurationTest.java
+++ b/apps/agora/api-next/src/test/java/org/sagebionetworks/agora/api/next/configuration/CacheConfigurationTest.java
@@ -1,0 +1,37 @@
+package org.sagebionetworks.agora.api.next.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+
+class CacheConfigurationTest {
+
+  private static final long EXPECTED_MAXIMUM_SIZE = 10_000L;
+
+  @Test
+  @DisplayName("should configure maximumSize for every registered cache")
+  void shouldConfigureMaximumSizeForEveryRegisteredCache() {
+    CacheManager cacheManager = new CacheConfiguration().cacheManager();
+
+    for (String name : new String[] {
+      CacheNames.DATA_VERSION,
+      CacheNames.COMPARISON_TOOL_CONFIG,
+      CacheNames.DRUG,
+      CacheNames.NOMINATED_DRUG,
+      CacheNames.NOMINATED_TARGET,
+    }) {
+      CaffeineCache springCache = (CaffeineCache) cacheManager.getCache(name);
+      assertThat(springCache).as("cache '%s' should be registered", name).isNotNull();
+
+      Cache<Object, Object> nativeCache = springCache.getNativeCache();
+      long maximum = nativeCache.policy().eviction().orElseThrow().getMaximum();
+      assertThat(maximum)
+        .as("cache '%s' maximumSize", name)
+        .isEqualTo(EXPECTED_MAXIMUM_SIZE);
+    }
+  }
+}

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/configuration/CacheConfiguration.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/configuration/CacheConfiguration.java
@@ -26,7 +26,7 @@ public class CacheConfiguration {
 
     // Configure cache
     // Enable cache statistics for monitoring
-    cacheManager.setCaffeine(Caffeine.newBuilder().recordStats());
+    cacheManager.setCaffeine(Caffeine.newBuilder().maximumSize(10_000).recordStats());
 
     // Define the cache names used by query services
     cacheManager.setCacheNames(

--- a/apps/model-ad/api-next/src/main/resources/application.yml
+++ b/apps/model-ad/api-next/src/main/resources/application.yml
@@ -22,7 +22,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health, metrics
   endpoint:
     health:
       probes:

--- a/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/configuration/CacheConfigurationTest.java
+++ b/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/configuration/CacheConfigurationTest.java
@@ -1,0 +1,39 @@
+package org.sagebionetworks.model.ad.api.next.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+
+class CacheConfigurationTest {
+
+  private static final long EXPECTED_MAXIMUM_SIZE = 10_000L;
+
+  @Test
+  @DisplayName("should configure maximumSize for every registered cache")
+  void shouldConfigureMaximumSizeForEveryRegisteredCache() {
+    CacheManager cacheManager = new CacheConfiguration().cacheManager();
+
+    for (String name : new String[] {
+      CacheNames.DISEASE_CORRELATION,
+      CacheNames.MODEL_OVERVIEW,
+      CacheNames.TRANSCRIPTOMICS,
+      CacheNames.TRANSCRIPTOMICS_INDIVIDUAL,
+      CacheNames.MODEL,
+      CacheNames.DATA_VERSION,
+      CacheNames.COMPARISON_TOOL_CONFIG,
+    }) {
+      CaffeineCache springCache = (CaffeineCache) cacheManager.getCache(name);
+      assertThat(springCache).as("cache '%s' should be registered", name).isNotNull();
+
+      Cache<Object, Object> nativeCache = springCache.getNativeCache();
+      long maximum = nativeCache.policy().eviction().orElseThrow().getMaximum();
+      assertThat(maximum)
+        .as("cache '%s' maximumSize", name)
+        .isEqualTo(EXPECTED_MAXIMUM_SIZE);
+    }
+  }
+}


### PR DESCRIPTION
## Description

The Caffeine cache in `model-ad-api-next` and `agora-api-next` previously had no size limit, so the dynamic-keyed caches could grow unbounded between deploys and eventually exhaust server memory. This PR adds a defensive [caffeine's eviction method](https://github.com/ben-manes/caffeine/wiki/Eviction) `maximumSize(10_000)` (entries) ceiling per cache based on the local stress testing (see [comment](https://sagebionetworks.jira.com/browse/MG-915?focusedCommentId=326755)). When hitting the max size cap, "the cache will try to evict entries that have not been used [recently or very often](https://github.com/ben-manes/caffeine/wiki/Efficiency)". This PR also exposes `/actuator/metrics` so we could rely on real prod cache stats instead of one-off investigations. 

> [!NOTE]
> This PR only prevents the cache from growing too large. **Invalidating cached entries on a desired frequency (so the API serves fresh data without a manual restart)** is addressed in a separate PR for [MG-873](https://sagebionetworks.jira.com/browse/MG-873).

## Related Issue

- [MG-915](https://sagebionetworks.jira.com/browse/MG-915)

## Changelog

- Add `maximumSize(10_000)` to the Caffeine builder in `model-ad-api-next` and `agora-api-next` `CacheConfiguration`
- Add `CacheConfigurationTest` for both services asserting the configured maximum via Caffeine's policy API
- Expose `/actuator/metrics` endpoint on both services so cache stats (`cache.size`, `cache.gets`, `cache.evictions`) are queryable in stage/prod

## Testing

1. Start the full stacks

```
agora-build-images && agora-docker-stop
```

2. Play around app at http://localhost:8000 to populate caches

3. Get available caches metrics

```
for c in $(curl -s http://localhost:3334/actuator/metrics/cache.size \
  | jq -r '.availableTags[] | select(.tag=="name") | .values[]'); do
  echo "=== $c ==="
  for m in cache.size cache.gets cache.evictions cache.puts; do
    curl -s "http://localhost:3334/actuator/metrics/$m?tag=cache:$c" \
      | jq -c '{name, value: .measurements[0].value}'
  done
done
 ```
```json
=== nominatedTarget ===
{"name":"cache.size","value":2.0}
{"name":"cache.gets","value":4.0}
{"name":"cache.evictions","value":0.0}
{"name":"cache.puts","value":0.0}
=== comparisonToolConfig ===
{"name":"cache.size","value":2.0}
{"name":"cache.gets","value":2.0}
{"name":"cache.evictions","value":0.0}
{"name":"cache.puts","value":0.0}
=== nominatedDrug ===
{"name":"cache.size","value":2.0}
{"name":"cache.gets","value":2.0}
{"name":"cache.evictions","value":0.0}
{"name":"cache.puts","value":0.0}
=== dataVersion ===
{"name":"cache.size","value":1.0}
{"name":"cache.gets","value":2.0}
{"name":"cache.evictions","value":0.0}
{"name":"cache.puts","value":0.0}
=== drug ===
{"name":"cache.size","value":0.0}
{"name":"cache.gets","value":0.0}
{"name":"cache.evictions","value":0.0}
{"name":"cache.puts","value":0.0}
```


[MG-915]: https://sagebionetworks.jira.com/browse/MG-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MG-873]: https://sagebionetworks.jira.com/browse/MG-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ