### PR TITLE
fix(sage-monorepo): configure allowedHosts for SSR CommonEngine (AG-2113)

### DIFF
--- a/apps/agora/app/server.ts
+++ b/apps/agora/app/server.ts
@@ -12,7 +12,9 @@ export function app(): express.Express {
   const browserDistFolder = resolve(serverDistFolder, '../browser');
   const indexHtml = join(serverDistFolder, 'index.server.html');
 
-  const commonEngine = new CommonEngine();
+  const commonEngine = new CommonEngine({
+    allowedHosts: ['*'],
+  });
 
   server.set('view engine', 'html');
   server.set('views', browserDistFolder);

--- a/apps/agora/app/server.ts
+++ b/apps/agora/app/server.ts
@@ -13,7 +13,7 @@ export function app(): express.Express {
   const indexHtml = join(serverDistFolder, 'index.server.html');
 
   const commonEngine = new CommonEngine({
-    allowedHosts: ['*'],
+    allowedHosts: ['localhost', '*.adknowledgeportal.org'],
   });
 
   server.set('view engine', 'html');

--- a/apps/bixarena/app/server.ts
+++ b/apps/bixarena/app/server.ts
@@ -11,7 +11,9 @@ export function app(): express.Express {
   const browserDistFolder = resolve(serverDistFolder, '../browser');
   const indexHtml = join(serverDistFolder, 'index.server.html');
 
-  const commonEngine = new CommonEngine();
+  const commonEngine = new CommonEngine({
+    allowedHosts: ['*'],
+  });
 
   server.set('view engine', 'html');
   server.set('views', browserDistFolder);

--- a/apps/bixarena/app/server.ts
+++ b/apps/bixarena/app/server.ts
@@ -12,7 +12,7 @@ export function app(): express.Express {
   const indexHtml = join(serverDistFolder, 'index.server.html');
 
   const commonEngine = new CommonEngine({
-    allowedHosts: ['*'],
+    allowedHosts: ['localhost', '*.bioarena.io', 'bioarena.io', '*.elb.amazonaws.com'],
   });
 
   server.set('view engine', 'html');

--- a/apps/model-ad/app/server.ts
+++ b/apps/model-ad/app/server.ts
@@ -12,7 +12,9 @@ export function app(): express.Express {
   const browserDistFolder = resolve(serverDistFolder, '../browser');
   const indexHtml = join(serverDistFolder, 'index.server.html');
 
-  const commonEngine = new CommonEngine();
+  const commonEngine = new CommonEngine({
+    allowedHosts: ['*'],
+  });
 
   server.set('view engine', 'html');
   server.set('views', browserDistFolder);

--- a/apps/model-ad/app/server.ts
+++ b/apps/model-ad/app/server.ts
@@ -13,7 +13,7 @@ export function app(): express.Express {
   const indexHtml = join(serverDistFolder, 'index.server.html');
 
   const commonEngine = new CommonEngine({
-    allowedHosts: ['*'],
+    allowedHosts: ['localhost', '*.modeladexplorer.org', 'modeladexplorer.org'],
   });
 
   server.set('view engine', 'html');

--- a/apps/qtl/app/server.ts
+++ b/apps/qtl/app/server.ts
@@ -13,7 +13,7 @@ export function app(): express.Express {
   const indexHtml = join(serverDistFolder, 'index.server.html');
 
   const commonEngine = new CommonEngine({
-    allowedHosts: ['*'],
+    allowedHosts: ['localhost'],
   });
 
   server.set('view engine', 'html');

--- a/apps/qtl/app/server.ts
+++ b/apps/qtl/app/server.ts
@@ -12,7 +12,9 @@ export function app(): express.Express {
   const browserDistFolder = resolve(serverDistFolder, '../browser');
   const indexHtml = join(serverDistFolder, 'index.server.html');
 
-  const commonEngine = new CommonEngine();
+  const commonEngine = new CommonEngine({
+    allowedHosts: ['*'],
+  });
 
   server.set('view engine', 'html');
   server.set('views', browserDistFolder);

--- a/apps/qtl/app/server.ts
+++ b/apps/qtl/app/server.ts
@@ -13,7 +13,7 @@ export function app(): express.Express {
   const indexHtml = join(serverDistFolder, 'index.server.html');
 
   const commonEngine = new CommonEngine({
-    allowedHosts: ['localhost'],
+    allowedHosts: ['localhost', '*.adknowledgeportal.org'],
   });
 
   server.set('view engine', 'html');


### PR DESCRIPTION
## Description

Configures explicit `allowedHosts` on `CommonEngine` to restore SSR on deployed environments after the `@angular/ssr` 20.3.17 bump broke it. The `'*'` wildcard is not supported in 20.3.x (only Angular 21+), so explicit subdomain patterns are used instead.

## Related Issue

- [AG-2113](https://sagebionetworks.jira.com/browse/AG-2113)

## Changelog

- Configure explicit `allowedHosts` on `CommonEngine` in all 4 Angular SSR apps (agora, model-ad, bixarena, qtl)

## Testing

- After merge, verify agora-dev SSR is working: open https://agora-dev.adknowledgeportal.org and confirm the browser console shows `[ConfigLoader] Using configuration transferred from server` (not `No transferred state found, loading from YAML files`)
- Confirm no CORS errors in the browser console when loading the page
- Repeat for dev.modeladexplorer.org


[AG-2113]: https://sagebionetworks.jira.com/browse/AG-2113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ