### PR TITLE
refactor(explorers): centralize ct filter logic in explorers base class (AG-2108)

### DIFF
--- a/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/model/dto/NominatedDrugIdentifier.java
+++ b/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/model/dto/NominatedDrugIdentifier.java
@@ -79,4 +79,18 @@ public class NominatedDrugIdentifier {
   public String toCompositeId() {
     return chemblId + DELIMITER + (combinedWith != null ? combinedWith : "null");
   }
+
+  /**
+   * Converts this identifier to a MongoDB {@link org.springframework.data.mongodb.core.query.Criteria}
+   * that matches documents with this exact chembl_id and combined_with.
+   *
+   * @return a Criteria requiring both fields to match
+   */
+  public org.springframework.data.mongodb.core.query.Criteria toCriteria() {
+    return new org.springframework.data.mongodb.core.query.Criteria()
+      .andOperator(
+        org.springframework.data.mongodb.core.query.Criteria.where("chembl_id").is(chemblId),
+        org.springframework.data.mongodb.core.query.Criteria.where("combined_with").is(combinedWith)
+      );
+  }
 }

--- a/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/model/dto/NominatedDrugIdentifier.java
+++ b/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/model/dto/NominatedDrugIdentifier.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.agora.api.next.model.dto;
 import lombok.Builder;
 import lombok.Value;
 import org.sagebionetworks.agora.api.next.exception.InvalidFilterException;
+import org.springframework.data.mongodb.core.query.Criteria;
 
 /**
  * Represents a composite identifier for nominated drug documents.
@@ -81,16 +82,16 @@ public class NominatedDrugIdentifier {
   }
 
   /**
-   * Converts this identifier to a MongoDB {@link org.springframework.data.mongodb.core.query.Criteria}
+   * Converts this identifier to a MongoDB {@link Criteria}
    * that matches documents with this exact chembl_id and combined_with.
    *
    * @return a Criteria requiring both fields to match
    */
-  public org.springframework.data.mongodb.core.query.Criteria toCriteria() {
-    return new org.springframework.data.mongodb.core.query.Criteria()
+  public Criteria toCriteria() {
+    return new Criteria()
       .andOperator(
-        org.springframework.data.mongodb.core.query.Criteria.where("chembl_id").is(chemblId),
-        org.springframework.data.mongodb.core.query.Criteria.where("combined_with").is(combinedWith)
+        Criteria.where("chembl_id").is(chemblId),
+        Criteria.where("combined_with").is(combinedWith)
       );
   }
 }

--- a/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/model/repository/CustomNominatedDrugRepositoryImpl.java
+++ b/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/model/repository/CustomNominatedDrugRepositoryImpl.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.agora.api.next.model.repository;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.sagebionetworks.agora.api.next.model.document.NominatedDrugDocument;
 import org.sagebionetworks.agora.api.next.model.dto.ItemFilterTypeQueryDto;
@@ -61,9 +62,8 @@ public class CustomNominatedDrugRepositoryImpl
     );
   }
 
-  @Override
-  protected CtFilterConfig<NominatedDrugSearchQueryDto> getFilterConfig() {
-    return CtFilterConfig.<NominatedDrugSearchQueryDto>builder()
+  private final CtFilterConfig<NominatedDrugSearchQueryDto> filterConfig =
+    CtFilterConfig.<NominatedDrugSearchQueryDto>builder()
       .dataFilter("principal_investigators", NominatedDrugSearchQueryDto::getPrincipalInvestigators)
       .dataFilter("programs", NominatedDrugSearchQueryDto::getPrograms)
       .dataFilter("total_nominations", NominatedDrugSearchQueryDto::getTotalNominations)
@@ -72,6 +72,10 @@ public class CustomNominatedDrugRepositoryImpl
       .compositeItemFilter(item -> NominatedDrugIdentifier.parse(item).toCriteria())
       .searchFilter(SEARCH_FIELD)
       .build();
+
+  @Override
+  protected CtFilterConfig<NominatedDrugSearchQueryDto> getFilterConfig() {
+    return filterConfig;
   }
 
   @Override
@@ -80,7 +84,11 @@ public class CustomNominatedDrugRepositoryImpl
     NominatedDrugSearchQueryDto query,
     List<String> items
   ) {
-    boolean isInclude = query.getItemFilterType() == ItemFilterTypeQueryDto.INCLUDE;
+    ItemFilterTypeQueryDto filterType = Objects.requireNonNullElse(
+      query.getItemFilterType(),
+      ItemFilterTypeQueryDto.INCLUDE
+    );
+    boolean isInclude = filterType == ItemFilterTypeQueryDto.INCLUDE;
     Criteria matchCriteria = buildCtMatchCriteria(
       query,
       items,

--- a/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/model/repository/CustomNominatedDrugRepositoryImpl.java
+++ b/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/model/repository/CustomNominatedDrugRepositoryImpl.java
@@ -1,17 +1,15 @@
 package org.sagebionetworks.agora.api.next.model.repository;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.sagebionetworks.agora.api.next.model.document.NominatedDrugDocument;
 import org.sagebionetworks.agora.api.next.model.dto.ItemFilterTypeQueryDto;
 import org.sagebionetworks.agora.api.next.model.dto.NominatedDrugIdentifier;
 import org.sagebionetworks.agora.api.next.model.dto.NominatedDrugSearchQueryDto;
-import org.sagebionetworks.explorers.ApiHelper;
 import org.sagebionetworks.explorers.ComparisonToolRepositorySupport;
+import org.sagebionetworks.explorers.ComputedSortField;
+import org.sagebionetworks.explorers.CtFilterConfig;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -54,11 +52,26 @@ public class CustomNominatedDrugRepositoryImpl
    * alongside other array fields without hitting MongoDB's "parallel arrays" limit.
    */
   @Override
-  protected Map<String, Object> getComputedSortFieldExpressions() {
+  protected Map<String, ComputedSortField> getComputedSortFieldExpressions() {
     return Map.of(
-      "principal_investigators", arrayToLoweredStringExpr("principal_investigators"),
-      "programs", arrayToLoweredStringExpr("programs")
+      "principal_investigators",
+      ComputedSortField.of(arrayToLoweredStringExpr("principal_investigators")),
+      "programs",
+      ComputedSortField.of(arrayToLoweredStringExpr("programs"))
     );
+  }
+
+  @Override
+  protected CtFilterConfig<NominatedDrugSearchQueryDto> getFilterConfig() {
+    return CtFilterConfig.<NominatedDrugSearchQueryDto>builder()
+      .dataFilter("principal_investigators", NominatedDrugSearchQueryDto::getPrincipalInvestigators)
+      .dataFilter("programs", NominatedDrugSearchQueryDto::getPrograms)
+      .dataFilter("total_nominations", NominatedDrugSearchQueryDto::getTotalNominations)
+      .dataFilter("initial_nomination", NominatedDrugSearchQueryDto::getInitialNomination)
+      .dataFilter("modality", NominatedDrugSearchQueryDto::getModality)
+      .compositeItemFilter(item -> NominatedDrugIdentifier.parse(item).toCriteria())
+      .searchFilter(SEARCH_FIELD)
+      .build();
   }
 
   @Override
@@ -67,150 +80,15 @@ public class CustomNominatedDrugRepositoryImpl
     NominatedDrugSearchQueryDto query,
     List<String> items
   ) {
-    ItemFilterTypeQueryDto filterType = Objects.requireNonNullElse(
-      query.getItemFilterType(),
-      ItemFilterTypeQueryDto.INCLUDE
+    boolean isInclude = query.getItemFilterType() == ItemFilterTypeQueryDto.INCLUDE;
+    Criteria matchCriteria = buildCtMatchCriteria(
+      query,
+      items,
+      isInclude,
+      query.getSearch(),
+      getFilterConfig()
     );
-    String search = query.getSearch();
-
-    // Build match criteria with all filters
-    Criteria matchCriteria = buildMatchCriteria(query, items, filterType, search);
 
     return executePagedAggregation(matchCriteria, pageable);
-  }
-
-  /**
-   * Builds match criteria combining all filters.
-   */
-  private Criteria buildMatchCriteria(
-    NominatedDrugSearchQueryDto query,
-    List<String> items,
-    ItemFilterTypeQueryDto filterType,
-    String search
-  ) {
-    List<Criteria> andCriteria = new ArrayList<>();
-
-    // Add data filters (AND between fields, OR within field)
-    addDataFilterCriteria(
-      query.getPrincipalInvestigators(),
-      query.getPrograms(),
-      query.getTotalNominations(),
-      query.getInitialNomination(),
-      query.getModality(),
-      andCriteria
-    );
-
-    // Add composite_id filtering (items + itemFilterType)
-    addItemFilterCriteria(items, filterType, andCriteria);
-
-    // Add search filtering (only when itemFilterType is EXCLUDE)
-    addSearchFilterCriteria(search, filterType, andCriteria);
-
-    if (andCriteria.isEmpty()) {
-      return new Criteria();
-    }
-    return new Criteria().andOperator(andCriteria.toArray(new Criteria[0]));
-  }
-
-  private void addDataFilterCriteria(
-    List<String> principalInvestigators,
-    List<String> programs,
-    List<Integer> totalNominations,
-    List<Integer> initialNomination,
-    List<String> modality,
-    List<Criteria> andCriteria
-  ) {
-    // principal_investigators: array field - use $in (matches if array contains any value)
-    if (principalInvestigators != null && !principalInvestigators.isEmpty()) {
-      andCriteria.add(Criteria.where("principal_investigators").in(principalInvestigators));
-    }
-
-    // programs: array field - use $in (matches if array contains any value)
-    if (programs != null && !programs.isEmpty()) {
-      andCriteria.add(Criteria.where("programs").in(programs));
-    }
-
-    // totalNominations: scalar field - use $in
-    if (totalNominations != null && !totalNominations.isEmpty()) {
-      andCriteria.add(Criteria.where("total_nominations").in(totalNominations));
-    }
-
-    // initialNomination: scalar field - use $in
-    if (initialNomination != null && !initialNomination.isEmpty()) {
-      andCriteria.add(Criteria.where("initial_nomination").in(initialNomination));
-    }
-
-    // modality: scalar field - use $in
-    if (modality != null && !modality.isEmpty()) {
-      andCriteria.add(Criteria.where("modality").in(modality));
-    }
-  }
-
-  private void addItemFilterCriteria(
-    List<String> items,
-    ItemFilterTypeQueryDto filterType,
-    List<Criteria> andCriteria
-  ) {
-    if (items.isEmpty()) {
-      // For INCLUDE mode with empty items, add impossible condition to return empty results
-      if (filterType == ItemFilterTypeQueryDto.INCLUDE) {
-        andCriteria.add(Criteria.where("_id").is(null));
-      }
-      // For EXCLUDE mode with empty items, no filtering needed (return all)
-      return;
-    }
-
-    // Parse composite identifiers (format: chembl_id~combined_with)
-    List<NominatedDrugIdentifier> identifiers = parseIdentifiers(items);
-
-    // Build criteria for each identifier (must match BOTH chembl_id AND combined_with)
-    List<Criteria> compositeConditions = new ArrayList<>();
-    for (NominatedDrugIdentifier id : identifiers) {
-      Criteria idCondition = new Criteria()
-        .andOperator(
-          Criteria.where("chembl_id").is(id.getChemblId()),
-          Criteria.where("combined_with").is(id.getCombinedWith())
-        );
-      compositeConditions.add(idCondition);
-    }
-
-    // Apply INCLUDE or EXCLUDE logic
-    if (filterType == ItemFilterTypeQueryDto.INCLUDE) {
-      // Match ANY of the composite identifiers ($or)
-      andCriteria.add(new Criteria().orOperator(compositeConditions.toArray(new Criteria[0])));
-    } else {
-      // Exclude ALL of the composite identifiers ($nor)
-      andCriteria.add(new Criteria().norOperator(compositeConditions.toArray(new Criteria[0])));
-    }
-  }
-
-  private List<NominatedDrugIdentifier> parseIdentifiers(List<String> items) {
-    List<NominatedDrugIdentifier> identifiers = new ArrayList<>();
-    for (String item : items) {
-      identifiers.add(NominatedDrugIdentifier.parse(item));
-    }
-    return identifiers;
-  }
-
-  private void addSearchFilterCriteria(
-    String search,
-    ItemFilterTypeQueryDto filterType,
-    List<Criteria> andCriteria
-  ) {
-    // Search only applies when itemFilterType is EXCLUDE
-    if (filterType != ItemFilterTypeQueryDto.EXCLUDE || search == null || search.trim().isEmpty()) {
-      return;
-    }
-
-    String trimmedSearch = search.trim();
-    if (trimmedSearch.contains(",")) {
-      // Comma-separated list: case-insensitive full matches
-      List<Pattern> patterns = ApiHelper.createCaseInsensitiveFullMatchPatterns(trimmedSearch);
-      andCriteria.add(Criteria.where(SEARCH_FIELD).in(patterns));
-    } else {
-      // Single term: case-insensitive partial match
-      String quotedSearch = Pattern.quote(trimmedSearch);
-      andCriteria.add(Criteria.where(SEARCH_FIELD).regex(quotedSearch, "i"));
-    }
   }
 }

--- a/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/model/repository/CustomNominatedTargetRepositoryImpl.java
+++ b/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/model/repository/CustomNominatedTargetRepositoryImpl.java
@@ -2,12 +2,13 @@ package org.sagebionetworks.agora.api.next.model.repository;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.sagebionetworks.agora.api.next.model.document.NominatedTargetDocument;
 import org.sagebionetworks.agora.api.next.model.dto.ItemFilterTypeQueryDto;
 import org.sagebionetworks.agora.api.next.model.dto.NominatedTargetSearchQueryDto;
-import org.sagebionetworks.explorers.ComputedSortField;
 import org.sagebionetworks.explorers.ComparisonToolRepositorySupport;
+import org.sagebionetworks.explorers.ComputedSortField;
 import org.sagebionetworks.explorers.CtFilterConfig;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -53,16 +54,19 @@ public class CustomNominatedTargetRepositoryImpl
   @Override
   protected Map<String, ComputedSortField> getComputedSortFieldExpressions() {
     return Map.of(
-      "nominating_teams", ComputedSortField.of(arrayToLoweredStringExpr("nominating_teams")),
-      "cohort_studies", ComputedSortField.of(arrayToLoweredStringExpr("cohort_studies")),
-      "input_data", ComputedSortField.of(arrayToLoweredStringExpr("input_data")),
-      "programs", ComputedSortField.of(arrayToLoweredStringExpr("programs"))
+      "nominating_teams",
+      ComputedSortField.of(arrayToLoweredStringExpr("nominating_teams")),
+      "cohort_studies",
+      ComputedSortField.of(arrayToLoweredStringExpr("cohort_studies")),
+      "input_data",
+      ComputedSortField.of(arrayToLoweredStringExpr("input_data")),
+      "programs",
+      ComputedSortField.of(arrayToLoweredStringExpr("programs"))
     );
   }
 
-  @Override
-  protected CtFilterConfig<NominatedTargetSearchQueryDto> getFilterConfig() {
-    return CtFilterConfig.<NominatedTargetSearchQueryDto>builder()
+  private final CtFilterConfig<NominatedTargetSearchQueryDto> filterConfig =
+    CtFilterConfig.<NominatedTargetSearchQueryDto>builder()
       .dataFilter("cohort_studies", NominatedTargetSearchQueryDto::getCohortStudies)
       .dataFilter("input_data", NominatedTargetSearchQueryDto::getInputData)
       .dataFilter("initial_nomination", NominatedTargetSearchQueryDto::getInitialNomination)
@@ -73,6 +77,10 @@ public class CustomNominatedTargetRepositoryImpl
       .simpleItemFilter(PRIMARY_FIELD)
       .searchFilter(PRIMARY_FIELD)
       .build();
+
+  @Override
+  protected CtFilterConfig<NominatedTargetSearchQueryDto> getFilterConfig() {
+    return filterConfig;
   }
 
   @Override
@@ -81,7 +89,11 @@ public class CustomNominatedTargetRepositoryImpl
     NominatedTargetSearchQueryDto query,
     List<String> items
   ) {
-    boolean isInclude = query.getItemFilterType() == ItemFilterTypeQueryDto.INCLUDE;
+    ItemFilterTypeQueryDto filterType = Objects.requireNonNullElse(
+      query.getItemFilterType(),
+      ItemFilterTypeQueryDto.INCLUDE
+    );
+    boolean isInclude = filterType == ItemFilterTypeQueryDto.INCLUDE;
     Criteria matchCriteria = buildCtMatchCriteria(
       query,
       items,

--- a/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/model/repository/CustomNominatedTargetRepositoryImpl.java
+++ b/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/model/repository/CustomNominatedTargetRepositoryImpl.java
@@ -1,16 +1,14 @@
 package org.sagebionetworks.agora.api.next.model.repository;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.sagebionetworks.agora.api.next.model.document.NominatedTargetDocument;
 import org.sagebionetworks.agora.api.next.model.dto.ItemFilterTypeQueryDto;
 import org.sagebionetworks.agora.api.next.model.dto.NominatedTargetSearchQueryDto;
-import org.sagebionetworks.explorers.ApiHelper;
+import org.sagebionetworks.explorers.ComputedSortField;
 import org.sagebionetworks.explorers.ComparisonToolRepositorySupport;
+import org.sagebionetworks.explorers.CtFilterConfig;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -53,13 +51,28 @@ public class CustomNominatedTargetRepositoryImpl
    * alongside other array fields without hitting MongoDB's "parallel arrays" limit.
    */
   @Override
-  protected Map<String, Object> getComputedSortFieldExpressions() {
+  protected Map<String, ComputedSortField> getComputedSortFieldExpressions() {
     return Map.of(
-      "nominating_teams", arrayToLoweredStringExpr("nominating_teams"),
-      "cohort_studies", arrayToLoweredStringExpr("cohort_studies"),
-      "input_data", arrayToLoweredStringExpr("input_data"),
-      "programs", arrayToLoweredStringExpr("programs")
+      "nominating_teams", ComputedSortField.of(arrayToLoweredStringExpr("nominating_teams")),
+      "cohort_studies", ComputedSortField.of(arrayToLoweredStringExpr("cohort_studies")),
+      "input_data", ComputedSortField.of(arrayToLoweredStringExpr("input_data")),
+      "programs", ComputedSortField.of(arrayToLoweredStringExpr("programs"))
     );
+  }
+
+  @Override
+  protected CtFilterConfig<NominatedTargetSearchQueryDto> getFilterConfig() {
+    return CtFilterConfig.<NominatedTargetSearchQueryDto>builder()
+      .dataFilter("cohort_studies", NominatedTargetSearchQueryDto::getCohortStudies)
+      .dataFilter("input_data", NominatedTargetSearchQueryDto::getInputData)
+      .dataFilter("initial_nomination", NominatedTargetSearchQueryDto::getInitialNomination)
+      .dataFilter("nominating_teams", NominatedTargetSearchQueryDto::getNominatingTeams)
+      .dataFilter("pharos_class", NominatedTargetSearchQueryDto::getPharosClass)
+      .dataFilter("programs", NominatedTargetSearchQueryDto::getPrograms)
+      .dataFilter("total_nominations", NominatedTargetSearchQueryDto::getTotalNominations)
+      .simpleItemFilter(PRIMARY_FIELD)
+      .searchFilter(PRIMARY_FIELD)
+      .build();
   }
 
   @Override
@@ -68,139 +81,15 @@ public class CustomNominatedTargetRepositoryImpl
     NominatedTargetSearchQueryDto query,
     List<String> items
   ) {
-    ItemFilterTypeQueryDto filterType = Objects.requireNonNullElse(
-      query.getItemFilterType(),
-      ItemFilterTypeQueryDto.INCLUDE
+    boolean isInclude = query.getItemFilterType() == ItemFilterTypeQueryDto.INCLUDE;
+    Criteria matchCriteria = buildCtMatchCriteria(
+      query,
+      items,
+      isInclude,
+      query.getSearch(),
+      getFilterConfig()
     );
-    String search = query.getSearch();
-
-    // Build match criteria with all filters
-    Criteria matchCriteria = buildMatchCriteria(query, items, filterType, search);
 
     return executePagedAggregation(matchCriteria, pageable);
-  }
-
-  /**
-   * Builds match criteria combining all filters.
-   */
-  private Criteria buildMatchCriteria(
-    NominatedTargetSearchQueryDto query,
-    List<String> items,
-    ItemFilterTypeQueryDto filterType,
-    String search
-  ) {
-    List<Criteria> andCriteria = new ArrayList<>();
-
-    // Add data filters (AND between fields, OR within field)
-    addDataFilterCriteria(
-      query.getCohortStudies(),
-      query.getInputData(),
-      query.getInitialNomination(),
-      query.getNominatingTeams(),
-      query.getPharosClass(),
-      query.getPrograms(),
-      query.getTotalNominations(),
-      andCriteria
-    );
-
-    // Add hgnc_symbol filtering (items + itemFilterType)
-    addHgncSymbolFilterCriteria(items, filterType, andCriteria);
-
-    // Add search filtering (only when itemFilterType is EXCLUDE)
-    addSearchFilterCriteria(search, filterType, andCriteria);
-
-    if (andCriteria.isEmpty()) {
-      return new Criteria();
-    }
-    return new Criteria().andOperator(andCriteria.toArray(new Criteria[0]));
-  }
-
-  private void addDataFilterCriteria(
-    List<String> cohortStudies,
-    List<String> inputData,
-    List<Integer> initialNomination,
-    List<String> nominatingTeams,
-    List<String> pharosClass,
-    List<String> programs,
-    List<Integer> totalNominations,
-    List<Criteria> andCriteria
-  ) {
-    // cohort_studies: array field - use $in (matches if array contains any value)
-    if (cohortStudies != null && !cohortStudies.isEmpty()) {
-      andCriteria.add(Criteria.where("cohort_studies").in(cohortStudies));
-    }
-
-    // input_data: array field - use $in (matches if array contains any value)
-    if (inputData != null && !inputData.isEmpty()) {
-      andCriteria.add(Criteria.where("input_data").in(inputData));
-    }
-
-    // initialNomination: array field - use $in (matches if array contains any value)
-    if (initialNomination != null && !initialNomination.isEmpty()) {
-      andCriteria.add(Criteria.where("initial_nomination").in(initialNomination));
-    }
-
-    // nominatingTeams: array field - use $in (matches if array contains any value)
-    if (nominatingTeams != null && !nominatingTeams.isEmpty()) {
-      andCriteria.add(Criteria.where("nominating_teams").in(nominatingTeams));
-    }
-
-    // pharosClass: array field - use $in (matches if array contains any value)
-    if (pharosClass != null && !pharosClass.isEmpty()) {
-      andCriteria.add(Criteria.where("pharos_class").in(pharosClass));
-    }
-
-    // programs: array field - use $in (matches if array contains any value)
-    if (programs != null && !programs.isEmpty()) {
-      andCriteria.add(Criteria.where("programs").in(programs));
-    }
-
-    // totalNominations: array field - use $in (matches if array contains any value)
-    if (totalNominations != null && !totalNominations.isEmpty()) {
-      andCriteria.add(Criteria.where("total_nominations").in(totalNominations));
-    }
-  }
-
-  private void addHgncSymbolFilterCriteria(
-    List<String> items,
-    ItemFilterTypeQueryDto filterType,
-    List<Criteria> andCriteria
-  ) {
-    if (items.isEmpty()) {
-      // For INCLUDE mode with empty items, add impossible condition to return empty results
-      if (filterType == ItemFilterTypeQueryDto.INCLUDE) {
-        andCriteria.add(Criteria.where("_id").is(null));
-      }
-      // For EXCLUDE mode with empty items, no filtering needed (return all)
-      return;
-    }
-
-    if (filterType == ItemFilterTypeQueryDto.INCLUDE) {
-      andCriteria.add(Criteria.where(PRIMARY_FIELD).in(items));
-    } else {
-      andCriteria.add(Criteria.where(PRIMARY_FIELD).nin(items));
-    }
-  }
-
-  private void addSearchFilterCriteria(
-    String search,
-    ItemFilterTypeQueryDto filterType,
-    List<Criteria> andCriteria
-  ) {
-    // Search only applies when itemFilterType is EXCLUDE
-    if (filterType != ItemFilterTypeQueryDto.EXCLUDE || search == null || search.trim().isEmpty()) {
-      return;
-    }
-
-    String trimmedSearch = search.trim();
-    if (trimmedSearch.contains(",")) {
-      // Comma-separated list: case-insensitive full matches
-      List<Pattern> patterns = ApiHelper.createCaseInsensitiveFullMatchPatterns(trimmedSearch);
-      andCriteria.add(Criteria.where(PRIMARY_FIELD).in(patterns));
-    } else {
-      // Single term: case-insensitive partial match
-      String quotedSearch = Pattern.quote(trimmedSearch);
-      andCriteria.add(Criteria.where(PRIMARY_FIELD).regex(quotedSearch, "i"));
-    }
   }
 }

--- a/apps/agora/api-next/src/test/java/org/sagebionetworks/agora/api/next/model/dto/NominatedDrugIdentifierTest.java
+++ b/apps/agora/api-next/src/test/java/org/sagebionetworks/agora/api/next/model/dto/NominatedDrugIdentifierTest.java
@@ -106,4 +106,36 @@ class NominatedDrugIdentifierTest {
 
     assertThat(result).isEqualTo(original);
   }
+
+  @Test
+  @DisplayName("should build correct criteria from identifier")
+  void shouldBuildCorrectCriteriaFromIdentifier() {
+    NominatedDrugIdentifier identifier = NominatedDrugIdentifier.builder()
+      .chemblId("CHEMBL2105758")
+      .combinedWith("Donepezil")
+      .build();
+
+    org.springframework.data.mongodb.core.query.Criteria result = identifier.toCriteria();
+
+    String criteriaStr = result.getCriteriaObject().toString();
+    assertThat(criteriaStr).contains("chembl_id").contains("CHEMBL2105758");
+    assertThat(criteriaStr).contains("combined_with").contains("Donepezil");
+    assertThat(criteriaStr).contains("$and");
+  }
+
+  @Test
+  @DisplayName("should build correct criteria from identifier with null combined_with")
+  void shouldBuildCorrectCriteriaFromIdentifierWithNullCombinedWith() {
+    NominatedDrugIdentifier identifier = NominatedDrugIdentifier.builder()
+      .chemblId("CHEMBL2105758")
+      .combinedWith(null)
+      .build();
+
+    org.springframework.data.mongodb.core.query.Criteria result = identifier.toCriteria();
+
+    String criteriaStr = result.getCriteriaObject().toString();
+    assertThat(criteriaStr).contains("chembl_id").contains("CHEMBL2105758");
+    assertThat(criteriaStr).contains("combined_with");
+    assertThat(criteriaStr).contains("$and");
+  }
 }

--- a/apps/agora/api-next/src/test/java/org/sagebionetworks/agora/api/next/model/dto/NominatedDrugIdentifierTest.java
+++ b/apps/agora/api-next/src/test/java/org/sagebionetworks/agora/api/next/model/dto/NominatedDrugIdentifierTest.java
@@ -3,9 +3,12 @@ package org.sagebionetworks.agora.api.next.model.dto;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
+import org.bson.Document;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.sagebionetworks.agora.api.next.exception.InvalidFilterException;
+import org.springframework.data.mongodb.core.query.Criteria;
 
 class NominatedDrugIdentifierTest {
 
@@ -115,12 +118,12 @@ class NominatedDrugIdentifierTest {
       .combinedWith("Donepezil")
       .build();
 
-    org.springframework.data.mongodb.core.query.Criteria result = identifier.toCriteria();
+    Criteria result = identifier.toCriteria();
 
-    String criteriaStr = result.getCriteriaObject().toString();
-    assertThat(criteriaStr).contains("chembl_id").contains("CHEMBL2105758");
-    assertThat(criteriaStr).contains("combined_with").contains("Donepezil");
-    assertThat(criteriaStr).contains("$and");
+    List<Document> andClauses = result.getCriteriaObject().getList("$and", Document.class);
+    assertThat(andClauses).hasSize(2);
+    assertThat(andClauses.get(0)).isEqualTo(new Document("chembl_id", "CHEMBL2105758"));
+    assertThat(andClauses.get(1)).isEqualTo(new Document("combined_with", "Donepezil"));
   }
 
   @Test
@@ -131,11 +134,11 @@ class NominatedDrugIdentifierTest {
       .combinedWith(null)
       .build();
 
-    org.springframework.data.mongodb.core.query.Criteria result = identifier.toCriteria();
+    Criteria result = identifier.toCriteria();
 
-    String criteriaStr = result.getCriteriaObject().toString();
-    assertThat(criteriaStr).contains("chembl_id").contains("CHEMBL2105758");
-    assertThat(criteriaStr).contains("combined_with");
-    assertThat(criteriaStr).contains("$and");
+    List<Document> andClauses = result.getCriteriaObject().getList("$and", Document.class);
+    assertThat(andClauses).hasSize(2);
+    assertThat(andClauses.get(0)).isEqualTo(new Document("chembl_id", "CHEMBL2105758"));
+    assertThat(andClauses.get(1)).isEqualTo(new Document("combined_with", null));
   }
 }

--- a/apps/agora/api-next/src/test/java/org/sagebionetworks/agora/api/next/model/repository/CustomNominatedDrugRepositoryImplTest.java
+++ b/apps/agora/api-next/src/test/java/org/sagebionetworks/agora/api/next/model/repository/CustomNominatedDrugRepositoryImplTest.java
@@ -45,6 +45,58 @@ class CustomNominatedDrugRepositoryImplTest {
     repository = new CustomNominatedDrugRepositoryImpl(mongoTemplate);
   }
 
+  private Pageable pageable() {
+    return PageRequest.of(0, 10);
+  }
+
+  @Test
+  @DisplayName("should default null itemFilterType to INCLUDE mode")
+  void shouldDefaultNullItemFilterTypeToInclude() {
+    when(mongoTemplate.count(any(Query.class), eq(COLLECTION_NAME))).thenReturn(0L);
+    when(
+      mongoTemplate.aggregate(
+        any(Aggregation.class),
+        eq(COLLECTION_NAME),
+        eq(NominatedDrugDocument.class)
+      )
+    ).thenReturn(aggregationResults);
+    when(aggregationResults.getMappedResults()).thenReturn(List.of());
+
+    // null itemFilterType with a non-empty items list — should behave as INCLUDE ($in)
+    NominatedDrugSearchQueryDto query = NominatedDrugSearchQueryDto.builder().build();
+
+    repository.findAll(pageable(), query, List.of("CHEMBL2105758~null"));
+
+    ArgumentCaptor<Aggregation> captor = ArgumentCaptor.forClass(Aggregation.class);
+    verify(mongoTemplate).aggregate(captor.capture(), eq(COLLECTION_NAME), eq(NominatedDrugDocument.class));
+
+    assertThat(captor.getValue().toString()).contains("$or").contains("CHEMBL2105758");
+  }
+
+  @Test
+  @DisplayName("should return empty result set when itemFilterType is null and items list is empty")
+  void shouldReturnEmptyWhenNullItemFilterTypeAndEmptyItems() {
+    when(mongoTemplate.count(any(Query.class), eq(COLLECTION_NAME))).thenReturn(0L);
+    when(
+      mongoTemplate.aggregate(
+        any(Aggregation.class),
+        eq(COLLECTION_NAME),
+        eq(NominatedDrugDocument.class)
+      )
+    ).thenReturn(aggregationResults);
+    when(aggregationResults.getMappedResults()).thenReturn(List.of());
+
+    // null itemFilterType with empty items — should default to INCLUDE and inject impossible condition
+    NominatedDrugSearchQueryDto query = NominatedDrugSearchQueryDto.builder().build();
+
+    repository.findAll(pageable(), query, List.of());
+
+    ArgumentCaptor<Aggregation> captor = ArgumentCaptor.forClass(Aggregation.class);
+    verify(mongoTemplate).aggregate(captor.capture(), eq(COLLECTION_NAME), eq(NominatedDrugDocument.class));
+
+    assertThat(captor.getValue().toString()).contains("_id").contains("null");
+  }
+
   @Test
   @DisplayName("should use aggregation pipeline for queries")
   void shouldUseAggregationPipeline() {

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/dto/DiseaseCorrelationIdentifier.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/dto/DiseaseCorrelationIdentifier.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Value;
 import org.sagebionetworks.model.ad.api.next.exception.InvalidFilterException;
+import org.springframework.data.mongodb.core.query.Criteria;
 
 /**
  * Represents a composite identifier for disease correlation documents.
@@ -71,17 +72,17 @@ public class DiseaseCorrelationIdentifier {
   }
 
   /**
-   * Converts this identifier to a MongoDB {@link org.springframework.data.mongodb.core.query.Criteria}
+   * Converts this identifier to a MongoDB {@link Criteria}
    * that matches documents with this exact name, age, and sex.
    *
    * @return a Criteria requiring all three fields to match
    */
-  public org.springframework.data.mongodb.core.query.Criteria toCriteria() {
-    return new org.springframework.data.mongodb.core.query.Criteria()
+  public Criteria toCriteria() {
+    return new Criteria()
       .andOperator(
-        org.springframework.data.mongodb.core.query.Criteria.where("name").is(name),
-        org.springframework.data.mongodb.core.query.Criteria.where("age").is(age),
-        org.springframework.data.mongodb.core.query.Criteria.where("sex").is(sex)
+        Criteria.where("name").is(name),
+        Criteria.where("age").is(age),
+        Criteria.where("sex").is(sex)
       );
   }
 }

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/dto/DiseaseCorrelationIdentifier.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/dto/DiseaseCorrelationIdentifier.java
@@ -69,4 +69,19 @@ public class DiseaseCorrelationIdentifier {
   public String toCompositeString() {
     return name + DELIMITER + age + DELIMITER + sex;
   }
+
+  /**
+   * Converts this identifier to a MongoDB {@link org.springframework.data.mongodb.core.query.Criteria}
+   * that matches documents with this exact name, age, and sex.
+   *
+   * @return a Criteria requiring all three fields to match
+   */
+  public org.springframework.data.mongodb.core.query.Criteria toCriteria() {
+    return new org.springframework.data.mongodb.core.query.Criteria()
+      .andOperator(
+        org.springframework.data.mongodb.core.query.Criteria.where("name").is(name),
+        org.springframework.data.mongodb.core.query.Criteria.where("age").is(age),
+        org.springframework.data.mongodb.core.query.Criteria.where("sex").is(sex)
+      );
+  }
 }

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/dto/TranscriptomicsIdentifier.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/dto/TranscriptomicsIdentifier.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Value;
 import org.sagebionetworks.model.ad.api.next.exception.InvalidFilterException;
+import org.springframework.data.mongodb.core.query.Criteria;
 
 /**
  * Represents a composite identifier for transcriptomics documents.
@@ -69,16 +70,16 @@ public class TranscriptomicsIdentifier {
   }
 
   /**
-   * Converts this identifier to a MongoDB {@link org.springframework.data.mongodb.core.query.Criteria}
+   * Converts this identifier to a MongoDB {@link Criteria}
    * that matches documents with this exact ensembl_gene_id and name.link_text.
    *
    * @return a Criteria requiring both fields to match
    */
-  public org.springframework.data.mongodb.core.query.Criteria toCriteria() {
-    return new org.springframework.data.mongodb.core.query.Criteria()
+  public Criteria toCriteria() {
+    return new Criteria()
       .andOperator(
-        org.springframework.data.mongodb.core.query.Criteria.where("ensembl_gene_id").is(ensemblGeneId),
-        org.springframework.data.mongodb.core.query.Criteria.where("name.link_text").is(name)
+        Criteria.where("ensembl_gene_id").is(ensemblGeneId),
+        Criteria.where("name.link_text").is(name)
       );
   }
 }

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/dto/TranscriptomicsIdentifier.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/dto/TranscriptomicsIdentifier.java
@@ -67,4 +67,18 @@ public class TranscriptomicsIdentifier {
   public String toCompositeId() {
     return String.format("%s~%s", ensemblGeneId, name);
   }
+
+  /**
+   * Converts this identifier to a MongoDB {@link org.springframework.data.mongodb.core.query.Criteria}
+   * that matches documents with this exact ensembl_gene_id and name.link_text.
+   *
+   * @return a Criteria requiring both fields to match
+   */
+  public org.springframework.data.mongodb.core.query.Criteria toCriteria() {
+    return new org.springframework.data.mongodb.core.query.Criteria()
+      .andOperator(
+        org.springframework.data.mongodb.core.query.Criteria.where("ensembl_gene_id").is(ensemblGeneId),
+        org.springframework.data.mongodb.core.query.Criteria.where("name.link_text").is(name)
+      );
+  }
 }

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomDiseaseCorrelationRepositoryImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomDiseaseCorrelationRepositoryImpl.java
@@ -1,13 +1,11 @@
 package org.sagebionetworks.model.ad.api.next.model.repository;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
-import org.sagebionetworks.explorers.ApiHelper;
+import org.sagebionetworks.explorers.ComputedSortField;
 import org.sagebionetworks.explorers.ComparisonToolRepositorySupport;
+import org.sagebionetworks.explorers.CtFilterConfig;
 import org.sagebionetworks.model.ad.api.next.model.document.DiseaseCorrelationDocument;
 import org.sagebionetworks.model.ad.api.next.model.dto.DiseaseCorrelationIdentifier;
 import org.sagebionetworks.model.ad.api.next.model.dto.DiseaseCorrelationSearchQueryDto;
@@ -53,13 +51,13 @@ public class CustomDiseaseCorrelationRepositoryImpl
    * (DocumentDB-compatible).
    */
   @Override
-  protected Map<String, Object> getComputedSortFieldExpressions() {
+  protected Map<String, ComputedSortField> getComputedSortFieldExpressions() {
     return Map.of(
-      "name", toLowerExpr("name"),
-      "sex", toLowerExpr("sex"),
-      "model_type", toLowerExpr("model_type"),
-      "matched_control", toLowerExpr("matched_control"),
-      "cluster", toLowerExpr("cluster")
+      "name", ComputedSortField.of(toLowerExpr("name")),
+      "sex", ComputedSortField.of(toLowerExpr("sex")),
+      "model_type", ComputedSortField.of(toLowerExpr("model_type")),
+      "matched_control", ComputedSortField.of(toLowerExpr("matched_control")),
+      "cluster", ComputedSortField.of(toLowerExpr("cluster"))
     );
   }
 
@@ -73,159 +71,35 @@ public class CustomDiseaseCorrelationRepositoryImpl
   }
 
   @Override
+  protected CtFilterConfig<DiseaseCorrelationSearchQueryDto> getFilterConfig() {
+    return CtFilterConfig.<DiseaseCorrelationSearchQueryDto>builder()
+      .dataFilter("age", DiseaseCorrelationSearchQueryDto::getAge)
+      .dataFilter("model_type", DiseaseCorrelationSearchQueryDto::getModelType)
+      .dataFilter("modified_genes", DiseaseCorrelationSearchQueryDto::getModifiedGenes)
+      .dataFilter("name", DiseaseCorrelationSearchQueryDto::getName)
+      .dataFilter("sex", DiseaseCorrelationSearchQueryDto::getSex)
+      .compositeItemFilter(item -> DiseaseCorrelationIdentifier.parse(item).toCriteria())
+      .searchFilter(NAME_FIELD)
+      .build();
+  }
+
+  @Override
   public Page<DiseaseCorrelationDocument> findAll(
     Pageable pageable,
     DiseaseCorrelationSearchQueryDto query,
     List<String> items,
     String cluster
   ) {
-    // Build match criteria with all filters (shared by count and data queries)
-    Criteria matchCriteria = buildMatchCriteria(cluster, query, items);
+    boolean isInclude = query.getItemFilterType() == ItemFilterTypeQueryDto.INCLUDE;
+    Criteria matchCriteria = buildCtMatchCriteria(
+      query,
+      items,
+      isInclude,
+      query.getSearch(),
+      getFilterConfig(),
+      Criteria.where("cluster").is(cluster)
+    );
 
     return executePagedAggregation(matchCriteria, pageable);
-  }
-
-  /**
-   * Builds match criteria combining all filters: cluster, data filters,
-   * composite identifiers, and name search.
-   */
-  private Criteria buildMatchCriteria(
-    String cluster,
-    DiseaseCorrelationSearchQueryDto query,
-    List<String> items
-  ) {
-    List<Criteria> allCriteria = new ArrayList<>();
-
-    ItemFilterTypeQueryDto filterType = Objects.requireNonNullElse(
-      query.getItemFilterType(),
-      ItemFilterTypeQueryDto.INCLUDE
-    );
-    String search = query.getSearch();
-
-    // Base criteria for cluster (required)
-    allCriteria.add(Criteria.where("cluster").is(cluster));
-
-    // Data filters: age, modelType, modifiedGenes, name, sex (OR within field, AND between fields)
-    addDataFilterCriteria(
-      query.getAge(),
-      query.getModelType(),
-      query.getModifiedGenes(),
-      query.getName(),
-      query.getSex(),
-      allCriteria
-    );
-
-    // Composite identifier filtering (items + itemFilterType)
-    addCompositeIdentifierCriteria(items, filterType, allCriteria);
-
-    // Name search (only for EXCLUDE mode)
-    addSearchCriteria(search, filterType, allCriteria);
-
-    // Combine all criteria with AND
-    return new Criteria().andOperator(allCriteria.toArray(new Criteria[0]));
-  }
-
-  private void addDataFilterCriteria(
-    List<String> age,
-    List<String> modelType,
-    List<String> modifiedGenes,
-    List<String> name,
-    List<String> sex,
-    List<Criteria> criteriaList
-  ) {
-    // age: string field - use $in (matches if value equals any)
-    if (age != null && !age.isEmpty()) {
-      criteriaList.add(Criteria.where("age").in(age));
-    }
-
-    // model_type: string field - use $in (matches if value equals any)
-    if (modelType != null && !modelType.isEmpty()) {
-      criteriaList.add(Criteria.where("model_type").in(modelType));
-    }
-
-    // modified_genes: array field - use $in (matches if array contains any value)
-    if (modifiedGenes != null && !modifiedGenes.isEmpty()) {
-      criteriaList.add(Criteria.where("modified_genes").in(modifiedGenes));
-    }
-
-    // name: string field - use $in (matches if value equals any)
-    if (name != null && !name.isEmpty()) {
-      criteriaList.add(Criteria.where("name").in(name));
-    }
-
-    // sex: string field - use $in (matches if value equals any)
-    if (sex != null && !sex.isEmpty()) {
-      criteriaList.add(Criteria.where("sex").in(sex));
-    }
-  }
-
-  private void addCompositeIdentifierCriteria(
-    List<String> items,
-    ItemFilterTypeQueryDto filterType,
-    List<Criteria> criteriaList
-  ) {
-    if (items.isEmpty()) {
-      // For INCLUDE mode with empty items, add impossible condition (return empty)
-      if (filterType == ItemFilterTypeQueryDto.INCLUDE) {
-        criteriaList.add(Criteria.where("_id").is(null));
-      }
-      // For EXCLUDE mode with empty items, no filtering needed (return all)
-      return;
-    }
-
-    // Parse composite identifiers (format: name~age~sex)
-    List<DiseaseCorrelationIdentifier> identifiers = parseIdentifiers(items);
-
-    // Build criteria for each identifier (must match ALL: name AND age AND sex)
-    List<Criteria> compositeConditions = new ArrayList<>();
-    for (DiseaseCorrelationIdentifier identifier : identifiers) {
-      Criteria idCondition = new Criteria()
-        .andOperator(
-          Criteria.where("name").is(identifier.getName()),
-          Criteria.where("age").is(identifier.getAge()),
-          Criteria.where("sex").is(identifier.getSex())
-        );
-      compositeConditions.add(idCondition);
-    }
-
-    // Apply INCLUDE or EXCLUDE logic
-    if (filterType == ItemFilterTypeQueryDto.INCLUDE) {
-      // Match ANY of the composite identifiers ($or)
-      criteriaList.add(new Criteria().orOperator(compositeConditions.toArray(new Criteria[0])));
-    } else {
-      // Exclude ALL of the composite identifiers ($nor)
-      criteriaList.add(new Criteria().norOperator(compositeConditions.toArray(new Criteria[0])));
-    }
-  }
-
-  private void addSearchCriteria(
-    String search,
-    ItemFilterTypeQueryDto filterType,
-    List<Criteria> criteriaList
-  ) {
-    // Search only applies when itemFilterType is EXCLUDE
-    if (search == null || search.trim().isEmpty() || filterType == ItemFilterTypeQueryDto.INCLUDE) {
-      return;
-    }
-
-    String trimmedSearch = search.trim();
-
-    // Comma-separated list: exact match (case-insensitive)
-    if (trimmedSearch.contains(",")) {
-      List<Pattern> patterns = ApiHelper.createCaseInsensitiveFullMatchPatterns(trimmedSearch);
-      criteriaList.add(Criteria.where(NAME_FIELD).in(patterns));
-    } else {
-      // Single term: partial match (case-insensitive)
-      String regex = Pattern.quote(trimmedSearch);
-      criteriaList.add(Criteria.where(NAME_FIELD).regex(regex, "i"));
-    }
-  }
-
-  private List<DiseaseCorrelationIdentifier> parseIdentifiers(List<String> items) {
-    List<DiseaseCorrelationIdentifier> identifiers = new ArrayList<>();
-    for (String item : items) {
-      identifiers.add(DiseaseCorrelationIdentifier.parse(item));
-    }
-    return identifiers;
   }
 }

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomDiseaseCorrelationRepositoryImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomDiseaseCorrelationRepositoryImpl.java
@@ -2,9 +2,10 @@ package org.sagebionetworks.model.ad.api.next.model.repository;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
-import org.sagebionetworks.explorers.ComputedSortField;
 import org.sagebionetworks.explorers.ComparisonToolRepositorySupport;
+import org.sagebionetworks.explorers.ComputedSortField;
 import org.sagebionetworks.explorers.CtFilterConfig;
 import org.sagebionetworks.model.ad.api.next.model.document.DiseaseCorrelationDocument;
 import org.sagebionetworks.model.ad.api.next.model.dto.DiseaseCorrelationIdentifier;
@@ -53,11 +54,16 @@ public class CustomDiseaseCorrelationRepositoryImpl
   @Override
   protected Map<String, ComputedSortField> getComputedSortFieldExpressions() {
     return Map.of(
-      "name", ComputedSortField.of(toLowerExpr("name")),
-      "sex", ComputedSortField.of(toLowerExpr("sex")),
-      "model_type", ComputedSortField.of(toLowerExpr("model_type")),
-      "matched_control", ComputedSortField.of(toLowerExpr("matched_control")),
-      "cluster", ComputedSortField.of(toLowerExpr("cluster"))
+      "name",
+      ComputedSortField.of(toLowerExpr("name")),
+      "sex",
+      ComputedSortField.of(toLowerExpr("sex")),
+      "model_type",
+      ComputedSortField.of(toLowerExpr("model_type")),
+      "matched_control",
+      ComputedSortField.of(toLowerExpr("matched_control")),
+      "cluster",
+      ComputedSortField.of(toLowerExpr("cluster"))
     );
   }
 
@@ -70,9 +76,8 @@ public class CustomDiseaseCorrelationRepositoryImpl
     return Map.of("age", "age_numeric");
   }
 
-  @Override
-  protected CtFilterConfig<DiseaseCorrelationSearchQueryDto> getFilterConfig() {
-    return CtFilterConfig.<DiseaseCorrelationSearchQueryDto>builder()
+  private final CtFilterConfig<DiseaseCorrelationSearchQueryDto> filterConfig =
+    CtFilterConfig.<DiseaseCorrelationSearchQueryDto>builder()
       .dataFilter("age", DiseaseCorrelationSearchQueryDto::getAge)
       .dataFilter("model_type", DiseaseCorrelationSearchQueryDto::getModelType)
       .dataFilter("modified_genes", DiseaseCorrelationSearchQueryDto::getModifiedGenes)
@@ -81,6 +86,10 @@ public class CustomDiseaseCorrelationRepositoryImpl
       .compositeItemFilter(item -> DiseaseCorrelationIdentifier.parse(item).toCriteria())
       .searchFilter(NAME_FIELD)
       .build();
+
+  @Override
+  protected CtFilterConfig<DiseaseCorrelationSearchQueryDto> getFilterConfig() {
+    return filterConfig;
   }
 
   @Override
@@ -90,7 +99,11 @@ public class CustomDiseaseCorrelationRepositoryImpl
     List<String> items,
     String cluster
   ) {
-    boolean isInclude = query.getItemFilterType() == ItemFilterTypeQueryDto.INCLUDE;
+    ItemFilterTypeQueryDto filterType = Objects.requireNonNullElse(
+      query.getItemFilterType(),
+      ItemFilterTypeQueryDto.INCLUDE
+    );
+    boolean isInclude = filterType == ItemFilterTypeQueryDto.INCLUDE;
     Criteria matchCriteria = buildCtMatchCriteria(
       query,
       items,

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomModelOverviewRepositoryImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomModelOverviewRepositoryImpl.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.model.ad.api.next.model.repository;
 
 import java.util.List;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.sagebionetworks.explorers.ComparisonToolRepositorySupport;
 import org.sagebionetworks.explorers.CtFilterConfig;
@@ -42,9 +43,8 @@ public class CustomModelOverviewRepositoryImpl
     return ModelOverviewDocument.class;
   }
 
-  @Override
-  protected CtFilterConfig<ModelOverviewSearchQueryDto> getFilterConfig() {
-    return CtFilterConfig.<ModelOverviewSearchQueryDto>builder()
+  private final CtFilterConfig<ModelOverviewSearchQueryDto> filterConfig =
+    CtFilterConfig.<ModelOverviewSearchQueryDto>builder()
       .dataFilter("available_data", ModelOverviewSearchQueryDto::getAvailableData)
       .dataFilter("center", ModelOverviewSearchQueryDto::getCenter)
       .dataFilter("model_type", ModelOverviewSearchQueryDto::getModelType)
@@ -52,6 +52,10 @@ public class CustomModelOverviewRepositoryImpl
       .simpleItemFilter("name")
       .searchFilter("name")
       .build();
+
+  @Override
+  protected CtFilterConfig<ModelOverviewSearchQueryDto> getFilterConfig() {
+    return filterConfig;
   }
 
   @Override
@@ -60,7 +64,11 @@ public class CustomModelOverviewRepositoryImpl
     ModelOverviewSearchQueryDto query,
     List<String> items
   ) {
-    boolean isInclude = query.getItemFilterType() == ItemFilterTypeQueryDto.INCLUDE;
+    ItemFilterTypeQueryDto filterType = Objects.requireNonNullElse(
+      query.getItemFilterType(),
+      ItemFilterTypeQueryDto.INCLUDE
+    );
+    boolean isInclude = filterType == ItemFilterTypeQueryDto.INCLUDE;
     Criteria matchCriteria = buildCtMatchCriteria(
       query,
       items,

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomModelOverviewRepositoryImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomModelOverviewRepositoryImpl.java
@@ -1,12 +1,9 @@
 package org.sagebionetworks.model.ad.api.next.model.repository;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
-import org.sagebionetworks.explorers.ApiHelper;
 import org.sagebionetworks.explorers.ComparisonToolRepositorySupport;
+import org.sagebionetworks.explorers.CtFilterConfig;
 import org.sagebionetworks.model.ad.api.next.model.document.ModelOverviewDocument;
 import org.sagebionetworks.model.ad.api.next.model.dto.ItemFilterTypeQueryDto;
 import org.sagebionetworks.model.ad.api.next.model.dto.ModelOverviewSearchQueryDto;
@@ -46,120 +43,32 @@ public class CustomModelOverviewRepositoryImpl
   }
 
   @Override
+  protected CtFilterConfig<ModelOverviewSearchQueryDto> getFilterConfig() {
+    return CtFilterConfig.<ModelOverviewSearchQueryDto>builder()
+      .dataFilter("available_data", ModelOverviewSearchQueryDto::getAvailableData)
+      .dataFilter("center", ModelOverviewSearchQueryDto::getCenter)
+      .dataFilter("model_type", ModelOverviewSearchQueryDto::getModelType)
+      .dataFilter("modified_genes", ModelOverviewSearchQueryDto::getModifiedGenes)
+      .simpleItemFilter("name")
+      .searchFilter("name")
+      .build();
+  }
+
+  @Override
   public Page<ModelOverviewDocument> findAll(
     Pageable pageable,
     ModelOverviewSearchQueryDto query,
     List<String> items
   ) {
-    ItemFilterTypeQueryDto filterType = Objects.requireNonNullElse(
-      query.getItemFilterType(),
-      ItemFilterTypeQueryDto.INCLUDE
+    boolean isInclude = query.getItemFilterType() == ItemFilterTypeQueryDto.INCLUDE;
+    Criteria matchCriteria = buildCtMatchCriteria(
+      query,
+      items,
+      isInclude,
+      query.getSearch(),
+      getFilterConfig()
     );
-    String search = query.getSearch();
 
-    Criteria matchCriteria = buildMatchCriteria(query, items, filterType, search);
     return executePagedAggregation(matchCriteria, pageable);
-  }
-
-  private Criteria buildMatchCriteria(
-    ModelOverviewSearchQueryDto query,
-    List<String> items,
-    ItemFilterTypeQueryDto filterType,
-    String search
-  ) {
-    List<Criteria> andCriteria = new ArrayList<>();
-
-    // Add data filters (AND between fields, OR within field)
-    addDataFilterCriteria(
-      query.getAvailableData(),
-      query.getCenter(),
-      query.getModelType(),
-      query.getModifiedGenes(),
-      andCriteria
-    );
-
-    // Add name filtering (items + itemFilterType)
-    addNameFilterCriteria(items, filterType, andCriteria);
-
-    // Add search filtering (only when itemFilterType is EXCLUDE)
-    addSearchFilterCriteria(search, filterType, andCriteria);
-
-    if (andCriteria.isEmpty()) {
-      return new Criteria();
-    }
-    return new Criteria().andOperator(andCriteria.toArray(new Criteria[0]));
-  }
-
-  private void addDataFilterCriteria(
-    List<String> availableData,
-    List<String> center,
-    List<String> modelType,
-    List<String> modifiedGenes,
-    List<Criteria> andCriteria
-  ) {
-    // available_data: array field - use $in (matches if array contains any value)
-    if (availableData != null && !availableData.isEmpty()) {
-      andCriteria.add(Criteria.where("available_data").in(availableData));
-    }
-
-    // center: string field - use $in (matches if value equals any)
-    if (center != null && !center.isEmpty()) {
-      andCriteria.add(Criteria.where("center").in(center));
-    }
-
-    // model_type: string field - use $in (matches if value equals any)
-    if (modelType != null && !modelType.isEmpty()) {
-      andCriteria.add(Criteria.where("model_type").in(modelType));
-    }
-
-    // modified_genes: array field - use $in (matches if array contains any value)
-    if (modifiedGenes != null && !modifiedGenes.isEmpty()) {
-      andCriteria.add(Criteria.where("modified_genes").in(modifiedGenes));
-    }
-  }
-
-  private void addNameFilterCriteria(
-    List<String> items,
-    ItemFilterTypeQueryDto filterType,
-    List<Criteria> andCriteria
-  ) {
-    if (items.isEmpty()) {
-      // For INCLUDE mode with empty items, add impossible condition to return empty results
-      if (filterType == ItemFilterTypeQueryDto.INCLUDE) {
-        andCriteria.add(Criteria.where("_id").is(null));
-      }
-      // For EXCLUDE mode with empty items, no filtering needed (return all)
-      return;
-    }
-
-    if (filterType == ItemFilterTypeQueryDto.INCLUDE) {
-      andCriteria.add(Criteria.where("name").in(items));
-    } else {
-      andCriteria.add(Criteria.where("name").nin(items));
-    }
-  }
-
-  private void addSearchFilterCriteria(
-    String search,
-    ItemFilterTypeQueryDto filterType,
-    List<Criteria> andCriteria
-  ) {
-    // Search only applies when itemFilterType is EXCLUDE
-    if (
-      filterType != ItemFilterTypeQueryDto.EXCLUDE || search == null || search.trim().isEmpty()
-    ) {
-      return;
-    }
-
-    String trimmedSearch = search.trim();
-    if (trimmedSearch.contains(",")) {
-      // Comma-separated list: case-insensitive full matches
-      List<Pattern> patterns = ApiHelper.createCaseInsensitiveFullMatchPatterns(trimmedSearch);
-      andCriteria.add(Criteria.where("name").in(patterns));
-    } else {
-      // Single term: case-insensitive partial match
-      String quotedSearch = Pattern.quote(trimmedSearch);
-      andCriteria.add(Criteria.where("name").regex(quotedSearch, "i"));
-    }
   }
 }

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
@@ -3,19 +3,20 @@ package org.sagebionetworks.model.ad.api.next.model.repository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
 import org.sagebionetworks.explorers.ApiHelper;
 import org.sagebionetworks.explorers.ComparisonToolRepositorySupport;
+import org.sagebionetworks.explorers.ComputedSortField;
+import org.sagebionetworks.explorers.CtFilterConfig;
+import org.sagebionetworks.explorers.SearchFilterDef;
 import org.sagebionetworks.model.ad.api.next.model.document.TranscriptomicsDocument;
 import org.sagebionetworks.model.ad.api.next.model.dto.ItemFilterTypeQueryDto;
 import org.sagebionetworks.model.ad.api.next.model.dto.TranscriptomicsIdentifier;
 import org.sagebionetworks.model.ad.api.next.model.dto.TranscriptomicsSearchQueryDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -55,46 +56,42 @@ public class CustomTranscriptomicsRepositoryImpl
 
   /**
    * Case-insensitive sort. {@code gene_symbol} routes through the computed
-   * {@code display_gene_symbol} (with the ensembl_gene_id fallback added by
-   * {@link #getExtraSortFieldComputations(Sort)}); {@code name} routes through its nested
-   * {@code link_text} child.
+   * {@code display_gene_symbol} (with the ensembl_gene_id fallback bundled as a prerequisite);
+   * {@code name} routes through its nested {@code link_text} child.
    */
   @Override
-  protected Map<String, Object> getComputedSortFieldExpressions() {
+  protected Map<String, ComputedSortField> getComputedSortFieldExpressions() {
     return Map.of(
-      GENE_SYMBOL_FIELD, toLowerExpr(DISPLAY_GENE_SYMBOL_FIELD),
-      "name", toLowerExpr("name.link_text"),
-      "model_type", toLowerExpr("model_type"),
-      "tissue", toLowerExpr("tissue"),
-      "sex_cohort", toLowerExpr("sex_cohort"),
-      "ensembl_gene_id", toLowerExpr("ensembl_gene_id"),
-      "matched_control", toLowerExpr("matched_control"),
-      "model_group", toLowerExpr("model_group")
+      GENE_SYMBOL_FIELD,
+      ComputedSortField.of(toLowerExpr(DISPLAY_GENE_SYMBOL_FIELD)).withPrerequisite(
+        buildDisplayGeneSymbolField()
+      ),
+      "name",
+      ComputedSortField.of(toLowerExpr("name.link_text")),
+      "model_type",
+      ComputedSortField.of(toLowerExpr("model_type")),
+      "tissue",
+      ComputedSortField.of(toLowerExpr("tissue")),
+      "sex_cohort",
+      ComputedSortField.of(toLowerExpr("sex_cohort")),
+      "ensembl_gene_id",
+      ComputedSortField.of(toLowerExpr("ensembl_gene_id")),
+      "matched_control",
+      ComputedSortField.of(toLowerExpr("matched_control")),
+      "model_group",
+      ComputedSortField.of(toLowerExpr("model_group"))
     );
   }
 
-  /**
-   * When the user sorts by {@code gene_symbol}, we need to compute the
-   * {@code display_gene_symbol} fallback first so the lowercase step ({@code $toLower}) can
-   * reference it.
-   *
-   * <p><strong>Invariant:</strong> this method MUST emit the {@code display_gene_symbol}
-   * {@code $addFields} stage whenever {@link #getComputedSortFieldExpressions()} would invoke
-   * its {@code gene_symbol} entry — i.e. whenever the requested sort includes
-   * {@value #GENE_SYMBOL_FIELD}. Narrowing the gating here without narrowing the computed
-   * expression (or vice versa) silently produces {@code $toLower(null)} sort keys.
-   * {@code CustomTranscriptomicsRepositoryImplTest#shouldEmitDisplayGeneSymbolPipelineWhenSortingByGeneSymbol}
-   * pins this invariant.
-   */
   @Override
-  protected List<AggregationOperation> getExtraSortFieldComputations(Sort sort) {
-    boolean sortsByGeneSymbol = sort
-      .stream()
-      .anyMatch(o -> GENE_SYMBOL_FIELD.equals(o.getProperty()));
-    if (!sortsByGeneSymbol) {
-      return List.of();
-    }
-    return List.of(buildDisplayGeneSymbolField());
+  protected CtFilterConfig<TranscriptomicsSearchQueryDto> getFilterConfig() {
+    return CtFilterConfig.<TranscriptomicsSearchQueryDto>builder()
+      .dataFilter("biodomains", TranscriptomicsSearchQueryDto::getBiodomains)
+      .dataFilter("model_type", TranscriptomicsSearchQueryDto::getModelType)
+      .dataFilter("name.link_text", TranscriptomicsSearchQueryDto::getName)
+      .compositeItemFilter(item -> TranscriptomicsIdentifier.parse(item).toCriteria())
+      .searchFilter(GENE_SYMBOL_FIELD)
+      .build();
   }
 
   @Override
@@ -105,8 +102,16 @@ public class CustomTranscriptomicsRepositoryImpl
     String tissue,
     String sexCohort
   ) {
-    // Build match criteria with all filters (shared by count and data queries)
-    Criteria matchCriteria = buildMatchCriteria(tissue, sexCohort, query, items);
+    boolean isInclude = query.getItemFilterType() == ItemFilterTypeQueryDto.INCLUDE;
+    Criteria matchCriteria = buildCtMatchCriteria(
+      query,
+      items,
+      isInclude,
+      query.getSearch(),
+      getFilterConfig(),
+      Criteria.where("tissue").is(tissue),
+      Criteria.where("sex_cohort").is(sexCohort)
+    );
 
     return executePagedAggregation(matchCriteria, pageable);
   }
@@ -153,134 +158,24 @@ public class CustomTranscriptomicsRepositoryImpl
   }
 
   /**
-   * Builds match criteria combining all filters: tissue, sex_cohort, data filters,
-   * composite identifiers, and gene symbol search.
-   */
-  private Criteria buildMatchCriteria(
-    String tissue,
-    String sexCohort,
-    TranscriptomicsSearchQueryDto query,
-    List<String> items
-  ) {
-    List<Criteria> allCriteria = new ArrayList<>();
-
-    ItemFilterTypeQueryDto filterType = Objects.requireNonNullElse(
-      query.getItemFilterType(),
-      ItemFilterTypeQueryDto.INCLUDE
-    );
-    String search = query.getSearch();
-
-    // Base criteria for tissue and sex_cohort (required)
-    allCriteria.add(Criteria.where("tissue").is(tissue));
-    allCriteria.add(Criteria.where("sex_cohort").is(sexCohort));
-
-    // Data filters: biodomains, modelType, name (OR within field, AND between fields)
-    addDataFilterCriteria(
-      query.getBiodomains(),
-      query.getModelType(),
-      query.getName(),
-      allCriteria
-    );
-
-    // Composite identifier filtering (items + itemFilterType)
-    addCompositeIdentifierCriteria(items, filterType, allCriteria);
-
-    // Gene symbol search (only for EXCLUDE mode)
-    addSearchCriteria(search, filterType, allCriteria);
-
-    // Combine all criteria with AND
-    return new Criteria().andOperator(allCriteria.toArray(new Criteria[0]));
-  }
-
-  private void addDataFilterCriteria(
-    List<String> biodomains,
-    List<String> modelType,
-    List<String> name,
-    List<Criteria> criteriaList
-  ) {
-    // biodomains: array field - use $in (matches if array contains any value)
-    if (biodomains != null && !biodomains.isEmpty()) {
-      criteriaList.add(Criteria.where("biodomains").in(biodomains));
-    }
-
-    // model_type: string field - use $in (matches if value equals any)
-    if (modelType != null && !modelType.isEmpty()) {
-      criteriaList.add(Criteria.where("model_type").in(modelType));
-    }
-
-    // name.link_text: nested field - use $in (matches if value equals any)
-    if (name != null && !name.isEmpty()) {
-      criteriaList.add(Criteria.where("name.link_text").in(name));
-    }
-  }
-
-  private void addCompositeIdentifierCriteria(
-    List<String> items,
-    ItemFilterTypeQueryDto filterType,
-    List<Criteria> criteriaList
-  ) {
-    if (items.isEmpty()) {
-      // For INCLUDE mode with empty items, add impossible condition (return empty)
-      if (filterType == ItemFilterTypeQueryDto.INCLUDE) {
-        criteriaList.add(Criteria.where("_id").is(null));
-      }
-      // For EXCLUDE mode with empty items, no filtering needed (return all)
-      return;
-    }
-
-    // Parse composite identifiers (format: ensembl_gene_id~name)
-    List<TranscriptomicsIdentifier> identifiers = parseIdentifiers(items);
-
-    // Build criteria for each identifier (must match BOTH ensembl_gene_id AND name.link_text)
-    List<Criteria> compositeConditions = new ArrayList<>();
-    for (TranscriptomicsIdentifier identifier : identifiers) {
-      Criteria idCondition = new Criteria()
-        .andOperator(
-          Criteria.where("ensembl_gene_id").is(identifier.getEnsemblGeneId()),
-          Criteria.where("name.link_text").is(identifier.getName())
-        );
-      compositeConditions.add(idCondition);
-    }
-
-    // Apply INCLUDE or EXCLUDE logic
-    if (filterType == ItemFilterTypeQueryDto.INCLUDE) {
-      // Match ANY of the composite identifiers ($or)
-      criteriaList.add(new Criteria().orOperator(compositeConditions.toArray(new Criteria[0])));
-    } else {
-      // Exclude ALL of the composite identifiers ($nor)
-      criteriaList.add(new Criteria().norOperator(compositeConditions.toArray(new Criteria[0])));
-    }
-  }
-
-  /**
-   * Adds search criteria that matches the display_gene_symbol logic using raw fields.
+   * Override search to add gene_symbol/ensembl_gene_id fallback logic.
    *
-   * <p>Since display_gene_symbol = gene_symbol ?? ensembl_gene_id, the search matches:
+   * <p>Since {@code display_gene_symbol = gene_symbol ?? ensembl_gene_id}, the search matches:
    * (gene_symbol matches) OR (gene_symbol is null/empty AND ensembl_gene_id matches)
    *
-   * <p>NOTE: We cannot use DISPLAY_GENE_SYMBOL_FIELD here because it's a computed field
-   * created by $addFields in the aggregation pipeline. The count query uses
-   * mongoTemplate.count() for performance, which doesn't run the aggregation pipeline
-   * and therefore has no access to the computed field.
+   * <p><strong>NOTE:</strong> We cannot use {@code DISPLAY_GENE_SYMBOL_FIELD} here because it's a
+   * computed field created by {@code $addFields} in the aggregation pipeline. The count query uses
+   * {@code mongoTemplate.count()} for performance, which doesn't run the aggregation pipeline and
+   * therefore has no access to the computed field. We must replicate the fallback logic using the
+   * raw {@code gene_symbol} and {@code ensembl_gene_id} fields.
    */
-  private void addSearchCriteria(
-    String search,
-    ItemFilterTypeQueryDto filterType,
-    List<Criteria> criteriaList
-  ) {
-    // Search only applies when itemFilterType is EXCLUDE
-    if (search == null || search.trim().isEmpty() || filterType == ItemFilterTypeQueryDto.INCLUDE) {
-      return;
-    }
-
-    String trimmedSearch = search.trim();
-
-    // Match if gene_symbol matches, OR if gene_symbol is null/empty and ensembl_gene_id matches
+  @Override
+  protected Criteria buildSearchCriteria(SearchFilterDef def, String trimmedSearch) {
     Criteria geneSymbolIsNullOrEmpty = new Criteria()
       .orOperator(
         Criteria.where(GENE_SYMBOL_FIELD).is(null),
         Criteria.where(GENE_SYMBOL_FIELD).is(""),
-        Criteria.where(GENE_SYMBOL_FIELD).regex("^\\s*$") // whitespace only
+        Criteria.where(GENE_SYMBOL_FIELD).regex("^\\s*$")
       );
 
     if (trimmedSearch.contains(",")) {
@@ -290,7 +185,7 @@ public class CustomTranscriptomicsRepositoryImpl
       Criteria ensemblFallbackMatches = new Criteria()
         .andOperator(geneSymbolIsNullOrEmpty, Criteria.where("ensembl_gene_id").in(patterns));
 
-      criteriaList.add(new Criteria().orOperator(geneSymbolMatches, ensemblFallbackMatches));
+      return new Criteria().orOperator(geneSymbolMatches, ensemblFallbackMatches);
     } else {
       // Single term: partial match (case-insensitive)
       String regex = Pattern.quote(trimmedSearch);
@@ -298,15 +193,7 @@ public class CustomTranscriptomicsRepositoryImpl
       Criteria ensemblFallbackMatches = new Criteria()
         .andOperator(geneSymbolIsNullOrEmpty, Criteria.where("ensembl_gene_id").regex(regex, "i"));
 
-      criteriaList.add(new Criteria().orOperator(geneSymbolMatches, ensemblFallbackMatches));
+      return new Criteria().orOperator(geneSymbolMatches, ensemblFallbackMatches);
     }
-  }
-
-  private List<TranscriptomicsIdentifier> parseIdentifiers(List<String> items) {
-    List<TranscriptomicsIdentifier> identifiers = new ArrayList<>();
-    for (String item : items) {
-      identifiers.add(TranscriptomicsIdentifier.parse(item));
-    }
-    return identifiers;
   }
 }

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.model.ad.api.next.model.repository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
@@ -10,7 +11,6 @@ import org.sagebionetworks.explorers.ApiHelper;
 import org.sagebionetworks.explorers.ComparisonToolRepositorySupport;
 import org.sagebionetworks.explorers.ComputedSortField;
 import org.sagebionetworks.explorers.CtFilterConfig;
-import org.sagebionetworks.explorers.SearchFilterDef;
 import org.sagebionetworks.model.ad.api.next.model.document.TranscriptomicsDocument;
 import org.sagebionetworks.model.ad.api.next.model.dto.ItemFilterTypeQueryDto;
 import org.sagebionetworks.model.ad.api.next.model.dto.TranscriptomicsIdentifier;
@@ -83,15 +83,18 @@ public class CustomTranscriptomicsRepositoryImpl
     );
   }
 
-  @Override
-  protected CtFilterConfig<TranscriptomicsSearchQueryDto> getFilterConfig() {
-    return CtFilterConfig.<TranscriptomicsSearchQueryDto>builder()
+  private final CtFilterConfig<TranscriptomicsSearchQueryDto> filterConfig =
+    CtFilterConfig.<TranscriptomicsSearchQueryDto>builder()
       .dataFilter("biodomains", TranscriptomicsSearchQueryDto::getBiodomains)
       .dataFilter("model_type", TranscriptomicsSearchQueryDto::getModelType)
       .dataFilter("name.link_text", TranscriptomicsSearchQueryDto::getName)
       .compositeItemFilter(item -> TranscriptomicsIdentifier.parse(item).toCriteria())
       .searchFilter(GENE_SYMBOL_FIELD)
       .build();
+
+  @Override
+  protected CtFilterConfig<TranscriptomicsSearchQueryDto> getFilterConfig() {
+    return filterConfig;
   }
 
   @Override
@@ -102,7 +105,11 @@ public class CustomTranscriptomicsRepositoryImpl
     String tissue,
     String sexCohort
   ) {
-    boolean isInclude = query.getItemFilterType() == ItemFilterTypeQueryDto.INCLUDE;
+    ItemFilterTypeQueryDto filterType = Objects.requireNonNullElse(
+      query.getItemFilterType(),
+      ItemFilterTypeQueryDto.INCLUDE
+    );
+    boolean isInclude = filterType == ItemFilterTypeQueryDto.INCLUDE;
     Criteria matchCriteria = buildCtMatchCriteria(
       query,
       items,
@@ -170,7 +177,7 @@ public class CustomTranscriptomicsRepositoryImpl
    * raw {@code gene_symbol} and {@code ensembl_gene_id} fields.
    */
   @Override
-  protected Criteria buildSearchCriteria(SearchFilterDef def, String trimmedSearch) {
+  protected Criteria buildSearchCriteria(String field, String trimmedSearch) {
     Criteria geneSymbolIsNullOrEmpty = new Criteria()
       .orOperator(
         Criteria.where(GENE_SYMBOL_FIELD).is(null),

--- a/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/dto/DiseaseCorrelationIdentifierTest.java
+++ b/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/dto/DiseaseCorrelationIdentifierTest.java
@@ -91,4 +91,22 @@ class DiseaseCorrelationIdentifierTest {
 
     assertThat(result).isEqualTo("APOE4~4 months~Female");
   }
+
+  @Test
+  @DisplayName("should build correct criteria from identifier")
+  void shouldBuildCorrectCriteriaFromIdentifier() {
+    DiseaseCorrelationIdentifier identifier = DiseaseCorrelationIdentifier.builder()
+      .name("APOE4")
+      .age("4 months")
+      .sex("Female")
+      .build();
+
+    org.springframework.data.mongodb.core.query.Criteria result = identifier.toCriteria();
+
+    String criteriaStr = result.getCriteriaObject().toString();
+    assertThat(criteriaStr).contains("name").contains("APOE4");
+    assertThat(criteriaStr).contains("age").contains("4 months");
+    assertThat(criteriaStr).contains("sex").contains("Female");
+    assertThat(criteriaStr).contains("$and");
+  }
 }

--- a/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/dto/DiseaseCorrelationIdentifierTest.java
+++ b/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/dto/DiseaseCorrelationIdentifierTest.java
@@ -3,9 +3,12 @@ package org.sagebionetworks.model.ad.api.next.model.dto;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
+import org.bson.Document;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.sagebionetworks.model.ad.api.next.exception.InvalidFilterException;
+import org.springframework.data.mongodb.core.query.Criteria;
 
 class DiseaseCorrelationIdentifierTest {
 
@@ -101,12 +104,12 @@ class DiseaseCorrelationIdentifierTest {
       .sex("Female")
       .build();
 
-    org.springframework.data.mongodb.core.query.Criteria result = identifier.toCriteria();
+    Criteria result = identifier.toCriteria();
 
-    String criteriaStr = result.getCriteriaObject().toString();
-    assertThat(criteriaStr).contains("name").contains("APOE4");
-    assertThat(criteriaStr).contains("age").contains("4 months");
-    assertThat(criteriaStr).contains("sex").contains("Female");
-    assertThat(criteriaStr).contains("$and");
+    List<Document> andClauses = result.getCriteriaObject().getList("$and", Document.class);
+    assertThat(andClauses).hasSize(3);
+    assertThat(andClauses.get(0)).isEqualTo(new Document("name", "APOE4"));
+    assertThat(andClauses.get(1)).isEqualTo(new Document("age", "4 months"));
+    assertThat(andClauses.get(2)).isEqualTo(new Document("sex", "Female"));
   }
 }

--- a/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/dto/TranscriptomicsIdentifierTest.java
+++ b/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/dto/TranscriptomicsIdentifierTest.java
@@ -141,4 +141,20 @@ class TranscriptomicsIdentifierTest {
     assertThat(result.getName()).isEqualTo("Model-123 (Test/Lab)");
     assertThat(result.toCompositeId()).isEqualTo(compositeId);
   }
+
+  @Test
+  @DisplayName("should build correct criteria from identifier")
+  void shouldBuildCorrectCriteriaFromIdentifier() {
+    TranscriptomicsIdentifier identifier = TranscriptomicsIdentifier.builder()
+      .ensemblGeneId("ENSMUSG00000000001")
+      .name("5xFAD")
+      .build();
+
+    org.springframework.data.mongodb.core.query.Criteria result = identifier.toCriteria();
+
+    String criteriaStr = result.getCriteriaObject().toString();
+    assertThat(criteriaStr).contains("ensembl_gene_id").contains("ENSMUSG00000000001");
+    assertThat(criteriaStr).contains("name.link_text").contains("5xFAD");
+    assertThat(criteriaStr).contains("$and");
+  }
 }

--- a/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/dto/TranscriptomicsIdentifierTest.java
+++ b/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/dto/TranscriptomicsIdentifierTest.java
@@ -3,9 +3,12 @@ package org.sagebionetworks.model.ad.api.next.model.dto;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
+import org.bson.Document;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.sagebionetworks.model.ad.api.next.exception.InvalidFilterException;
+import org.springframework.data.mongodb.core.query.Criteria;
 
 class TranscriptomicsIdentifierTest {
 
@@ -150,11 +153,11 @@ class TranscriptomicsIdentifierTest {
       .name("5xFAD")
       .build();
 
-    org.springframework.data.mongodb.core.query.Criteria result = identifier.toCriteria();
+    Criteria result = identifier.toCriteria();
 
-    String criteriaStr = result.getCriteriaObject().toString();
-    assertThat(criteriaStr).contains("ensembl_gene_id").contains("ENSMUSG00000000001");
-    assertThat(criteriaStr).contains("name.link_text").contains("5xFAD");
-    assertThat(criteriaStr).contains("$and");
+    List<Document> andClauses = result.getCriteriaObject().getList("$and", Document.class);
+    assertThat(andClauses).hasSize(2);
+    assertThat(andClauses.get(0)).isEqualTo(new Document("ensembl_gene_id", "ENSMUSG00000000001"));
+    assertThat(andClauses.get(1)).isEqualTo(new Document("name.link_text", "5xFAD"));
   }
 }

--- a/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImplTest.java
+++ b/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImplTest.java
@@ -21,23 +21,19 @@ import org.sagebionetworks.model.ad.api.next.model.document.TranscriptomicsDocum
 import org.sagebionetworks.model.ad.api.next.model.dto.ItemFilterTypeQueryDto;
 import org.sagebionetworks.model.ad.api.next.model.dto.TranscriptomicsSearchQueryDto;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
-import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
 /**
- * Tests for CustomTranscriptomicsRepositoryImpl focusing on criteria building, pagination, and
- * pipeline assembly.
+ * Tests for CustomTranscriptomicsRepositoryImpl focusing on criteria building and pipeline
+ * assembly.
  *
- * <p>Most tests use reflection to call the private {@code buildMatchCriteria} directly and inspect
- * the returned {@link Criteria}. The pipeline-invariant test
- * ({@code shouldEmitDisplayGeneSymbolPipelineWhenSortingByGeneSymbol}) uses a mocked
- * {@link MongoTemplate} to capture and inspect the full {@link Aggregation} produced by the base
- * class.
+ * <p>All tests call {@link CustomTranscriptomicsRepositoryImpl#findAll} with a mocked
+ * {@link MongoTemplate} and capture the {@link Query} passed to {@code count()} to inspect the
+ * match criteria, or capture the full {@link Aggregation} to inspect the pipeline shape.
  */
 @ExtendWith(MockitoExtension.class)
 class CustomTranscriptomicsRepositoryImplTest {
@@ -54,162 +50,7 @@ class CustomTranscriptomicsRepositoryImplTest {
 
   @BeforeEach
   void setUp() {
-    repository = new CustomTranscriptomicsRepositoryImpl(null);
-  }
-
-  @Test
-  @DisplayName("should apply pagination to data query")
-  void shouldApplyPaginationToDataQuery() throws Exception {
-    // Given
-    TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
-      .biodomains(Arrays.asList("test-domain"))
-      .itemFilterType(ItemFilterTypeQueryDto.EXCLUDE)
-      .build();
-
-    // When
-    Criteria criteria = invokeBuildMatchCriteria(
-      "test-tissue",
-      "test-cohort",
-      query,
-      Collections.emptyList()
-    );
-    Document criteriaDoc = criteria.getCriteriaObject();
-
-    // Then - Verify criteria is built (pagination happens at aggregation level)
-    assertThat(criteriaDoc).containsKey("$and");
-    List<Document> andConditions = (List<Document>) criteriaDoc.get("$and");
-
-    // Verify required filters exist
-    assertThat(andConditions).anySatisfy(doc -> assertThat(doc).containsKey("tissue"));
-    assertThat(andConditions).anySatisfy(doc -> assertThat(doc).containsKey("sex_cohort"));
-    assertThat(andConditions).anySatisfy(doc -> assertThat(doc).containsKey("biodomains"));
-  }
-
-  @Test
-  @DisplayName("should execute count query without pagination")
-  void shouldExecuteCountQueryWithoutPagination() throws Exception {
-    // Given
-    TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
-      .biodomains(Arrays.asList("test-domain"))
-      .modelType(Arrays.asList("test-type"))
-      .itemFilterType(ItemFilterTypeQueryDto.EXCLUDE)
-      .build();
-
-    // When
-    Criteria criteria = invokeBuildMatchCriteria(
-      "test-tissue",
-      "test-cohort",
-      query,
-      Collections.emptyList()
-    );
-    Document criteriaDoc = criteria.getCriteriaObject();
-
-    // Then - Verify all filters are included (count uses same criteria as data query)
-    assertThat(criteriaDoc).containsKey("$and");
-    List<Document> andConditions = (List<Document>) criteriaDoc.get("$and");
-
-    // Should have filters: tissue, sex_cohort, biodomains, model_type
-    assertThat(andConditions.size()).isGreaterThanOrEqualTo(4);
-  }
-
-  @Test
-  @DisplayName("should search on gene_symbol with fallback to ensembl_gene_id for single term")
-  void shouldSearchOnDisplayGeneSymbolWithSingleTerm() throws Exception {
-    // Given
-    TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
-      .search("APOE")
-      .itemFilterType(ItemFilterTypeQueryDto.EXCLUDE)
-      .build();
-
-    // When
-    Criteria criteria = invokeBuildMatchCriteria(
-      "test-tissue",
-      "test-cohort",
-      query,
-      Collections.emptyList()
-    );
-    Document criteriaDoc = criteria.getCriteriaObject();
-
-    // Then
-    assertThat(criteriaDoc).containsKey("$and");
-    List<Document> andConditions = (List<Document>) criteriaDoc.get("$and");
-    assertThat(andConditions).anySatisfy(doc -> assertThat(doc).containsKey("$or"));
-  }
-
-  @Test
-  @DisplayName(
-    "should search on gene_symbol with fallback to ensembl_gene_id for comma-separated terms"
-  )
-  void shouldSearchOnDisplayGeneSymbolWithCommaSeparatedTerms() throws Exception {
-    // Given
-    TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
-      .search("APOE,TREM2,APP")
-      .itemFilterType(ItemFilterTypeQueryDto.EXCLUDE)
-      .build();
-
-    // When
-    Criteria criteria = invokeBuildMatchCriteria(
-      "test-tissue",
-      "test-cohort",
-      query,
-      Collections.emptyList()
-    );
-    Document criteriaDoc = criteria.getCriteriaObject();
-
-    // Then
-    assertThat(criteriaDoc).containsKey("$and");
-    List<Document> andConditions = (List<Document>) criteriaDoc.get("$and");
-    assertThat(andConditions).anySatisfy(doc -> assertThat(doc).containsKey("$or"));
-  }
-
-  @Test
-  @DisplayName("should not apply search filter in INCLUDE mode")
-  void shouldNotApplySearchFilterInIncludeMode() throws Exception {
-    // Given
-    TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
-      .search("APOE")
-      .itemFilterType(ItemFilterTypeQueryDto.INCLUDE)
-      .build();
-    List<String> items = Arrays.asList("ENSG00000130203~5xFAD");
-
-    // When
-    Criteria criteria = invokeBuildMatchCriteria("test-tissue", "test-cohort", query, items);
-    Document criteriaDoc = criteria.getCriteriaObject();
-
-    // Then
-    String criteriaString = criteriaDoc.toJson();
-    assertThat(criteriaString).doesNotContain("\"$regex\"");
-  }
-
-  @Test
-  @DisplayName("should not apply search filter when search is empty")
-  void shouldNotApplySearchFilterWhenSearchIsEmpty() throws Exception {
-    // Given
-    TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
-      .search("   ")
-      .itemFilterType(ItemFilterTypeQueryDto.EXCLUDE)
-      .build();
-
-    // When
-    Criteria criteria = invokeBuildMatchCriteria(
-      "test-tissue",
-      "test-cohort",
-      query,
-      Collections.emptyList()
-    );
-    Document criteriaDoc = criteria.getCriteriaObject();
-
-    // Then
-    String criteriaString = criteriaDoc.toJson();
-    assertThat(criteriaString).doesNotContain("\"$regex\"");
-  }
-
-  @Test
-  @DisplayName(
-    "should emit display_gene_symbol $addFields AND reference it in computed sort when sorting by gene_symbol"
-  )
-  void shouldEmitDisplayGeneSymbolPipelineWhenSortingByGeneSymbol() {
-    // Mocked MongoTemplate so we can capture the assembled Aggregation
+    repository = new CustomTranscriptomicsRepositoryImpl(mongoTemplate);
     when(mongoTemplate.count(any(Query.class), eq(COLLECTION_NAME))).thenReturn(0L);
     when(
       mongoTemplate.aggregate(
@@ -219,62 +60,182 @@ class CustomTranscriptomicsRepositoryImplTest {
       )
     ).thenReturn(aggregationResults);
     when(aggregationResults.getMappedResults()).thenReturn(List.of());
+  }
 
-    CustomTranscriptomicsRepositoryImpl repoWithMock = new CustomTranscriptomicsRepositoryImpl(
-      mongoTemplate
+  @Test
+  @DisplayName("should apply pagination to data query")
+  void shouldApplyPaginationToDataQuery() {
+    TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
+      .biodomains(Arrays.asList("test-domain"))
+      .itemFilterType(ItemFilterTypeQueryDto.EXCLUDE)
+      .build();
+
+    repository.findAll(
+      PageRequest.of(0, 10),
+      query,
+      Collections.emptyList(),
+      "test-tissue",
+      "test-cohort"
     );
 
+    Document criteriaDoc = captureCountQuery().getQueryObject();
+    assertThat(criteriaDoc).containsKey("$and");
+    List<Document> andConditions = (List<Document>) criteriaDoc.get("$and");
+    assertThat(andConditions).anySatisfy(doc -> assertThat(doc).containsKey("tissue"));
+    assertThat(andConditions).anySatisfy(doc -> assertThat(doc).containsKey("sex_cohort"));
+    assertThat(andConditions).anySatisfy(doc -> assertThat(doc).containsKey("biodomains"));
+  }
+
+  @Test
+  @DisplayName("should execute count query without pagination")
+  void shouldExecuteCountQueryWithoutPagination() {
+    TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
+      .biodomains(Arrays.asList("test-domain"))
+      .modelType(Arrays.asList("test-type"))
+      .itemFilterType(ItemFilterTypeQueryDto.EXCLUDE)
+      .build();
+
+    repository.findAll(
+      PageRequest.of(0, 10),
+      query,
+      Collections.emptyList(),
+      "test-tissue",
+      "test-cohort"
+    );
+
+    Document criteriaDoc = captureCountQuery().getQueryObject();
+    assertThat(criteriaDoc).containsKey("$and");
+    List<Document> andConditions = (List<Document>) criteriaDoc.get("$and");
+    // tissue, sex_cohort, biodomains, model_type
+    assertThat(andConditions.size()).isGreaterThanOrEqualTo(4);
+  }
+
+  @Test
+  @DisplayName("should search on gene_symbol with fallback to ensembl_gene_id for single term")
+  void shouldSearchOnDisplayGeneSymbolWithSingleTerm() {
+    TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
+      .search("APOE")
+      .itemFilterType(ItemFilterTypeQueryDto.EXCLUDE)
+      .build();
+
+    repository.findAll(
+      PageRequest.of(0, 10),
+      query,
+      Collections.emptyList(),
+      "test-tissue",
+      "test-cohort"
+    );
+
+    Document criteriaDoc = captureCountQuery().getQueryObject();
+    assertThat(criteriaDoc).containsKey("$and");
+    List<Document> andConditions = (List<Document>) criteriaDoc.get("$and");
+    assertThat(andConditions).anySatisfy(doc -> assertThat(doc).containsKey("$or"));
+  }
+
+  @Test
+  @DisplayName(
+    "should search on gene_symbol with fallback to ensembl_gene_id for comma-separated terms"
+  )
+  void shouldSearchOnDisplayGeneSymbolWithCommaSeparatedTerms() {
+    TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
+      .search("APOE,TREM2,APP")
+      .itemFilterType(ItemFilterTypeQueryDto.EXCLUDE)
+      .build();
+
+    repository.findAll(
+      PageRequest.of(0, 10),
+      query,
+      Collections.emptyList(),
+      "test-tissue",
+      "test-cohort"
+    );
+
+    Document criteriaDoc = captureCountQuery().getQueryObject();
+    assertThat(criteriaDoc).containsKey("$and");
+    List<Document> andConditions = (List<Document>) criteriaDoc.get("$and");
+    assertThat(andConditions).anySatisfy(doc -> assertThat(doc).containsKey("$or"));
+  }
+
+  @Test
+  @DisplayName("should not apply search filter in INCLUDE mode")
+  void shouldNotApplySearchFilterInIncludeMode() {
+    TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
+      .search("APOE")
+      .itemFilterType(ItemFilterTypeQueryDto.INCLUDE)
+      .build();
+
+    repository.findAll(
+      PageRequest.of(0, 10),
+      query,
+      Arrays.asList("ENSG00000130203~5xFAD"),
+      "test-tissue",
+      "test-cohort"
+    );
+
+    assertThat(captureCountQuery().getQueryObject().toJson()).doesNotContain("\"$regex\"");
+  }
+
+  @Test
+  @DisplayName("should not apply search filter when search is empty")
+  void shouldNotApplySearchFilterWhenSearchIsEmpty() {
+    TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
+      .search("   ")
+      .itemFilterType(ItemFilterTypeQueryDto.EXCLUDE)
+      .build();
+
+    repository.findAll(
+      PageRequest.of(0, 10),
+      query,
+      Collections.emptyList(),
+      "test-tissue",
+      "test-cohort"
+    );
+
+    assertThat(captureCountQuery().getQueryObject().toJson()).doesNotContain("\"$regex\"");
+  }
+
+  @Test
+  @DisplayName(
+    "should emit display_gene_symbol $addFields AND reference it in computed sort when sorting by gene_symbol"
+  )
+  void shouldEmitDisplayGeneSymbolPipelineWhenSortingByGeneSymbol() {
     TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
       .itemFilterType(ItemFilterTypeQueryDto.EXCLUDE)
       .build();
 
-    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Order.asc("gene_symbol")));
-
-    repoWithMock.findAll(pageable, query, Collections.emptyList(), "test-tissue", "test-cohort");
-
-    ArgumentCaptor<Aggregation> aggregationCaptor = ArgumentCaptor.forClass(Aggregation.class);
-    verify(mongoTemplate).aggregate(
-      aggregationCaptor.capture(),
-      eq(COLLECTION_NAME),
-      eq(TranscriptomicsDocument.class)
+    repository.findAll(
+      PageRequest.of(0, 10, Sort.by(Sort.Order.asc("gene_symbol"))),
+      query,
+      Collections.emptyList(),
+      "test-tissue",
+      "test-cohort"
     );
 
-    String pipeline = aggregationCaptor.getValue().toString();
-
-    // Extras must emit the display_gene_symbol $addFields with the $cond fallback
+    String pipeline = captureAggregation().toString();
     assertThat(pipeline)
       .as("extras stage must compute display_gene_symbol")
       .contains("display_gene_symbol")
       .contains("$cond");
-
-    // The computed sort must reference $toLower($display_gene_symbol) under the gene_symbol_sort key
     assertThat(pipeline)
-      .as("computed sort must alias gene_symbol to gene_symbol_sort sourced from display_gene_symbol")
+      .as("computed sort must alias gene_symbol to gene_symbol_sort via display_gene_symbol")
       .contains("gene_symbol_sort")
       .contains("$toLower");
-
-    // The $sort doc must use the gene_symbol_sort key (not the raw gene_symbol)
     assertThat(pipeline).contains("\"gene_symbol_sort\" : 1");
   }
 
-  /**
-   * Uses reflection to invoke the private buildMatchCriteria method for testing.
-   */
-  private Criteria invokeBuildMatchCriteria(
-    String tissue,
-    String sexCohort,
-    TranscriptomicsSearchQueryDto query,
-    List<String> items
-  ) throws Exception {
-    var method =
-      CustomTranscriptomicsRepositoryImpl.class.getDeclaredMethod(
-          "buildMatchCriteria",
-          String.class,
-          String.class,
-          TranscriptomicsSearchQueryDto.class,
-          List.class
-        );
-    method.setAccessible(true);
-    return (Criteria) method.invoke(repository, tissue, sexCohort, query, items);
+  private Query captureCountQuery() {
+    ArgumentCaptor<Query> captor = ArgumentCaptor.forClass(Query.class);
+    verify(mongoTemplate).count(captor.capture(), eq(COLLECTION_NAME));
+    return captor.getValue();
+  }
+
+  private Aggregation captureAggregation() {
+    ArgumentCaptor<Aggregation> captor = ArgumentCaptor.forClass(Aggregation.class);
+    verify(mongoTemplate).aggregate(
+      captor.capture(),
+      eq(COLLECTION_NAME),
+      eq(TranscriptomicsDocument.class)
+    );
+    return captor.getValue();
   }
 }

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
@@ -1,8 +1,10 @@
 package org.sagebionetworks.explorers;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
@@ -61,11 +63,11 @@ public abstract class ComparisonToolRepositorySupport<T> {
    * <p>Subclasses override to declare their data filters, item filter, and search filter. Used by
    * {@link #buildCtMatchCriteria}.
    *
-   * <p>Default implementation returns null; subclasses that use {@link #buildCtMatchCriteria} must
-   * override.
+   * <p>Default implementation throws {@link UnsupportedOperationException}; subclasses that use
+   * {@link #buildCtMatchCriteria} must override.
    */
   protected <Q> CtFilterConfig<Q> getFilterConfig() {
-    return null;
+    throw new UnsupportedOperationException("Subclasses that use buildCtMatchCriteria must override getFilterConfig()");
   }
 
   /**
@@ -229,7 +231,7 @@ public abstract class ComparisonToolRepositorySupport<T> {
     // 4. Add search filter (only in EXCLUDE mode)
     if (!isInclude && search != null && !search.trim().isEmpty()) {
       String trimmedSearch = search.trim();
-      Criteria searchCriteria = buildSearchCriteria(config.searchFilter(), trimmedSearch);
+      Criteria searchCriteria = buildSearchCriteria(config.searchFilter().field(), trimmedSearch);
       allCriteria.add(searchCriteria);
     }
 
@@ -241,7 +243,7 @@ public abstract class ComparisonToolRepositorySupport<T> {
   }
 
   /**
-   * Builds search criteria for the given search filter definition.
+   * Builds search criteria for the given field and search term.
    *
    * <p>Default implementation:
    *
@@ -252,14 +254,14 @@ public abstract class ComparisonToolRepositorySupport<T> {
    * </ul>
    *
    * <p>Subclasses can override to provide custom search logic (e.g. fallback fields or
-   * multi-field matching).
+   * multi-field matching). The {@code field} parameter can be ignored by overrides that manage
+   * their own field names.
    *
-   * @param def the search filter definition
+   * @param field the MongoDB field to search against
    * @param trimmedSearch the trimmed search string (never null or blank)
    * @return the search criteria
    */
-  protected Criteria buildSearchCriteria(SearchFilterDef def, String trimmedSearch) {
-    String field = def.field();
+  protected Criteria buildSearchCriteria(String field, String trimmedSearch) {
     if (trimmedSearch.contains(",")) {
       // Comma-separated list: exact match (case-insensitive)
       List<Pattern> patterns = ApiHelper.createCaseInsensitiveFullMatchPatterns(trimmedSearch);
@@ -321,14 +323,14 @@ public abstract class ComparisonToolRepositorySupport<T> {
       return List.of();
     }
 
-    List<AggregationOperation> prerequisites = new ArrayList<>();
+    Set<AggregationOperation> seen = new LinkedHashSet<>();
     for (Sort.Order order : sort) {
       ComputedSortField field = computedFields.get(order.getProperty());
-      if (field != null && !field.prerequisites().isEmpty()) {
-        prerequisites.addAll(field.prerequisites());
+      if (field != null) {
+        seen.addAll(field.prerequisites());
       }
     }
-    return prerequisites;
+    return new ArrayList<>(seen);
   }
 
   private AggregationOperation buildComputedSortFields(

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
@@ -60,8 +60,8 @@ public abstract class ComparisonToolRepositorySupport<T> {
   /**
    * Declarative filter configuration for this comparison-tool repository.
    *
-   * <p>Subclasses override to declare their data filters, item filter, and search filter. Used by
-   * {@link #buildCtMatchCriteria}.
+   * <p>Subclasses override to declare their data filters, item filter, and search filter. Pass the
+   * return value as the {@code config} argument to {@link #buildCtMatchCriteria}.
    *
    * <p>Default implementation throws {@link UnsupportedOperationException}; subclasses that use
    * {@link #buildCtMatchCriteria} must override.

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.explorers;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
 import org.springframework.data.domain.Page;
@@ -25,7 +26,7 @@ import org.springframework.data.mongodb.core.query.Query;
  *
  * <pre>
  *   $match
- *   $addFields (extra pre-sort computations, from {@link #getExtraSortFieldComputations(Sort)})
+ *   $addFields (prerequisites bundled with requested computed sort fields)
  *   $addFields (computed sort fields, from {@link #getComputedSortFieldExpressions()})
  *   $sort       (field names resolved via {@link #getSortFieldAliases()} and the computed map)
  *   $skip / $limit
@@ -55,15 +56,32 @@ public abstract class ComparisonToolRepositorySupport<T> {
   protected abstract Class<T> getDocumentClass();
 
   /**
-   * Map of sort field → MongoDB expression that produces a sortable scalar.
+   * Declarative filter configuration for this comparison-tool repository.
    *
-   * <p>When a user sorts by a key in this map, an {@code $addFields: {<field>_sort: <expr>}} stage
-   * is injected and the {@code $sort} uses {@code <field>_sort} instead of the raw field. Use this
-   * for case-insensitive string sort (via {@link #toLowerExpr(String)}), array-to-string reduction
-   * (via {@link #arrayToLoweredStringExpr(String)}), nested-field unwrapping, or any case where
-   * the raw field isn't directly sortable.
+   * <p>Subclasses override to declare their data filters, item filter, and search filter. Used by
+   * {@link #buildCtMatchCriteria}.
+   *
+   * <p>Default implementation returns null; subclasses that use {@link #buildCtMatchCriteria} must
+   * override.
    */
-  protected Map<String, Object> getComputedSortFieldExpressions() {
+  protected <Q> CtFilterConfig<Q> getFilterConfig() {
+    return null;
+  }
+
+  /**
+   * Map of sort field → computed sort field (expression + prerequisites).
+   *
+   * <p>When a user sorts by a key in this map, the prerequisites (if any) are injected first,
+   * then an {@code $addFields: {<field>_sort: <expr>}} stage is injected, and the {@code $sort}
+   * uses {@code <field>_sort} instead of the raw field. Use this for case-insensitive string sort
+   * (via {@link #toLowerExpr(String)}), array-to-string reduction (via
+   * {@link #arrayToLoweredStringExpr(String)}), nested-field unwrapping, or any case where the raw
+   * field isn't directly sortable.
+   *
+   * <p>For expressions that reference computed fields, bundle the prerequisite stages via
+   * {@link ComputedSortField#withPrerequisite(AggregationOperation)}.
+   */
+  protected Map<String, ComputedSortField> getComputedSortFieldExpressions() {
     return Map.of();
   }
 
@@ -77,19 +95,6 @@ public abstract class ComparisonToolRepositorySupport<T> {
   }
 
   /**
-   * Extra {@code $addFields} stages contributed before the standard computed-sort step.
-   *
-   * <p>Use when a computed sort expression references a field that itself must be computed first
-   * (e.g. Transcriptomics' {@code display_gene_symbol} fallback, which is later lower-cased into
-   * {@code gene_symbol_sort}). The subclass typically inspects {@code sort} to decide whether the
-   * stage is needed for the requested ordering.
-   */
-  @SuppressWarnings("java:S1172") // sort is unused in the default; subclasses use it for inspection
-  protected List<AggregationOperation> getExtraSortFieldComputations(Sort sort) {
-    return List.of();
-  }
-
-  /**
    * Assembles and executes the standard CT pipeline. Subclasses build {@code matchCriteria} and
    * pass it in along with the {@link Pageable}.
    */
@@ -97,24 +102,28 @@ public abstract class ComparisonToolRepositorySupport<T> {
     try {
       List<AggregationOperation> operations = new ArrayList<>();
       operations.add(Aggregation.match(matchCriteria));
-      operations.addAll(getExtraSortFieldComputations(pageable.getSort()));
 
-      Map<String, Object> computedExpressions = getComputedSortFieldExpressions();
+      Map<String, ComputedSortField> computedFields = getComputedSortFieldExpressions();
       Map<String, String> aliases = getSortFieldAliases();
 
+      // Inject prerequisites for requested sort fields
+      List<AggregationOperation> prerequisites = buildPrerequisites(
+        pageable.getSort(),
+        computedFields
+      );
+      operations.addAll(prerequisites);
+
+      // Inject computed sort fields
       AggregationOperation computedSort = buildComputedSortFields(
         pageable.getSort(),
-        computedExpressions
+        computedFields
       );
       if (computedSort != null) {
         operations.add(computedSort);
       }
 
-      AggregationOperation sort = buildSortOperation(
-        pageable.getSort(),
-        computedExpressions,
-        aliases
-      );
+      // Build and add sort operation
+      AggregationOperation sort = buildSortOperation(pageable.getSort(), computedFields, aliases);
       if (sort != null) {
         operations.add(sort);
       }
@@ -159,16 +168,182 @@ public abstract class ComparisonToolRepositorySupport<T> {
     return new Document("$toLower", reduce);
   }
 
-  private AggregationOperation buildComputedSortFields(Sort sort, Map<String, Object> expressions) {
-    if (sort.isUnsorted() || expressions.isEmpty()) {
+  /**
+   * Builds {@link Criteria} for comparison-tool filtering using declarative configuration.
+   *
+   * <p>Applies in order:
+   *
+   * <ol>
+   *   <li><strong>Base criteria</strong> — required filters (cluster, tissue, sex_cohort, etc.)
+   *   <li><strong>Data filters</strong> — field-level filters (age, model_type, etc.) with
+   *       {@code $in} matching
+   *   <li><strong>Item filter</strong> — row-level identifier matching (INCLUDE/EXCLUDE):
+   *       <ul>
+   *         <li>Empty items + INCLUDE → impossible condition (return empty)
+   *         <li>Empty items + EXCLUDE → no-op (return all)
+   *         <li>Simple item filter → {@code field $in items} or {@code field $nin items}
+   *         <li>Composite item filter → parse each item, combine with {@code $or}/{@code $nor}
+   *       </ul>
+   *   <li><strong>Search filter</strong> — text search (EXCLUDE-only):
+   *       <ul>
+   *         <li>Comma-separated → exact match (case-insensitive)
+   *         <li>Single term → partial regex match (case-insensitive)
+   *       </ul>
+   * </ol>
+   *
+   * <p>All criteria are combined with {@code $and}.
+   *
+   * @param query the query DTO
+   * @param items the list of item identifiers
+   * @param isInclude true if itemFilterType is INCLUDE, false if EXCLUDE
+   * @param search the search string
+   * @param config the filter configuration
+   * @param baseCriteria required base filters (e.g., cluster, tissue)
+   * @param <Q> the query DTO type
+   * @return the combined match criteria
+   */
+  protected <Q> Criteria buildCtMatchCriteria(
+    Q query,
+    List<String> items,
+    boolean isInclude,
+    String search,
+    CtFilterConfig<Q> config,
+    Criteria... baseCriteria
+  ) {
+    List<Criteria> allCriteria = new ArrayList<>();
+
+    // 1. Add base criteria (required filters)
+    allCriteria.addAll(List.of(baseCriteria));
+
+    // 2. Add data filters
+    for (DataFilterDef<Q> dataFilter : config.dataFilters()) {
+      List<?> values = dataFilter.accessor().apply(query);
+      if (values != null && !values.isEmpty()) {
+        allCriteria.add(Criteria.where(dataFilter.mongoField()).in(values));
+      }
+    }
+
+    // 3. Add item filter
+    addItemFilterCriteria(items, isInclude, config.itemFilter(), allCriteria);
+
+    // 4. Add search filter (only in EXCLUDE mode)
+    if (!isInclude && search != null && !search.trim().isEmpty()) {
+      String trimmedSearch = search.trim();
+      Criteria searchCriteria = buildSearchCriteria(config.searchFilter(), trimmedSearch);
+      allCriteria.add(searchCriteria);
+    }
+
+    // Combine all with AND; return empty Criteria (match-all) when no filters are active
+    if (allCriteria.isEmpty()) {
+      return new Criteria();
+    }
+    return new Criteria().andOperator(allCriteria.toArray(new Criteria[0]));
+  }
+
+  /**
+   * Builds search criteria for the given search filter definition.
+   *
+   * <p>Default implementation:
+   *
+   * <ul>
+   *   <li>Comma-separated search → exact match (case-insensitive) via
+   *       {@link ApiHelper#createCaseInsensitiveFullMatchPatterns}
+   *   <li>Single term → partial match (case-insensitive regex)
+   * </ul>
+   *
+   * <p>Subclasses can override to provide custom search logic (e.g. fallback fields or
+   * multi-field matching).
+   *
+   * @param def the search filter definition
+   * @param trimmedSearch the trimmed search string (never null or blank)
+   * @return the search criteria
+   */
+  protected Criteria buildSearchCriteria(SearchFilterDef def, String trimmedSearch) {
+    String field = def.field();
+    if (trimmedSearch.contains(",")) {
+      // Comma-separated list: exact match (case-insensitive)
+      List<Pattern> patterns = ApiHelper.createCaseInsensitiveFullMatchPatterns(trimmedSearch);
+      return Criteria.where(field).in(patterns);
+    } else {
+      // Single term: partial match (case-insensitive)
+      String regex = Pattern.quote(trimmedSearch);
+      return Criteria.where(field).regex(regex, "i");
+    }
+  }
+
+  private static void addItemFilterCriteria(
+    List<String> items,
+    boolean isInclude,
+    ItemFilterDef itemFilter,
+    List<Criteria> allCriteria
+  ) {
+    if (items.isEmpty()) {
+      // For INCLUDE mode with empty items, add impossible condition (return empty)
+      if (isInclude) {
+        allCriteria.add(Criteria.where("_id").is(null));
+      }
+      // For EXCLUDE mode with empty items, no filtering needed (return all)
+      return;
+    }
+
+    switch (itemFilter) {
+      case ItemFilterDef.Simple simple -> {
+        if (isInclude) {
+          allCriteria.add(Criteria.where(simple.field()).in(items));
+        } else {
+          allCriteria.add(Criteria.where(simple.field()).nin(items));
+        }
+      }
+      case ItemFilterDef.Composite composite -> {
+        // Parse each item into a Criteria
+        List<Criteria> itemCriteriaList = new ArrayList<>();
+        for (String item : items) {
+          itemCriteriaList.add(composite.parser().apply(item));
+        }
+
+        // Combine with $or (INCLUDE) or $nor (EXCLUDE)
+        if (isInclude) {
+          // Match ANY of the composite identifiers ($or)
+          allCriteria.add(new Criteria().orOperator(itemCriteriaList.toArray(new Criteria[0])));
+        } else {
+          // Exclude ALL of the composite identifiers ($nor)
+          allCriteria.add(new Criteria().norOperator(itemCriteriaList.toArray(new Criteria[0])));
+        }
+      }
+    }
+  }
+
+  private List<AggregationOperation> buildPrerequisites(
+    Sort sort,
+    Map<String, ComputedSortField> computedFields
+  ) {
+    if (sort.isUnsorted() || computedFields.isEmpty()) {
+      return List.of();
+    }
+
+    List<AggregationOperation> prerequisites = new ArrayList<>();
+    for (Sort.Order order : sort) {
+      ComputedSortField field = computedFields.get(order.getProperty());
+      if (field != null && !field.prerequisites().isEmpty()) {
+        prerequisites.addAll(field.prerequisites());
+      }
+    }
+    return prerequisites;
+  }
+
+  private AggregationOperation buildComputedSortFields(
+    Sort sort,
+    Map<String, ComputedSortField> computedFields
+  ) {
+    if (sort.isUnsorted() || computedFields.isEmpty()) {
       return null;
     }
 
     Document fields = new Document();
     for (Sort.Order order : sort) {
-      Object expression = expressions.get(order.getProperty());
-      if (expression != null) {
-        fields.append(order.getProperty() + "_sort", expression);
+      ComputedSortField field = computedFields.get(order.getProperty());
+      if (field != null) {
+        fields.append(order.getProperty() + "_sort", field.expression());
       }
     }
 
@@ -180,7 +355,7 @@ public abstract class ComparisonToolRepositorySupport<T> {
 
   private AggregationOperation buildSortOperation(
     Sort sort,
-    Map<String, Object> computed,
+    Map<String, ComputedSortField> computed,
     Map<String, String> aliases
   ) {
     if (sort.isUnsorted()) {

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComputedSortField.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComputedSortField.java
@@ -1,0 +1,43 @@
+package org.sagebionetworks.explorers;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
+
+/**
+ * Bundles a MongoDB sort expression with its prerequisite pipeline stages.
+ *
+ * <p>When a sort expression references a field that must be computed by an earlier aggregation
+ * stage, declare the prerequisite alongside the expression via
+ * {@link #withPrerequisite(AggregationOperation)}. The base class automatically emits prerequisites
+ * before the computed-sort {@code $addFields} stage, only when the user's sort actually requests
+ * that field.
+ *
+ * @param expression the MongoDB expression that produces a sortable scalar (e.g.
+ *     {@code new Document("$toLower", "$field")})
+ * @param prerequisites aggregation stages that must run before this expression is evaluated
+ */
+public record ComputedSortField(Object expression, List<AggregationOperation> prerequisites) {
+
+  /**
+   * Creates a computed sort field with no prerequisites.
+   *
+   * @param expression the MongoDB expression
+   * @return a computed sort field
+   */
+  public static ComputedSortField of(Object expression) {
+    return new ComputedSortField(expression, List.of());
+  }
+
+  /**
+   * Returns a new computed sort field with an additional prerequisite.
+   *
+   * @param prereq the prerequisite stage to add
+   * @return a new computed sort field with the prerequisite appended
+   */
+  public ComputedSortField withPrerequisite(AggregationOperation prereq) {
+    List<AggregationOperation> newPrereqs = new ArrayList<>(prerequisites);
+    newPrereqs.add(prereq);
+    return new ComputedSortField(expression, List.copyOf(newPrereqs));
+  }
+}

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/CtFilterConfig.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/CtFilterConfig.java
@@ -1,0 +1,116 @@
+package org.sagebionetworks.explorers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+/**
+ * Declarative filter configuration for a comparison-tool repository.
+ *
+ * <p>Defines:
+ *
+ * <ul>
+ *   <li><strong>Data filters</strong> — field-level filters (age, model_type, etc.) applied with
+ *       {@code $in}
+ *   <li><strong>Item filter</strong> — row-level identifier matching (INCLUDE/EXCLUDE), either
+ *       simple (single field) or composite (multi-field AND-clauses)
+ *   <li><strong>Search filter</strong> — text search on a designated field (EXCLUDE-only)
+ * </ul>
+ *
+ * <p>Consumed by {@link ComparisonToolRepositorySupport#buildCtMatchCriteria}.
+ *
+ * @param dataFilters list of data filter definitions
+ * @param itemFilter item filter definition (simple or composite)
+ * @param searchFilter search filter definition
+ * @param <Q> the query DTO type
+ */
+public record CtFilterConfig<Q>(
+  List<DataFilterDef<Q>> dataFilters,
+  ItemFilterDef itemFilter,
+  SearchFilterDef searchFilter
+) {
+  public static <Q> Builder<Q> builder() {
+    return new Builder<>();
+  }
+
+  /**
+   * Builder for {@link CtFilterConfig}.
+   *
+   * @param <Q> the query DTO type
+   */
+  public static final class Builder<Q> {
+
+    private final List<DataFilterDef<Q>> dataFilters = new ArrayList<>();
+    private ItemFilterDef itemFilter;
+    private SearchFilterDef searchFilter;
+
+    private Builder() {}
+
+    /**
+     * Adds a data filter.
+     *
+     * @param mongoField the MongoDB field name to filter on
+     * @param accessor function extracting the filter values from the query DTO
+     * @return this builder
+     */
+    public Builder<Q> dataFilter(String mongoField, Function<Q, List<?>> accessor) {
+      this.dataFilters.add(new DataFilterDef<>(mongoField, accessor));
+      return this;
+    }
+
+    /**
+     * Sets the item filter to a simple single-field matcher.
+     *
+     * @param field the MongoDB field name to match items by
+     * @return this builder
+     */
+    public Builder<Q> simpleItemFilter(String field) {
+      this.itemFilter = new ItemFilterDef.Simple(field);
+      return this;
+    }
+
+    /**
+     * Sets the item filter to a composite multi-field matcher.
+     *
+     * @param parser function that parses an item string and returns a Criteria matching that item
+     *     (typically a method reference to an identifier DTO's {@code toCriteria()} method)
+     * @return this builder
+     */
+    public Builder<Q> compositeItemFilter(Function<String, Criteria> parser) {
+      this.itemFilter = new ItemFilterDef.Composite(parser);
+      return this;
+    }
+
+    /**
+     * Sets the search filter field.
+     *
+     * @param field the MongoDB field name to search against
+     * @return this builder
+     */
+    public Builder<Q> searchFilter(String field) {
+      this.searchFilter = new SearchFilterDef(field);
+      return this;
+    }
+
+    /**
+     * Builds the {@link CtFilterConfig}.
+     *
+     * @return the configured filter config
+     * @throws IllegalStateException if itemFilter or searchFilter is not set
+     */
+    public CtFilterConfig<Q> build() {
+      if (itemFilter == null) {
+        throw new IllegalStateException("itemFilter must be set");
+      }
+      if (searchFilter == null) {
+        throw new IllegalStateException("searchFilter must be set");
+      }
+      return new CtFilterConfig<>(
+        List.copyOf(dataFilters),
+        itemFilter,
+        searchFilter
+      );
+    }
+  }
+}

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/DataFilterDef.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/DataFilterDef.java
@@ -1,0 +1,16 @@
+package org.sagebionetworks.explorers;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Defines a single data filter for a comparison-tool query.
+ *
+ * <p>A data filter applies {@code $in} matching on a MongoDB field when the accessor returns a
+ * non-empty list from the query DTO.
+ *
+ * @param mongoField the MongoDB field name to filter on (e.g. "age", "model_type")
+ * @param accessor function extracting the filter values from the query DTO
+ * @param <Q> the query DTO type
+ */
+public record DataFilterDef<Q>(String mongoField, Function<Q, List<?>> accessor) {}

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ItemFilterDef.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ItemFilterDef.java
@@ -1,0 +1,41 @@
+package org.sagebionetworks.explorers;
+
+import java.util.function.Function;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+/**
+ * Defines how to filter comparison-tool rows by a list of item identifiers.
+ *
+ * <p>Two variants:
+ *
+ * <ul>
+ *   <li>{@link Simple} — items are matched by a single field using {@code $in}/{@code $nin}
+ *   <li>{@link Composite} — items are parsed into multi-field AND-clauses combined via
+ *       {@code $or}/{@code $nor}
+ * </ul>
+ */
+public sealed interface ItemFilterDef {
+
+  /**
+   * Simple item filter: match items by a single field.
+   *
+   * <p>INCLUDE mode: {@code field $in items}<br>
+   * EXCLUDE mode: {@code field $nin items}
+   *
+   * @param field the MongoDB field name to match (e.g. "ensembl_gene_id")
+   */
+  record Simple(String field) implements ItemFilterDef {}
+
+  /**
+   * Composite item filter: parse each item string into a multi-field Criteria.
+   *
+   * <p>The parser function is typically a method reference to an identifier DTO's
+   * {@code toCriteria()} method (e.g. {@code DiseaseCorrelationIdentifier::toCriteria}).
+   *
+   * <p>INCLUDE mode: {@code $or: [parser(item1), parser(item2), ...]}<br>
+   * EXCLUDE mode: {@code $nor: [parser(item1), parser(item2), ...]}
+   *
+   * @param parser function that parses an item string and returns a Criteria matching that item
+   */
+  record Composite(Function<String, Criteria> parser) implements ItemFilterDef {}
+}

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/SearchFilterDef.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/SearchFilterDef.java
@@ -1,0 +1,16 @@
+package org.sagebionetworks.explorers;
+
+/**
+ * Defines the field used for comparison-tool search filtering.
+ *
+ * <p>Search applies only in EXCLUDE mode (when {@code itemFilterType == EXCLUDE}). Two patterns:
+ *
+ * <ul>
+ *   <li>Comma-separated search terms → exact match (case-insensitive) via
+ *       {@link ApiHelper#createCaseInsensitiveFullMatchPatterns}
+ *   <li>Single search term → partial match (case-insensitive regex)
+ * </ul>
+ *
+ * @param field the MongoDB field name to search against (e.g. "name", "gene_symbol")
+ */
+public record SearchFilterDef(String field) {}

--- a/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/BuildCtMatchCriteriaTest.java
+++ b/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/BuildCtMatchCriteriaTest.java
@@ -1,0 +1,399 @@
+package org.sagebionetworks.explorers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+/**
+ * Tests for {@link ComparisonToolRepositorySupport#buildCtMatchCriteria}.
+ *
+ * <p>Uses a minimal test repository to exercise the filter-building logic without full MongoDB
+ * infrastructure.
+ */
+class BuildCtMatchCriteriaTest {
+
+  @Nested
+  @DisplayName("Data filters")
+  class DataFilters {
+
+    @Test
+    @DisplayName("should add $in criteria for non-empty data filter values")
+    void shouldAddDataFilterCriteria() {
+      TestRepo repo = new TestRepo();
+      TestQuery query = new TestQuery(List.of("value1", "value2"), List.of());
+
+      CtFilterConfig<TestQuery> config = CtFilterConfig.<TestQuery>builder()
+        .dataFilter("field1", TestQuery::getField1)
+        .simpleItemFilter("id")
+        .searchFilter("name")
+        .build();
+
+      Criteria result = repo.buildCtMatchCriteria(query, List.of(), false, null, config);
+
+      assertThat(result.getCriteriaObject().toString()).contains("field1").contains("value1");
+    }
+
+    @Test
+    @DisplayName("should skip data filters when values are null or empty")
+    void shouldSkipEmptyDataFilters() {
+      TestRepo repo = new TestRepo();
+      TestQuery query = new TestQuery(null, List.of());
+
+      CtFilterConfig<TestQuery> config = CtFilterConfig.<TestQuery>builder()
+        .dataFilter("field1", TestQuery::getField1)
+        .simpleItemFilter("id")
+        .searchFilter("name")
+        .build();
+
+      Criteria result = repo.buildCtMatchCriteria(query, List.of(), false, null, config);
+
+      assertThat(result.getCriteriaObject().toString()).doesNotContain("field1");
+    }
+
+    @Test
+    @DisplayName("should combine multiple data filters with AND")
+    void shouldCombineMultipleDataFilters() {
+      TestRepo repo = new TestRepo();
+      TestQuery query = new TestQuery(List.of("a"), List.of("b"));
+
+      CtFilterConfig<TestQuery> config = CtFilterConfig.<TestQuery>builder()
+        .dataFilter("field1", TestQuery::getField1)
+        .dataFilter("field2", TestQuery::getField2)
+        .simpleItemFilter("id")
+        .searchFilter("name")
+        .build();
+
+      Criteria result = repo.buildCtMatchCriteria(query, List.of(), false, null, config);
+
+      String criteriaStr = result.getCriteriaObject().toString();
+      assertThat(criteriaStr).contains("field1").contains("field2");
+    }
+  }
+
+  @Nested
+  @DisplayName("Simple item filter")
+  class SimpleItemFilter {
+
+    @Test
+    @DisplayName("should use $in for INCLUDE mode with non-empty items")
+    void shouldUseInForIncludeMode() {
+      TestRepo repo = new TestRepo();
+      TestQuery query = new TestQuery(List.of(), List.of());
+
+      CtFilterConfig<TestQuery> config = CtFilterConfig.<TestQuery>builder()
+        .simpleItemFilter("hgnc_symbol")
+        .searchFilter("name")
+        .build();
+
+      Criteria result = repo.buildCtMatchCriteria(
+        query,
+        List.of("APOE", "APP"),
+        true,
+        null,
+        config
+      );
+
+      String criteriaStr = result.getCriteriaObject().toString();
+      assertThat(criteriaStr).contains("hgnc_symbol").contains("$in").contains("APOE");
+    }
+
+    @Test
+    @DisplayName("should use $nin for EXCLUDE mode with non-empty items")
+    void shouldUseNinForExcludeMode() {
+      TestRepo repo = new TestRepo();
+      TestQuery query = new TestQuery(List.of(), List.of());
+
+      CtFilterConfig<TestQuery> config = CtFilterConfig.<TestQuery>builder()
+        .simpleItemFilter("hgnc_symbol")
+        .searchFilter("name")
+        .build();
+
+      Criteria result = repo.buildCtMatchCriteria(
+        query,
+        List.of("APOE", "APP"),
+        false,
+        null,
+        config
+      );
+
+      String criteriaStr = result.getCriteriaObject().toString();
+      assertThat(criteriaStr).contains("hgnc_symbol").contains("$nin").contains("APOE");
+    }
+
+    @Test
+    @DisplayName("should add impossible condition for empty items in INCLUDE mode")
+    void shouldAddImpossibleConditionForEmptyInclude() {
+      TestRepo repo = new TestRepo();
+      TestQuery query = new TestQuery(List.of(), List.of());
+
+      CtFilterConfig<TestQuery> config = CtFilterConfig.<TestQuery>builder()
+        .simpleItemFilter("hgnc_symbol")
+        .searchFilter("name")
+        .build();
+
+      Criteria result = repo.buildCtMatchCriteria(query, List.of(), true, null, config);
+
+      String criteriaStr = result.getCriteriaObject().toString();
+      assertThat(criteriaStr).contains("_id").contains("null");
+    }
+
+    @Test
+    @DisplayName("should skip item filter for empty items in EXCLUDE mode")
+    void shouldSkipFilterForEmptyExclude() {
+      TestRepo repo = new TestRepo();
+      TestQuery query = new TestQuery(List.of(), List.of());
+
+      CtFilterConfig<TestQuery> config = CtFilterConfig.<TestQuery>builder()
+        .simpleItemFilter("hgnc_symbol")
+        .searchFilter("name")
+        .build();
+
+      Criteria result = repo.buildCtMatchCriteria(query, List.of(), false, null, config);
+
+      String criteriaStr = result.getCriteriaObject().toString();
+      assertThat(criteriaStr).doesNotContain("hgnc_symbol").doesNotContain("_id");
+    }
+  }
+
+  @Nested
+  @DisplayName("Composite item filter")
+  class CompositeItemFilter {
+
+    @Test
+    @DisplayName("should parse items and combine with $or for INCLUDE mode")
+    void shouldUseOrForIncludeMode() {
+      TestRepo repo = new TestRepo();
+      TestQuery query = new TestQuery(List.of(), List.of());
+
+      CtFilterConfig<TestQuery> config = CtFilterConfig.<TestQuery>builder()
+        .compositeItemFilter(item -> {
+          String[] parts = item.split("~");
+          return new Criteria()
+            .andOperator(
+              Criteria.where("field1").is(parts[0]),
+              Criteria.where("field2").is(parts[1])
+            );
+        })
+        .searchFilter("name")
+        .build();
+
+      Criteria result = repo.buildCtMatchCriteria(
+        query,
+        List.of("a~b", "c~d"),
+        true,
+        null,
+        config
+      );
+
+      String criteriaStr = result.getCriteriaObject().toString();
+      assertThat(criteriaStr).contains("$or").contains("field1").contains("field2");
+    }
+
+    @Test
+    @DisplayName("should parse items and combine with $nor for EXCLUDE mode")
+    void shouldUseNorForExcludeMode() {
+      TestRepo repo = new TestRepo();
+      TestQuery query = new TestQuery(List.of(), List.of());
+
+      CtFilterConfig<TestQuery> config = CtFilterConfig.<TestQuery>builder()
+        .compositeItemFilter(item -> {
+          String[] parts = item.split("~");
+          return new Criteria()
+            .andOperator(
+              Criteria.where("field1").is(parts[0]),
+              Criteria.where("field2").is(parts[1])
+            );
+        })
+        .searchFilter("name")
+        .build();
+
+      Criteria result = repo.buildCtMatchCriteria(
+        query,
+        List.of("a~b", "c~d"),
+        false,
+        null,
+        config
+      );
+
+      String criteriaStr = result.getCriteriaObject().toString();
+      assertThat(criteriaStr).contains("$nor").contains("field1").contains("field2");
+    }
+  }
+
+  @Nested
+  @DisplayName("Search filter")
+  class SearchFilter {
+
+    @Test
+    @DisplayName("should skip search in INCLUDE mode")
+    void shouldSkipSearchInIncludeMode() {
+      TestRepo repo = new TestRepo();
+      TestQuery query = new TestQuery(List.of(), List.of());
+
+      CtFilterConfig<TestQuery> config = CtFilterConfig.<TestQuery>builder()
+        .simpleItemFilter("id")
+        .searchFilter("name")
+        .build();
+
+      Criteria result = repo.buildCtMatchCriteria(query, List.of(), true, "test", config);
+
+      String criteriaStr = result.getCriteriaObject().toString();
+      assertThat(criteriaStr).doesNotContain("name").doesNotContain("test");
+    }
+
+    @Test
+    @DisplayName("should use regex for single term search in EXCLUDE mode")
+    void shouldUseRegexForSingleTermSearch() {
+      TestRepo repo = new TestRepo();
+      TestQuery query = new TestQuery(List.of(), List.of());
+
+      CtFilterConfig<TestQuery> config = CtFilterConfig.<TestQuery>builder()
+        .simpleItemFilter("id")
+        .searchFilter("name")
+        .build();
+
+      Criteria result = repo.buildCtMatchCriteria(query, List.of(), false, "test", config);
+
+      String criteriaStr = result.getCriteriaObject().toString();
+      // The Criteria contains "name" field with regex matching
+      assertThat(criteriaStr).contains("name");
+      assertThat(criteriaStr).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("should use exact match patterns for comma-separated search")
+    void shouldUseExactMatchForCommaSeparatedSearch() {
+      TestRepo repo = new TestRepo();
+      TestQuery query = new TestQuery(List.of(), List.of());
+
+      CtFilterConfig<TestQuery> config = CtFilterConfig.<TestQuery>builder()
+        .simpleItemFilter("id")
+        .searchFilter("name")
+        .build();
+
+      Criteria result = repo.buildCtMatchCriteria(query, List.of(), false, "a,b,c", config);
+
+      String criteriaStr = result.getCriteriaObject().toString();
+      assertThat(criteriaStr).contains("name").contains("$in");
+    }
+
+    @Test
+    @DisplayName("should skip search when search string is null or blank")
+    void shouldSkipBlankSearch() {
+      TestRepo repo = new TestRepo();
+      TestQuery query = new TestQuery(List.of(), List.of());
+
+      CtFilterConfig<TestQuery> config = CtFilterConfig.<TestQuery>builder()
+        .simpleItemFilter("id")
+        .searchFilter("name")
+        .build();
+
+      Criteria result1 = repo.buildCtMatchCriteria(query, List.of(), false, null, config);
+      Criteria result2 = repo.buildCtMatchCriteria(query, List.of(), false, "  ", config);
+
+      assertThat(result1.getCriteriaObject().toString()).doesNotContain("name");
+      assertThat(result2.getCriteriaObject().toString()).doesNotContain("name");
+    }
+  }
+
+  @Nested
+  @DisplayName("Empty criteria")
+  class EmptyCriteria {
+
+    @Test
+    @DisplayName("should return match-all criteria when no filters are active")
+    void shouldReturnMatchAllWhenNoFiltersActive() {
+      TestRepo repo = new TestRepo();
+      TestQuery query = new TestQuery(null, null);
+
+      CtFilterConfig<TestQuery> config = CtFilterConfig.<TestQuery>builder()
+        .dataFilter("field1", TestQuery::getField1)
+        .simpleItemFilter("id")
+        .searchFilter("name")
+        .build();
+
+      // No data filters, no items (EXCLUDE), no search — allCriteria would be empty
+      Criteria result = repo.buildCtMatchCriteria(query, List.of(), false, null, config);
+
+      // Empty Criteria produces {} which matches all documents (no $and with empty array)
+      assertThat(result.getCriteriaObject().isEmpty()).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("Base criteria")
+  class BaseCriteria {
+
+    @Test
+    @DisplayName("should include all base criteria in result")
+    void shouldIncludeBaseCriteria() {
+      TestRepo repo = new TestRepo();
+      TestQuery query = new TestQuery(List.of(), List.of());
+
+      CtFilterConfig<TestQuery> config = CtFilterConfig.<TestQuery>builder()
+        .simpleItemFilter("id")
+        .searchFilter("name")
+        .build();
+
+      Criteria result = repo.buildCtMatchCriteria(
+        query,
+        List.of(),
+        false,
+        null,
+        config,
+        Criteria.where("cluster").is("c1"),
+        Criteria.where("tissue").is("brain")
+      );
+
+      String criteriaStr = result.getCriteriaObject().toString();
+      assertThat(criteriaStr).contains("cluster").contains("c1").contains("tissue").contains("brain");
+    }
+  }
+
+  /** Test query DTO. */
+  @Data
+  @AllArgsConstructor
+  private static class TestQuery {
+
+    List<String> field1;
+    List<String> field2;
+  }
+
+  /** Minimal test repository. */
+  private static class TestRepo extends ComparisonToolRepositorySupport<Object> {
+
+    TestRepo() {
+      super(null);
+    }
+
+    @Override
+    protected String getCollectionName() {
+      return "test";
+    }
+
+    @Override
+    protected Class<Object> getDocumentClass() {
+      return Object.class;
+    }
+
+    // Expose protected method for testing
+    @Override
+    public <Q> Criteria buildCtMatchCriteria(
+      Q query,
+      List<String> items,
+      boolean isInclude,
+      String search,
+      CtFilterConfig<Q> config,
+      Criteria... baseCriteria
+    ) {
+      return super.buildCtMatchCriteria(query, items, isInclude, search, config, baseCriteria);
+    }
+  }
+}

--- a/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupportTest.java
+++ b/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupportTest.java
@@ -96,9 +96,9 @@ class ComparisonToolRepositorySupportTest {
   }
 
   @Test
-  @DisplayName("should add extra sort field computations before the standard computed-sort step")
-  void shouldAddExtraSortFieldComputations() {
-    ExtraComputationRepo repo = new ExtraComputationRepo(mongoTemplate);
+  @DisplayName("should add prerequisites before computed-sort step when using ComputedSortField")
+  void shouldAddPrerequisitesForComputedSortFields() {
+    PrerequisiteRepo repo = new PrerequisiteRepo(mongoTemplate);
     stubMongoTemplate(0L);
 
     Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Order.asc("gene_symbol")));
@@ -212,8 +212,8 @@ class ComparisonToolRepositorySupportTest {
     }
 
     @Override
-    protected Map<String, Object> getComputedSortFieldExpressions() {
-      return Map.of("name", toLowerExpr("name"));
+    protected Map<String, ComputedSortField> getComputedSortFieldExpressions() {
+      return Map.of("name", ComputedSortField.of(toLowerExpr("name")));
     }
 
     Page<TestDocument> run(Criteria criteria, Pageable pageable) {
@@ -221,11 +221,11 @@ class ComparisonToolRepositorySupportTest {
     }
   }
 
-  /** Subclass that exercises {@link #getExtraSortFieldComputations(Sort)}. */
-  private static final class ExtraComputationRepo
+  /** Subclass that exercises {@link ComputedSortField} with prerequisites. */
+  private static final class PrerequisiteRepo
     extends ComparisonToolRepositorySupport<TestDocument> {
 
-    ExtraComputationRepo(MongoTemplate mongoTemplate) {
+    PrerequisiteRepo(MongoTemplate mongoTemplate) {
       super(mongoTemplate);
     }
 
@@ -240,16 +240,7 @@ class ComparisonToolRepositorySupportTest {
     }
 
     @Override
-    protected Map<String, Object> getComputedSortFieldExpressions() {
-      return Map.of("gene_symbol", toLowerExpr("display_gene_symbol"));
-    }
-
-    @Override
-    protected List<AggregationOperation> getExtraSortFieldComputations(Sort sort) {
-      boolean sortsByGeneSymbol = sort.stream().anyMatch(o -> "gene_symbol".equals(o.getProperty()));
-      if (!sortsByGeneSymbol) {
-        return List.of();
-      }
+    protected Map<String, ComputedSortField> getComputedSortFieldExpressions() {
       java.util.List<Object> eqArgs = new java.util.ArrayList<>();
       eqArgs.add("$gene_symbol");
       eqArgs.add(null);
@@ -261,7 +252,12 @@ class ComparisonToolRepositorySupportTest {
         "$addFields",
         new Document("display_gene_symbol", new Document("$cond", condArgs))
       );
-      return List.of(context -> addFields);
+      AggregationOperation prereq = context -> addFields;
+
+      return Map.of(
+        "gene_symbol",
+        ComputedSortField.of(toLowerExpr("display_gene_symbol")).withPrerequisite(prereq)
+      );
     }
 
     Page<TestDocument> run(Criteria criteria, Pageable pageable) {

--- a/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupportTest.java
+++ b/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupportTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.explorers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -115,6 +116,16 @@ class ComparisonToolRepositorySupportTest {
   }
 
   @Test
+  @DisplayName("should throw UnsupportedOperationException when getFilterConfig is not overridden")
+  void shouldThrowWhenGetFilterConfigNotOverridden() {
+    BareRepo repo = new BareRepo(mongoTemplate);
+
+    assertThatThrownBy(repo::getFilterConfig)
+      .isInstanceOf(UnsupportedOperationException.class)
+      .hasMessageContaining("getFilterConfig");
+  }
+
+  @Test
   @DisplayName("should count using mongoTemplate.count, not aggregation")
   void shouldCountWithoutAggregation() {
     BareRepo repo = new BareRepo(mongoTemplate);
@@ -164,6 +175,12 @@ class ComparisonToolRepositorySupportTest {
 
     Page<TestDocument> run(Criteria criteria, Pageable pageable) {
       return executePagedAggregation(criteria, pageable);
+    }
+
+    // expose for testing
+    @Override
+    public <Q> CtFilterConfig<Q> getFilterConfig() {
+      return super.getFilterConfig();
     }
   }
 

--- a/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/CtFilterConfigTest.java
+++ b/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/CtFilterConfigTest.java
@@ -1,0 +1,33 @@
+package org.sagebionetworks.explorers;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CtFilterConfigTest {
+
+  @Test
+  @DisplayName("should throw IllegalStateException when itemFilter is not set")
+  void shouldThrowWhenItemFilterNotSet() {
+    assertThatThrownBy(() ->
+      CtFilterConfig.builder()
+        .searchFilter("name")
+        .build()
+    )
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("itemFilter must be set");
+  }
+
+  @Test
+  @DisplayName("should throw IllegalStateException when searchFilter is not set")
+  void shouldThrowWhenSearchFilterNotSet() {
+    assertThatThrownBy(() ->
+      CtFilterConfig.builder()
+        .simpleItemFilter("id")
+        .build()
+    )
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("searchFilter must be set");
+  }
+}


### PR DESCRIPTION
## Description

Centralizes duplicated filter logic from 5 comparison-tool repositories into a declarative `CtFilterConfig` system. Also eliminates implicit coupling in computed-sort prerequisites by bundling them with sort expressions.

## Related Issue

- [AG-2108](https://sagebionetworks.jira.com/browse/AG-2108)

## Changelog

- Add `CtFilterConfig` for declarative filter specification
- Add `ComputedSortField` to bundle sort expressions with prerequisites
- Add `buildCtMatchCriteria()` helper to centralize filter logic
- Migrate all 5 CT repositories to use declarative config

## Testing

- Test disease correlation CT filters in Model-AD (apply data filters, item INCLUDE/EXCLUDE, search)
- Verify differential expression search in Model-AD still falls back to `ensembl_gene_id` when `gene_symbol` is null/empty
- Test nominated-targets CT filters in Agora (apply data filters, simple item filter, search)
- Spot-check that filter results match before/after migration

## Preview

`model-ad-build-images && model-ad-docker-start`

In Differential Expression CT, search for "ens". See matches by `gene_symbol` ("Ensa") and by `ensembl_gene_id` ("ENSMUSG...").:

Apply filters: 
  - Type: Late Onset AD
  - Model: APOE4, Trem2R47H
Confirm results match dev.

dev | pr
:---: | :---:
<img width="2074" height="1345" alt="image" src="https://github.com/user-attachments/assets/98658787-315a-4384-97e1-8ec78a63c1c5" /> | <img width="2074" height="1345" alt="image" src="https://github.com/user-attachments/assets/db6a2979-7189-43d4-a53f-837203f0e954" />

In Disease Correlation CT, pin APOE4~4 months~Female. Search for "oad". Filter to Age: 8 months, 12 months. Sex: Male. Confirm results match dev.

dev | pr 
:---: | :---: 
<img width="2088" height="1455" alt="image" src="https://github.com/user-attachments/assets/c5a999a5-e8dc-4c2e-850f-ed21e15f4b31" /> | <img width="2089" height="1470" alt="image" src="https://github.com/user-attachments/assets/80ba7b57-48d4-4964-ba55-77c462937647" />

[AG-2108]: https://sagebionetworks.jira.com/browse/AG-2108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ