### PR TITLE
feat(explorers): sort empty/null CT rows to end; fix heatmap and array sorts; add CT repository skill (AG-2087, MG-923, MG-924)

### DIFF
--- a/.claude/rules/ct-repository.md
+++ b/.claude/rules/ct-repository.md
@@ -1,0 +1,270 @@
+# Comparison Tool Repository Pattern
+
+This rule covers every task that touches a `ComparisonToolRepositorySupport` subclass: creating a new CT repository, adding or debugging a sort column, reviewing an implementation, or understanding why rows are ordered unexpectedly.
+
+## What is a CT repository?
+
+Every CT table is backed by a MongoDB aggregation pipeline assembled by `ComparisonToolRepositorySupport<T>` (`libs/explorers/api-helper/`). Each product (Agora, Model-AD) has one or more concrete subclasses -- one per CT collection. The base class owns the pipeline shape; subclasses configure it by overriding a small set of hooks.
+
+## Minimal subclass skeleton
+
+Every CT repository follows this structure. Fill in the product-specific parts:
+
+```java
+@Repository
+@Slf4j
+public class CustomMyThingRepositoryImpl
+  extends ComparisonToolRepositorySupport<MyThingDocument>
+  implements CustomMyThingRepository {
+
+  private static final String COLLECTION_NAME = "my_collection";
+
+  public CustomMyThingRepositoryImpl(MongoTemplate mongoTemplate) {
+    super(mongoTemplate);
+  }
+
+  @Override
+  protected String getCollectionName() {
+    return COLLECTION_NAME;
+  }
+
+  @Override
+  protected Class<MyThingDocument> getDocumentClass() {
+    return MyThingDocument.class;
+  }
+
+  // --- sort hooks (override only what's needed) ---
+
+  // --- filter config ---
+
+  private final CtFilterConfig<MyThingSearchQueryDto> filterConfig = CtFilterConfig.<
+    MyThingSearchQueryDto
+  >builder()
+    .dataFilter("some_field", MyThingSearchQueryDto::getSomeField)
+    .simpleItemFilter("name")
+    .searchFilter("name")
+    .build();
+
+  @Override
+  protected CtFilterConfig<MyThingSearchQueryDto> getFilterConfig() {
+    return filterConfig;
+  }
+
+  // --- findAll (signature matches the custom interface) ---
+
+  @Override
+  public Page<MyThingDocument> findAll(
+    Pageable pageable,
+    MyThingSearchQueryDto query,
+    List<String> items
+  ) {
+    ItemFilterTypeQueryDto filterType = Objects.requireNonNullElse(
+      query.getItemFilterType(),
+      ItemFilterTypeQueryDto.INCLUDE // always default to INCLUDE if null
+    );
+    boolean isInclude = filterType == ItemFilterTypeQueryDto.INCLUDE;
+    Criteria matchCriteria = buildCtMatchCriteria(
+      query,
+      items,
+      isInclude,
+      query.getSearch(),
+      getFilterConfig()
+      // add Criteria.where(...).is(...) varargs here if the collection needs base scoping
+    );
+    return executePagedAggregation(matchCriteria, pageable);
+  }
+}
+
+```
+
+Key points:
+
+- `@Repository @Slf4j` on the class; constructor takes only `MongoTemplate`.
+- Always `Objects.requireNonNullElse(query.getItemFilterType(), ItemFilterTypeQueryDto.INCLUDE)` -- the frontend may send null and the base class does not default it.
+- `findAll` signature is defined by the custom interface, not the base class -- add product-specific parameters (tissue, cluster, etc.) there and pass them as base criteria varargs.
+
+## Pipeline shape
+
+The base class assembles this pipeline on every paged request:
+
+```
+$match          ← assembled from getFilterConfig() + optional base criteria
+[$addFields]    ← prerequisites for computed sort fields (when needed)
+[$addFields]    ← computed sort fields from getComputedSortFieldExpressions()
+[$addFields]    ← isEmpty flags (null/empty rows → tail), always present when sorted
+$sort           ← field names resolved via aliases and computed fields
+$skip / $limit
+```
+
+Stages in brackets are omitted when not needed (e.g. no computed sort field requested, or sort is unsorted). The `allowDiskUse: true` option is set on every CT aggregation.
+
+## Hooks to override
+
+### Required
+
+| Method                | What it returns                       | When to override |
+| --------------------- | ------------------------------------- | ---------------- |
+| `getCollectionName()` | MongoDB collection name string        | Always           |
+| `getDocumentClass()`  | Java POJO class                       | Always           |
+| `getFilterConfig()`   | `CtFilterConfig<Q>` built via builder | Always           |
+
+### Sort configuration
+
+| Method                              | What it returns                            | When to override                                                           |
+| ----------------------------------- | ------------------------------------------ | -------------------------------------------------------------------------- |
+| `getComputedSortFieldExpressions()` | `Map<String, ComputedSortField>`           | String columns (case-insensitive), array columns, computed/fallback fields |
+| `getSortFieldAliases()`             | `Map<String, String>` field → aliased path | Nested object columns, companion numeric fields                            |
+
+### Optional
+
+| Method                                      | When to override                                          |
+| ------------------------------------------- | --------------------------------------------------------- |
+| `buildSearchCriteria(field, trimmedSearch)` | Custom search logic (e.g. fallback field, multi-field OR) |
+
+---
+
+## Sort column patterns
+
+Choose the right hook for each column type. Using the wrong hook produces silent misbehavior (sort operates on the wrong value, or null/empty rows float to the top).
+
+### 1. Plain scalar string column
+
+Use `getComputedSortFieldExpressions()` with `toLowerExpr()` for case-insensitive sort. Dot-path notation works for nested fields:
+
+```java
+"model_type", ComputedSortField.of(toLowerExpr("model_type")),
+"name",       ComputedSortField.of(toLowerExpr("name.link_text"))  // nested child field
+```
+
+### 2. Array column
+
+Use `getComputedSortFieldExpressions()` with `arrayToLoweredStringExpr()`. This reduces the array to a NUL-separated lowercase string so `$sort` produces a stable, human-readable order. Do NOT use `getSortFieldAliases()` for array fields.
+
+```java
+"nominating_teams", ComputedSortField.of(arrayToLoweredStringExpr("nominating_teams"))
+```
+
+### 3. Nested object column (heatmap cell, time-point bucket)
+
+Use `getSortFieldAliases()` to redirect `$sort` to the numeric sub-field. Without the alias, `$sort` operates on the full object and produces undefined ordering.
+
+The alias must match a scalar sub-field, not a nested object. These keys **must stay in sync with the document schema** -- if a new object-valued column is added to the OpenAPI spec and document class, add the corresponding alias here.
+
+```java
+// DiseaseCorrelation: each brain region is { correlation, adj_p_val }
+Map.entry("CBE",  "CBE.correlation"),
+Map.entry("DLPFC","DLPFC.correlation"),
+...
+
+// Transcriptomics: each time-point is { log2_fc, adj_p_val }
+"4 months",  "4 months.log2_fc",
+"12 months", "12 months.log2_fc",
+```
+
+### 4. Companion numeric field
+
+Use `getSortFieldAliases()` to redirect from the display field to its numeric counterpart.
+
+```java
+"age", "age_numeric"
+```
+
+### 5. Computed fallback field
+
+Use `getComputedSortFieldExpressions()` with a prerequisite `$addFields` stage that computes the value before sort. Wire the prerequisite via `ComputedSortField.of(...).withPrerequisite(op)`.
+
+Also add the field to `getSortFieldAliases()` so the isEmpty flag checks the computed value (not the raw field). Without the alias, rows with a blank primary field but a populated fallback would incorrectly sort to the tail.
+
+```java
+// In getComputedSortFieldExpressions():
+GENE_SYMBOL_FIELD,
+ComputedSortField.of(toLowerExpr(DISPLAY_GENE_SYMBOL_FIELD))
+  .withPrerequisite(buildDisplayGeneSymbolField())
+
+// In getSortFieldAliases():
+GENE_SYMBOL_FIELD, DISPLAY_GENE_SYMBOL_FIELD
+```
+
+---
+
+## Overriding search: buildSearchCriteria
+
+The default search (driven by `searchFilter` in `CtFilterConfig`) supports two modes: comma-separated exact match (case-insensitive) and single-term partial regex. Override `buildSearchCriteria(String field, String trimmedSearch)` when that isn't enough.
+
+**Critical constraint:** the count query uses `mongoTemplate.count()`, which does NOT run the aggregation pipeline. Computed `$addFields` values (like `display_gene_symbol`) are unavailable in the count query. Any override must replicate fallback logic using raw document fields only:
+
+```java
+@Override
+protected Criteria buildSearchCriteria(String field, String trimmedSearch) {
+  // Can't use display_gene_symbol here -- count query bypasses the pipeline.
+  // Instead, match gene_symbol directly OR (gene_symbol blank AND ensembl_gene_id matches).
+  Criteria geneSymbolBlank = new Criteria()
+    .orOperator(
+      Criteria.where(GENE_SYMBOL_FIELD).is(null),
+      Criteria.where(GENE_SYMBOL_FIELD).is(""),
+      Criteria.where(GENE_SYMBOL_FIELD).regex("^\\s*$")
+    );
+  // ... build match branches and combine with orOperator
+}
+
+```
+
+---
+
+## Spaced field names
+
+MongoDB's `"$field"` expression syntax silently fails for field names that contain spaces (e.g. `"4 months"`). `ApiHelper.buildIsEmptyExpr()` detects spaces and uses `$getField` + `$let` automatically. No special handling is needed in the subclass, but be aware:
+
+- **Spaced path, one dot** (`"4 months.log2_fc"`) -- supported.
+- **Spaced path, two or more dots** -- throws `IllegalArgumentException` at runtime. Use an alias to a single-dot path instead.
+- **Space in `$addFields` key** -- unreliable in DocumentDB. `isEmptyFlagKey()` normalises spaces to underscores automatically.
+
+---
+
+## CtFilterConfig builder
+
+```java
+CtFilterConfig.<MyQueryDto>builder()
+  .dataFilter("mongo_field", MyQueryDto::getField)   // multi-value $in/$nin filter
+  .simpleItemFilter("name")                           // single-field item include/exclude
+  .compositeItemFilter(s -> MyIdentifier.parse(s).toCriteria()) // multi-field item filter
+  .searchFilter("search_field")                       // free-text search
+  .build();
+```
+
+- Use `simpleItemFilter` when each item string _is_ the field value (e.g. item `"APOE"` matches `name = "APOE"` directly).
+- Use `compositeItemFilter` when each item string is a compound key encoding multiple fields (e.g. `"APOE~Hippocampus~Female"` needs to be split and matched across `gene`, `tissue`, `sex`). Parse it with an identifier DTO whose `toCriteria()` returns an AND-clause; the base class combines them with `$or` / `$nor` for include/exclude.
+- `searchFilter` drives `buildSearchCriteria()`; override that method if the default (comma-separated exact match OR single-term partial regex) is insufficient.
+
+---
+
+## Base criteria injection
+
+When the collection is always scoped by a request parameter (cluster, tissue, sex_cohort), pass the mandatory `Criteria` objects as varargs at the end of `buildCtMatchCriteria()`:
+
+```java
+Criteria matchCriteria = buildCtMatchCriteria(
+  query,
+  items,
+  isInclude,
+  query.getSearch(),
+  getFilterConfig(),
+  Criteria.where("tissue").is(tissue),
+  Criteria.where("sex_cohort").is(sexCohort)
+);
+
+```
+
+---
+
+## Existing implementations (reference)
+
+| App      | Class                                    | Collection            | Notable                                                                                                          |
+| -------- | ---------------------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Agora    | `CustomNominatedTargetRepositoryImpl`    | `nominatedtargets`    | 4 array columns, simple item filter                                                                              |
+| Agora    | `CustomNominatedDrugRepositoryImpl`      | `nominateddrugs`      | 2 array columns, composite item filter                                                                           |
+| Model-AD | `CustomModelOverviewRepositoryImpl`      | `model_overview`      | 1 array column                                                                                                   |
+| Model-AD | `CustomDiseaseCorrelationRepositoryImpl` | `disease_correlation` | Nested object columns (brain regions), companion numeric field, base criteria (cluster)                          |
+| Model-AD | `CustomTranscriptomicsRepositoryImpl`    | `rna_de_aggregate`    | Nested object columns (time-points), computed fallback field, custom search, base criteria (tissue + sex_cohort) |
+
+All implementations are under `apps/<product>/api-next/src/main/java/.../model/repository/`.

--- a/.claude/skills/ct-repository/SKILL.md
+++ b/.claude/skills/ct-repository/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: ct-repository
+description: >
+  Reference guide for implementing and configuring Comparison Tool (CT) repository classes
+  that extend ComparisonToolRepositorySupport. Use this skill whenever the user is: creating
+  a new CT repository, adding a sort column to an existing CT, debugging unexpected sort order
+  (null rows floating up, wrong column ordering), configuring filters or search for a CT,
+  reviewing a CT repository implementation, or asking how to wire up any part of the CT
+  backend pipeline (sort hooks, filter config, base criteria, spaced field names, heatmap
+  columns, array columns, computed/fallback fields). Trigger phrases include "new CT",
+  "comparison tool", "CT repository", "CT sort", "null rows", "empty rows", "sort order",
+  "heatmap column sort", "array column sort", "getComputedSortFieldExpressions",
+  "getSortFieldAliases", "ComparisonToolRepositorySupport", "CtFilterConfig".
+---
+
+Read and apply the rule at [`.claude/rules/ct-repository.md`](../../rules/ct-repository.md). If that path isn't found, search for `ct-repository.md` under `.claude/rules/` from the repo root.
+
+That rule is the single source of truth for the CT repository pattern. It covers:
+
+- The full pipeline shape and which stages are optional
+- All five sort column patterns (scalar string, array, nested object, companion numeric, computed fallback) and which hook to use for each
+- Spaced field name constraints and what `ApiHelper` handles automatically
+- `CtFilterConfig` builder reference (dataFilter, simpleItemFilter, compositeItemFilter, searchFilter)
+- Base criteria injection for collection-scoped queries
+- A reference table of all existing implementations to use as examples

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomDiseaseCorrelationRepositoryImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomDiseaseCorrelationRepositoryImpl.java
@@ -68,12 +68,22 @@ public class CustomDiseaseCorrelationRepositoryImpl
   }
 
   /**
-   * Map {@code age} (a string column) to the numeric companion field so sorts are numeric
-   * instead of lexicographic.
+   * Maps {@code age} to its numeric companion field, and each heatmap column to its nested
+   * {@code correlation} value. Without the heatmap aliases, {@code $sort} operates on the
+   * full object ({@code { correlation, adj_p_val }}) and produces undefined ordering.
    */
   @Override
   protected Map<String, String> getSortFieldAliases() {
-    return Map.of("age", "age_numeric");
+    return Map.ofEntries(
+      Map.entry("age", "age_numeric"),
+      Map.entry("CBE", "CBE.correlation"),
+      Map.entry("DLPFC", "DLPFC.correlation"),
+      Map.entry("FP", "FP.correlation"),
+      Map.entry("IFG", "IFG.correlation"),
+      Map.entry("PHG", "PHG.correlation"),
+      Map.entry("STG", "STG.correlation"),
+      Map.entry("TCX", "TCX.correlation")
+    );
   }
 
   private final CtFilterConfig<DiseaseCorrelationSearchQueryDto> filterConfig =

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomDiseaseCorrelationRepositoryImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomDiseaseCorrelationRepositoryImpl.java
@@ -68,9 +68,9 @@ public class CustomDiseaseCorrelationRepositoryImpl
   }
 
   /**
-   * Maps {@code age} to its numeric companion field, and each heatmap column to its nested
-   * {@code correlation} value. Without the heatmap aliases, {@code $sort} operates on the
-   * full object ({@code { correlation, adj_p_val }}) and produces undefined ordering.
+   * Maps {@code age} to its numeric companion field, and each brain-region heatmap column to its
+   * nested {@code correlation} value ({@code { correlation, adj_p_val }}). Keys must stay in sync
+   * with the {@link DiseaseCorrelationDocument} heatmap fields.
    */
   @Override
   protected Map<String, String> getSortFieldAliases() {

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomModelOverviewRepositoryImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomModelOverviewRepositoryImpl.java
@@ -1,9 +1,11 @@
 package org.sagebionetworks.model.ad.api.next.model.repository;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.sagebionetworks.explorers.ComparisonToolRepositorySupport;
+import org.sagebionetworks.explorers.ComputedSortField;
 import org.sagebionetworks.explorers.CtFilterConfig;
 import org.sagebionetworks.model.ad.api.next.model.document.ModelOverviewDocument;
 import org.sagebionetworks.model.ad.api.next.model.dto.ItemFilterTypeQueryDto;
@@ -43,15 +45,24 @@ public class CustomModelOverviewRepositoryImpl
     return ModelOverviewDocument.class;
   }
 
-  private final CtFilterConfig<ModelOverviewSearchQueryDto> filterConfig =
-    CtFilterConfig.<ModelOverviewSearchQueryDto>builder()
-      .dataFilter("available_data", ModelOverviewSearchQueryDto::getAvailableData)
-      .dataFilter("center", ModelOverviewSearchQueryDto::getCenter)
-      .dataFilter("model_type", ModelOverviewSearchQueryDto::getModelType)
-      .dataFilter("modified_genes", ModelOverviewSearchQueryDto::getModifiedGenes)
-      .simpleItemFilter("name")
-      .searchFilter("name")
-      .build();
+  @Override
+  protected Map<String, ComputedSortField> getComputedSortFieldExpressions() {
+    return Map.of(
+      "matched_controls",
+      ComputedSortField.of(arrayToLoweredStringExpr("matched_controls"))
+    );
+  }
+
+  private final CtFilterConfig<ModelOverviewSearchQueryDto> filterConfig = CtFilterConfig.<
+    ModelOverviewSearchQueryDto
+  >builder()
+    .dataFilter("available_data", ModelOverviewSearchQueryDto::getAvailableData)
+    .dataFilter("center", ModelOverviewSearchQueryDto::getCenter)
+    .dataFilter("model_type", ModelOverviewSearchQueryDto::getModelType)
+    .dataFilter("modified_genes", ModelOverviewSearchQueryDto::getModifiedGenes)
+    .simpleItemFilter("name")
+    .searchFilter("name")
+    .build();
 
   @Override
   protected CtFilterConfig<ModelOverviewSearchQueryDto> getFilterConfig() {

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomModelOverviewRepositoryImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomModelOverviewRepositoryImpl.java
@@ -19,9 +19,10 @@ import org.springframework.stereotype.Repository;
 /**
  * Custom repository implementation backed by the shared CT aggregation pipeline.
  *
- * <p>ModelOverview has no case-insensitive sort, sort-field aliases, or computed sort fields,
- * so it overrides only the two abstract collection/document hooks. The pipeline scaffold
- * (count, $match, $sort, $skip, $limit) lives in {@link ComparisonToolRepositorySupport}.
+ * <p>Uses aggregation to support sorting by array fields. MongoDB cannot sort by multiple
+ * array fields simultaneously ("parallel arrays"), so we compute scalar sort fields for
+ * lexicographic comparison. The pipeline scaffold (count, $match, $addFields, $sort, $skip,
+ * $limit) lives in {@link ComparisonToolRepositorySupport}.
  */
 @Repository
 @Slf4j

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
@@ -83,14 +83,31 @@ public class CustomTranscriptomicsRepositoryImpl
     );
   }
 
-  private final CtFilterConfig<TranscriptomicsSearchQueryDto> filterConfig =
-    CtFilterConfig.<TranscriptomicsSearchQueryDto>builder()
-      .dataFilter("biodomains", TranscriptomicsSearchQueryDto::getBiodomains)
-      .dataFilter("model_type", TranscriptomicsSearchQueryDto::getModelType)
-      .dataFilter("name.link_text", TranscriptomicsSearchQueryDto::getName)
-      .compositeItemFilter(item -> TranscriptomicsIdentifier.parse(item).toCriteria())
-      .searchFilter(GENE_SYMBOL_FIELD)
-      .build();
+  private final CtFilterConfig<TranscriptomicsSearchQueryDto> filterConfig = CtFilterConfig.<
+    TranscriptomicsSearchQueryDto
+  >builder()
+    .dataFilter("biodomains", TranscriptomicsSearchQueryDto::getBiodomains)
+    .dataFilter("model_type", TranscriptomicsSearchQueryDto::getModelType)
+    .dataFilter("name.link_text", TranscriptomicsSearchQueryDto::getName)
+    .compositeItemFilter(item -> TranscriptomicsIdentifier.parse(item).toCriteria())
+    .searchFilter(GENE_SYMBOL_FIELD)
+    .build();
+
+  /**
+   * Heatmap columns store nested objects ({@code { log2_fc, adj_p_val }}); alias each to
+   * the numeric sub-field so {@code $sort} operates on the actual fold-change value.
+   */
+  @Override
+  protected Map<String, String> getSortFieldAliases() {
+    return Map.of(
+      "4 months",
+      "4 months.log2_fc",
+      "12 months",
+      "12 months.log2_fc",
+      "18 months",
+      "18 months.log2_fc"
+    );
+  }
 
   @Override
   protected CtFilterConfig<TranscriptomicsSearchQueryDto> getFilterConfig() {

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
@@ -94,8 +94,9 @@ public class CustomTranscriptomicsRepositoryImpl
     .build();
 
   /**
-   * Heatmap columns store nested objects ({@code { log2_fc, adj_p_val }}); alias each to
-   * the numeric sub-field so {@code $sort} operates on the actual fold-change value.
+   * Maps each heatmap time-point column to its nested {@code log2_fc} value
+   * ({@code { log2_fc, adj_p_val }}). Keys must stay in sync with the
+   * {@link TranscriptomicsDocument} heatmap fields.
    *
    * <p>{@code gene_symbol} is aliased to {@code display_gene_symbol} so the isEmpty flag checks
    * the computed fallback value (gene_symbol ?? ensembl_gene_id) rather than the raw field.

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
@@ -96,10 +96,17 @@ public class CustomTranscriptomicsRepositoryImpl
   /**
    * Heatmap columns store nested objects ({@code { log2_fc, adj_p_val }}); alias each to
    * the numeric sub-field so {@code $sort} operates on the actual fold-change value.
+   *
+   * <p>{@code gene_symbol} is aliased to {@code display_gene_symbol} so the isEmpty flag checks
+   * the computed fallback value (gene_symbol ?? ensembl_gene_id) rather than the raw field.
+   * Without this, rows where {@code gene_symbol} is blank but {@code ensembl_gene_id} is populated
+   * would be treated as empty and incorrectly sorted to the tail.
    */
   @Override
   protected Map<String, String> getSortFieldAliases() {
     return Map.of(
+      GENE_SYMBOL_FIELD,
+      DISPLAY_GENE_SYMBOL_FIELD,
       "4 months",
       "4 months.log2_fc",
       "12 months",

--- a/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomDiseaseCorrelationRepositoryImplTest.java
+++ b/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomDiseaseCorrelationRepositoryImplTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.model.ad.api.next.model.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -192,5 +193,49 @@ class CustomDiseaseCorrelationRepositoryImplTest {
       aggregationString.contains("age_lower"),
       "Aggregation should not create age_lower field"
     );
+  }
+
+  @Test
+  @DisplayName("should sort by correlation sub-field when sorting by a heatmap module column")
+  void shouldSortByCorrelationWhenSortingByHeatmapColumn() {
+    DiseaseCorrelationSearchQueryDto query = new DiseaseCorrelationSearchQueryDto();
+    query.setItemFilterType(ItemFilterTypeQueryDto.EXCLUDE);
+
+    when(
+      mongoTemplate.aggregate(
+        any(Aggregation.class),
+        eq("disease_correlation"),
+        eq(DiseaseCorrelationDocument.class)
+      )
+    ).thenReturn(aggregationResults);
+    when(aggregationResults.getMappedResults()).thenReturn(List.of());
+
+    repository.findAll(
+      PageRequest.of(
+        0,
+        10,
+        org.springframework.data.domain.Sort.by(
+          org.springframework.data.domain.Sort.Order.asc("CBE")
+        )
+      ),
+      query,
+      List.of(),
+      "Immune System - Consensus Cluster B"
+    );
+
+    ArgumentCaptor<Aggregation> captor = ArgumentCaptor.forClass(Aggregation.class);
+    verify(mongoTemplate).aggregate(
+      captor.capture(),
+      eq("disease_correlation"),
+      eq(DiseaseCorrelationDocument.class)
+    );
+    String pipeline = captor.getValue().toString();
+
+    assertThat(pipeline)
+      .as("$sort should use the nested correlation path, not the raw object")
+      .contains("CBE.correlation");
+    assertThat(pipeline)
+      .as("$sort should not reference the raw CBE object directly as a sort key")
+      .doesNotContain("\"CBE\" :");
   }
 }

--- a/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomModelOverviewRepositoryImplTest.java
+++ b/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomModelOverviewRepositoryImplTest.java
@@ -19,6 +19,7 @@ import org.sagebionetworks.model.ad.api.next.model.dto.ItemFilterTypeQueryDto;
 import org.sagebionetworks.model.ad.api.next.model.dto.ModelOverviewSearchQueryDto;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
@@ -108,6 +109,37 @@ class CustomModelOverviewRepositoryImplTest {
     // Page 2 with size 25 → skip 50, limit 25
     assertThat(pipelineString).contains("$skip").contains("50");
     assertThat(pipelineString).contains("$limit").contains("25");
+  }
+
+  @Test
+  @DisplayName("should compute matched_controls_sort via $reduce when sorting by matched_controls")
+  void shouldComputeMatchedControlsSortWhenSortingByMatchedControls() {
+    ModelOverviewSearchQueryDto query = new ModelOverviewSearchQueryDto();
+    query.setItemFilterType(ItemFilterTypeQueryDto.EXCLUDE);
+
+    Pageable pageable = PageRequest.of(
+      0,
+      10,
+      Sort.by(Sort.Order.asc("matched_controls"))
+    );
+
+    repository.findAll(pageable, query, List.of());
+
+    ArgumentCaptor<Aggregation> aggregationCaptor = ArgumentCaptor.forClass(Aggregation.class);
+    verify(mongoTemplate).aggregate(
+      aggregationCaptor.capture(),
+      eq(COLLECTION_NAME),
+      eq(ModelOverviewDocument.class)
+    );
+
+    String pipelineString = aggregationCaptor.getValue().toString();
+    assertThat(pipelineString)
+      .as("Should compute a sort key via $reduce for matched_controls array")
+      .contains("matched_controls_sort")
+      .contains("$reduce");
+    assertThat(pipelineString)
+      .as("$sort should use the computed key, not the raw array field")
+      .contains("\"matched_controls_sort\" : 1");
   }
 
   @Test

--- a/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImplTest.java
+++ b/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImplTest.java
@@ -223,6 +223,30 @@ class CustomTranscriptomicsRepositoryImplTest {
     assertThat(pipeline).contains("\"gene_symbol_sort\" : 1");
   }
 
+  @Test
+  @DisplayName("should sort by log2_fc sub-field when sorting by a heatmap month column")
+  void shouldSortByLog2FcWhenSortingByMonthColumn() {
+    TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
+      .itemFilterType(ItemFilterTypeQueryDto.EXCLUDE)
+      .build();
+
+    repository.findAll(
+      PageRequest.of(0, 10, Sort.by(Sort.Order.asc("4 months"))),
+      query,
+      Collections.emptyList(),
+      "Hippocampus",
+      "Females & Males"
+    );
+
+    String pipeline = captureAggregation().toString();
+    assertThat(pipeline)
+      .as("$sort should use the nested log2_fc path, not the raw object")
+      .contains("4 months.log2_fc");
+    assertThat(pipeline)
+      .as("$sort should not reference the raw '4 months' object directly as a sort key")
+      .doesNotContain("\"4 months\" :");
+  }
+
   private Query captureCountQuery() {
     ArgumentCaptor<Query> captor = ArgumentCaptor.forClass(Query.class);
     verify(mongoTemplate).count(captor.capture(), eq(COLLECTION_NAME));

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ApiHelper.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ApiHelper.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.explorers;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -8,7 +9,9 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.lang.Nullable;
@@ -136,6 +139,66 @@ public final class ApiHelper {
     }
 
     return builder.toString();
+  }
+
+  /**
+   * Builds an {@code $addFields} stage that emits a {@code <field>_isEmpty} boolean for every sort
+   * order in {@code sort}. The flag is {@code true} when the field is {@code null} or an empty
+   * string, {@code false} otherwise.
+   *
+   * <p>Prepending {@code <field>_isEmpty: 1} to the {@code $sort} doc (always ascending) before the
+   * user's chosen sort key pushes empty/null rows to the tail regardless of the user's sort
+   * direction, while non-empty rows sort normally within themselves.
+   *
+   * @param sort the requested sort; if unsorted, returns {@code null}
+   * @return an {@code $addFields} {@link AggregationOperation}, or {@code null} when sort is empty
+   */
+  public static AggregationOperation buildEmptyFlagFields(Sort sort) {
+    if (sort.isUnsorted()) {
+      return null;
+    }
+
+    Document fields = new Document();
+    for (Sort.Order order : sort) {
+      String field = order.getProperty();
+
+      // null or missing -- ArrayList because List.of() prohibits null elements
+      List<Object> isNullArgs = new ArrayList<>(2);
+      isNullArgs.add("$" + field);
+      isNullArgs.add(null);
+
+      // empty string
+      List<Object> isEmptyStringArgs = List.of("$" + field, "");
+
+      // empty array: $cond guards with $isArray so non-array fields return -1 (not 0)
+      Document isEmptyArrayExpr = new Document(
+        "$eq",
+        List.of(
+          new Document(
+            "$cond",
+            List.of(
+              new Document("$isArray", "$" + field),
+              new Document("$size", "$" + field),
+              -1
+            )
+          ),
+          0
+        )
+      );
+
+      Document isEmptyExpr = new Document(
+        "$or",
+        List.of(
+          new Document("$eq", isNullArgs),
+          new Document("$eq", isEmptyStringArgs),
+          isEmptyArrayExpr
+        )
+      );
+
+      fields.append(field + "_isEmpty", isEmptyExpr);
+    }
+
+    return context -> new Document("$addFields", fields);
   }
 
   /**

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ApiHelper.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ApiHelper.java
@@ -183,11 +183,12 @@ public final class ApiHelper {
 
   /**
    * Returns the {@code $addFields} output key for the isEmpty flag of the given sort field.
-   * Spaces are replaced with underscores because spaces in {@code $addFields} key names are
-   * unreliable in DocumentDB's {@code $sort} parser -- the flag would silently have no effect.
+   * Spaces and dots are replaced with underscores: spaces because they are unreliable in
+   * DocumentDB's {@code $sort} parser, and dots because MongoDB interprets them as nested-path
+   * separators in {@code $addFields} keys, which would silently corrupt the flag.
    */
   static String isEmptyFlagKey(String field) {
-    return field.replace(" ", "_") + "_isEmpty";
+    return field.replace(" ", "_").replace(".", "_") + "_isEmpty";
   }
 
   /**

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ApiHelper.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ApiHelper.java
@@ -212,6 +212,14 @@ public final class ApiHelper {
       if (dotIndex >= 0) {
         String parent = resolvedField.substring(0, dotIndex);
         String child = resolvedField.substring(dotIndex + 1);
+        if (child.contains(".")) {
+          throw new IllegalArgumentException(
+            "Spaced field paths support only one level of nesting via $getField; '"
+              + resolvedField
+              + "' contains more than one dot."
+              + " Add an explicit sort-field alias to a single-dot path instead."
+          );
+        }
         fieldAccess = new Document(
           "$getField",
           new Document("field", child).append("input", new Document("$getField", parent))

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ApiHelper.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ApiHelper.java
@@ -194,19 +194,21 @@ public final class ApiHelper {
    * Builds an isEmpty expression for the given resolved field path. The flag is {@code true} when
    * the field is null, missing, an empty string, or an empty array.
    *
-   * <p>For field paths containing spaces (e.g. {@code "4 months.log2_fc"}), {@code "$field"}
-   * expression syntax silently fails to resolve the name, so {@code $getField} is used instead.
-   * Both access strategies are bound to {@code $$val} via {@code $let} so the three isEmpty checks
-   * (null/missing, empty string, empty array) apply uniformly regardless of how the field is
-   * accessed.
+   * <p>For field paths containing no spaces, uses {@code "$field"} expression syntax directly.
+   * For field paths containing spaces (e.g. {@code "4 months.log2_fc"}), {@code "$field"}
+   * expression syntax silently fails to resolve the name, so {@code $getField} is used instead,
+   * and the field access expression is bound to {@code $$val} via {@code $let} so all three
+   * isEmpty checks can reference it uniformly. The null/missing branch uses {@code $type} rather
+   * than {@code $eq null} because {@code $getField} returns {@code $$REMOVE} (not {@code null})
+   * when the parent field is absent, and {@code $eq [$$REMOVE, null]} evaluates to {@code false}.
    *
    * <p>Spaced paths support one level of nesting by splitting on the first dot. Deeper nesting
    * would require additional chained {@code $getField} calls.
    */
   private static Document buildIsEmptyExpr(String resolvedField) {
-    Object fieldAccess;
     if (resolvedField.contains(" ")) {
       int dotIndex = resolvedField.indexOf('.');
+      Object fieldAccess;
       if (dotIndex >= 0) {
         String parent = resolvedField.substring(0, dotIndex);
         String child = resolvedField.substring(dotIndex + 1);
@@ -217,39 +219,59 @@ public final class ApiHelper {
       } else {
         fieldAccess = new Document("$getField", resolvedField);
       }
-    } else {
-      fieldAccess = "$" + resolvedField;
+
+      // null/missing: $type returns "null" or "missing" for absent/null; $eq null fails for
+      // $$REMOVE so $type is required here
+      Document isNullOrMissing = new Document(
+        "$in", List.of(new Document("$type", "$$val"), List.of("null", "missing"))
+      );
+      // empty string
+      Document isEmptyString = new Document("$eq", List.of("$$val", ""));
+      // empty array: $cond guards with $isArray so non-array fields return -1 (not 0)
+      Document isEmptyArray = new Document(
+        "$eq",
+        List.of(
+          new Document("$cond", List.of(
+            new Document("$isArray", "$$val"),
+            new Document("$size", "$$val"),
+            -1
+          )),
+          0
+        )
+      );
+
+      return new Document("$let", new Document()
+        .append("vars", new Document("val", fieldAccess))
+        .append("in", new Document("$or", List.of(isNullOrMissing, isEmptyString, isEmptyArray)))
+      );
     }
 
     // null or missing -- ArrayList because List.of() prohibits null elements
     List<Object> isNullArgs = new ArrayList<>(2);
-    isNullArgs.add("$$val");
+    isNullArgs.add("$" + resolvedField);
     isNullArgs.add(null);
 
     // empty string
-    List<Object> isEmptyStringArgs = List.of("$$val", "");
+    List<Object> isEmptyStringArgs = List.of("$" + resolvedField, "");
 
     // empty array: $cond guards with $isArray so non-array fields return -1 (not 0)
     Document isEmptyArrayExpr = new Document(
       "$eq",
       List.of(
         new Document("$cond", List.of(
-          new Document("$isArray", "$$val"),
-          new Document("$size", "$$val"),
+          new Document("$isArray", "$" + resolvedField),
+          new Document("$size", "$" + resolvedField),
           -1
         )),
         0
       )
     );
 
-    return new Document("$let", new Document()
-      .append("vars", new Document("val", fieldAccess))
-      .append("in", new Document("$or", List.of(
-        new Document("$eq", isNullArgs),
-        new Document("$eq", isEmptyStringArgs),
-        isEmptyArrayExpr
-      )))
-    );
+    return new Document("$or", List.of(
+      new Document("$eq", isNullArgs),
+      new Document("$eq", isEmptyStringArgs),
+      isEmptyArrayExpr
+    ));
   }
 
   /**

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ApiHelper.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ApiHelper.java
@@ -143,17 +143,22 @@ public final class ApiHelper {
 
   /**
    * Builds an {@code $addFields} stage that emits a {@code <field>_isEmpty} boolean for every sort
-   * order in {@code sort}. The flag is {@code true} when the field is {@code null} or an empty
-   * string, {@code false} otherwise.
+   * order in {@code sort}. The flag is {@code true} when the field is {@code null}, missing, an
+   * empty string, or an empty array; {@code false} otherwise.
    *
    * <p>Prepending {@code <field>_isEmpty: 1} to the {@code $sort} doc (always ascending) before the
    * user's chosen sort key pushes empty/null rows to the tail regardless of the user's sort
    * direction, while non-empty rows sort normally within themselves.
    *
+   * <p>When {@code aliases} is provided, the isEmpty expression is evaluated against the aliased
+   * path rather than the raw sort field, so null detection targets the actual value being sorted
+   * rather than a parent object that may be present even when the value itself is absent.
+   *
    * @param sort the requested sort; if unsorted, returns {@code null}
+   * @param aliases map from sort field name to the aliased document path used in {@code $sort}
    * @return an {@code $addFields} {@link AggregationOperation}, or {@code null} when sort is empty
    */
-  public static AggregationOperation buildEmptyFlagFields(Sort sort) {
+  public static AggregationOperation buildEmptyFlagFields(Sort sort, Map<String, String> aliases) {
     if (sort.isUnsorted()) {
       return null;
     }
@@ -161,44 +166,90 @@ public final class ApiHelper {
     Document fields = new Document();
     for (Sort.Order order : sort) {
       String field = order.getProperty();
+      String resolvedField = aliases.getOrDefault(field, field);
 
-      // null or missing -- ArrayList because List.of() prohibits null elements
-      List<Object> isNullArgs = new ArrayList<>(2);
-      isNullArgs.add("$" + field);
-      isNullArgs.add(null);
+      Document isEmptyExpr = buildIsEmptyExpr(resolvedField);
 
-      // empty string
-      List<Object> isEmptyStringArgs = List.of("$" + field, "");
-
-      // empty array: $cond guards with $isArray so non-array fields return -1 (not 0)
-      Document isEmptyArrayExpr = new Document(
-        "$eq",
-        List.of(
-          new Document(
-            "$cond",
-            List.of(
-              new Document("$isArray", "$" + field),
-              new Document("$size", "$" + field),
-              -1
-            )
-          ),
-          0
-        )
-      );
-
-      Document isEmptyExpr = new Document(
-        "$or",
-        List.of(
-          new Document("$eq", isNullArgs),
-          new Document("$eq", isEmptyStringArgs),
-          isEmptyArrayExpr
-        )
-      );
-
-      fields.append(field + "_isEmpty", isEmptyExpr);
+      fields.append(isEmptyFlagKey(field), isEmptyExpr);
     }
 
     return context -> new Document("$addFields", fields);
+  }
+
+  /** Overload for callers with no sort-field aliases. */
+  public static AggregationOperation buildEmptyFlagFields(Sort sort) {
+    return buildEmptyFlagFields(sort, Map.of());
+  }
+
+  /**
+   * Returns the {@code $addFields} output key for the isEmpty flag of the given sort field.
+   * Spaces are replaced with underscores because spaces in {@code $addFields} key names are
+   * unreliable in DocumentDB's {@code $sort} parser -- the flag would silently have no effect.
+   */
+  static String isEmptyFlagKey(String field) {
+    return field.replace(" ", "_") + "_isEmpty";
+  }
+
+  /**
+   * Builds an isEmpty expression for the given resolved field path. The flag is {@code true} when
+   * the field is null, missing, an empty string, or an empty array.
+   *
+   * <p>For field paths containing spaces (e.g. {@code "4 months.log2_fc"}), {@code "$field"}
+   * expression syntax silently fails to resolve the name, so {@code $getField} is used instead.
+   * Both access strategies are bound to {@code $$val} via {@code $let} so the three isEmpty checks
+   * (null/missing, empty string, empty array) apply uniformly regardless of how the field is
+   * accessed.
+   *
+   * <p>Spaced paths support one level of nesting by splitting on the first dot. Deeper nesting
+   * would require additional chained {@code $getField} calls.
+   */
+  private static Document buildIsEmptyExpr(String resolvedField) {
+    Object fieldAccess;
+    if (resolvedField.contains(" ")) {
+      int dotIndex = resolvedField.indexOf('.');
+      if (dotIndex >= 0) {
+        String parent = resolvedField.substring(0, dotIndex);
+        String child = resolvedField.substring(dotIndex + 1);
+        fieldAccess = new Document(
+          "$getField",
+          new Document("field", child).append("input", new Document("$getField", parent))
+        );
+      } else {
+        fieldAccess = new Document("$getField", resolvedField);
+      }
+    } else {
+      fieldAccess = "$" + resolvedField;
+    }
+
+    // null or missing -- ArrayList because List.of() prohibits null elements
+    List<Object> isNullArgs = new ArrayList<>(2);
+    isNullArgs.add("$$val");
+    isNullArgs.add(null);
+
+    // empty string
+    List<Object> isEmptyStringArgs = List.of("$$val", "");
+
+    // empty array: $cond guards with $isArray so non-array fields return -1 (not 0)
+    Document isEmptyArrayExpr = new Document(
+      "$eq",
+      List.of(
+        new Document("$cond", List.of(
+          new Document("$isArray", "$$val"),
+          new Document("$size", "$$val"),
+          -1
+        )),
+        0
+      )
+    );
+
+    return new Document("$let", new Document()
+      .append("vars", new Document("val", fieldAccess))
+      .append("in", new Document("$or", List.of(
+        new Document("$eq", isNullArgs),
+        new Document("$eq", isEmptyStringArgs),
+        isEmptyArrayExpr
+      )))
+    );
   }
 
   /**

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
@@ -91,9 +91,21 @@ public abstract class ComparisonToolRepositorySupport<T> {
   }
 
   /**
-   * Map of sort field → aliased field name for a direct {@code $sort} rename (no {@code $addFields}
-   * stage). Use when an alternate field is already present on the document (e.g.
-   * {@code "age" → "age_numeric"} for a numeric companion to a string column).
+   * Map of sort field name → aliased document path for a direct {@code $sort} rename (no
+   * {@code $addFields} stage). Two cases require an entry:
+   *
+   * <ol>
+   *   <li><strong>Companion-field redirect</strong> — a separate field already on the document
+   *       carries the sortable value (e.g. {@code "age" → "age_numeric"}).
+   *   <li><strong>Nested-object columns</strong> — any column whose document value is an object
+   *       (rather than a scalar) must be aliased to the specific sub-field to sort on (e.g.
+   *       {@code "CBE" → "CBE.correlation"}, {@code "4 months" → "4 months.log2_fc"}). Without the
+   *       alias, {@code $sort} operates on the full object and produces undefined ordering. This
+   *       applies to any object-valued column — heatmap modules, time-point buckets, or similar.
+   * </ol>
+   *
+   * <p>Subclass overrides must stay in sync with the document schema: whenever a new object-valued
+   * column is added, add the corresponding alias here.
    */
   protected Map<String, String> getSortFieldAliases() {
     return Map.of();

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
+import org.springframework.data.mongodb.core.aggregation.AggregationOptions;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -142,7 +143,11 @@ public abstract class ComparisonToolRepositorySupport<T> {
       operations.add(Aggregation.skip(skipCount));
       operations.add(Aggregation.limit(pageable.getPageSize()));
 
-      Aggregation aggregation = Aggregation.newAggregation(operations);
+      // Permits disk spillover when the $sort working set exceeds 100MB; only activates
+      // when needed -- required for deep pagination on large collections
+      Aggregation aggregation = Aggregation.newAggregation(operations).withOptions(
+        AggregationOptions.builder().allowDiskUse(true).build()
+      );
       log.debug("Executing aggregation on collection {}: {}", getCollectionName(), aggregation);
       AggregationResults<T> results = mongoTemplate.aggregate(
         aggregation,

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
@@ -67,7 +67,9 @@ public abstract class ComparisonToolRepositorySupport<T> {
    * {@link #buildCtMatchCriteria} must override.
    */
   protected <Q> CtFilterConfig<Q> getFilterConfig() {
-    throw new UnsupportedOperationException("Subclasses that use buildCtMatchCriteria must override getFilterConfig()");
+    throw new UnsupportedOperationException(
+      "Subclasses that use buildCtMatchCriteria must override getFilterConfig()"
+    );
   }
 
   /**
@@ -122,6 +124,12 @@ public abstract class ComparisonToolRepositorySupport<T> {
       );
       if (computedSort != null) {
         operations.add(computedSort);
+      }
+
+      // Inject empty-flag fields so null/empty values always sort last regardless of direction
+      AggregationOperation emptyFlags = ApiHelper.buildEmptyFlagFields(pageable.getSort());
+      if (emptyFlags != null) {
+        operations.add(emptyFlags);
       }
 
       // Build and add sort operation
@@ -375,6 +383,9 @@ public abstract class ComparisonToolRepositorySupport<T> {
       } else {
         resolved = field;
       }
+      // _isEmpty is the raw field name (not the resolved alias) to match the $addFields output,
+      // and is always ascending so nulls/empties tail regardless of user direction
+      sortDoc.append(field + "_isEmpty", 1);
       sortDoc.append(resolved, order.isAscending() ? 1 : -1);
     }
 

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
@@ -128,7 +128,7 @@ public abstract class ComparisonToolRepositorySupport<T> {
       }
 
       // Inject empty-flag fields so null/empty values always sort last regardless of direction
-      AggregationOperation emptyFlags = ApiHelper.buildEmptyFlagFields(pageable.getSort());
+      AggregationOperation emptyFlags = ApiHelper.buildEmptyFlagFields(pageable.getSort(), aliases);
       if (emptyFlags != null) {
         operations.add(emptyFlags);
       }
@@ -385,12 +385,11 @@ public abstract class ComparisonToolRepositorySupport<T> {
         resolved = field + "_sort";
       } else if (aliases.containsKey(field)) {
         resolved = aliases.get(field);
+        log.debug("Resolved sort alias: '{}' -> '{}'", field, resolved);
       } else {
         resolved = field;
       }
-      // _isEmpty is the raw field name (not the resolved alias) to match the $addFields output,
-      // and is always ascending so nulls/empties tail regardless of user direction
-      sortDoc.append(field + "_isEmpty", 1);
+      sortDoc.append(ApiHelper.isEmptyFlagKey(field), 1);
       sortDoc.append(resolved, order.isAscending() ? 1 : -1);
     }
 

--- a/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ApiHelperTest.java
+++ b/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ApiHelperTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -186,14 +187,7 @@ class ApiHelperTest {
     @Test
     @DisplayName("should append extra parts using Objects.toString")
     void shouldAppendExtraParts() {
-      String key = ApiHelper.buildCacheKey(
-        "scope",
-        SampleEnum.EXCLUDE,
-        List.of("a"),
-        1,
-        null,
-        "x"
-      );
+      String key = ApiHelper.buildCacheKey("scope", SampleEnum.EXCLUDE, List.of("a"), 1, null, "x");
 
       assertThat(key).isEqualTo("scope-exclude-[a]-1-null-x");
     }
@@ -240,7 +234,9 @@ class ApiHelperTest {
     }
 
     @Test
-    @DisplayName("should emit _isEmpty flag covering null, empty string, and empty array when sort has one field")
+    @DisplayName(
+      "should emit _isEmpty flag covering null, empty string, and empty array when sort has one field"
+    )
     void shouldEmitIsEmptyFlagWhenSortHasOneField() {
       AggregationOperation op = ApiHelper.buildEmptyFlagFields(Sort.by(Sort.Order.asc("name")));
 
@@ -250,7 +246,7 @@ class ApiHelperTest {
         .contains("name_isEmpty")
         .contains("$or")
         .contains("$eq")
-        .contains("$isArray")  // empty-array branch
+        .contains("$isArray") // empty-array branch
         .contains("$size");
     }
 
@@ -275,6 +271,36 @@ class ApiHelperTest {
       assertThat(asc).isNotNull();
       assertThat(desc).isNotNull();
       assertThat(asc.toDocument(null).toJson()).isEqualTo(desc.toDocument(null).toJson());
+    }
+
+    @Test
+    @DisplayName("should use aliased path in isEmpty expression when aliases map is provided")
+    void shouldUseAliasedPathInIsEmptyExpressionWhenAliasesMapIsProvided() {
+      Map<String, String> aliases = Map.of("4 months", "4 months.log2_fc");
+      AggregationOperation op = ApiHelper.buildEmptyFlagFields(
+        Sort.by(Sort.Order.asc("4 months")),
+        aliases
+      );
+
+      assertThat(op).isNotNull();
+      String doc = op.toDocument(null).toJson();
+      assertThat(doc)
+        .as("flag name should use the sort key with spaces replaced by underscores")
+        .contains("4_months_isEmpty");
+      assertThat(doc)
+        .as("isEmpty expression should use $let to bind the field access to $$val")
+        .contains("$let");
+      assertThat(doc)
+        .as("isEmpty expression should use $getField to navigate the spaced parent field")
+        .contains("$getField");
+      assertThat(doc)
+        .as("isEmpty expression should reference log2_fc as the child field")
+        .contains("log2_fc");
+      assertThat(doc)
+        .as("isEmpty expression should cover null, empty string, and empty array via $$val")
+        .contains("$$val")
+        .contains("$isArray")
+        .contains("$size");
     }
   }
 }

--- a/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ApiHelperTest.java
+++ b/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ApiHelperTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 
 class ApiHelperTest {
@@ -241,7 +242,7 @@ class ApiHelperTest {
       AggregationOperation op = ApiHelper.buildEmptyFlagFields(Sort.by(Sort.Order.asc("name")));
 
       assertThat(op).isNotNull();
-      String doc = op.toDocument(null).toJson();
+      String doc = op.toPipelineStages(Aggregation.DEFAULT_CONTEXT).get(0).toJson();
       assertThat(doc)
         .contains("name_isEmpty")
         .contains("$or")
@@ -258,7 +259,7 @@ class ApiHelperTest {
       );
 
       assertThat(op).isNotNull();
-      String doc = op.toDocument(null).toJson();
+      String doc = op.toPipelineStages(Aggregation.DEFAULT_CONTEXT).get(0).toJson();
       assertThat(doc).contains("name_isEmpty").contains("age_isEmpty");
     }
 
@@ -270,7 +271,9 @@ class ApiHelperTest {
 
       assertThat(asc).isNotNull();
       assertThat(desc).isNotNull();
-      assertThat(asc.toDocument(null).toJson()).isEqualTo(desc.toDocument(null).toJson());
+      assertThat(asc.toPipelineStages(Aggregation.DEFAULT_CONTEXT).get(0).toJson()).isEqualTo(
+        desc.toPipelineStages(Aggregation.DEFAULT_CONTEXT).get(0).toJson()
+      );
     }
 
     @Test
@@ -286,6 +289,21 @@ class ApiHelperTest {
     }
 
     @Test
+    @DisplayName("should replace dots with underscores in isEmpty flag key for dotted sort fields")
+    void shouldReplaceDotsWithUnderscoresInIsEmptyFlagKeyForDottedSortFields() {
+      AggregationOperation op = ApiHelper.buildEmptyFlagFields(
+        Sort.by(Sort.Order.asc("name.link_text"))
+      );
+
+      assertThat(op).isNotNull();
+      String doc = op.toPipelineStages(Aggregation.DEFAULT_CONTEXT).get(0).toJson();
+      assertThat(doc)
+        .as("dots in sort field name should be replaced with underscores in flag key")
+        .contains("name_link_text_isEmpty")
+        .doesNotContain("name.link_text_isEmpty");
+    }
+
+    @Test
     @DisplayName("should use aliased path in isEmpty expression when aliases map is provided")
     void shouldUseAliasedPathInIsEmptyExpressionWhenAliasesMapIsProvided() {
       Map<String, String> aliases = Map.of("4 months", "4 months.log2_fc");
@@ -295,7 +313,7 @@ class ApiHelperTest {
       );
 
       assertThat(op).isNotNull();
-      String doc = op.toDocument(null).toJson();
+      String doc = op.toPipelineStages(Aggregation.DEFAULT_CONTEXT).get(0).toJson();
       assertThat(doc)
         .as("flag name should use the sort key with spaces replaced by underscores")
         .contains("4_months_isEmpty");

--- a/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ApiHelperTest.java
+++ b/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ApiHelperTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 
 class ApiHelperTest {
 
@@ -225,6 +226,55 @@ class ApiHelperTest {
       public String toString() {
         return String.valueOf(value);
       }
+    }
+  }
+
+  @Nested
+  @DisplayName("buildEmptyFlagFields")
+  class BuildEmptyFlagFields {
+
+    @Test
+    @DisplayName("should return null when sort is unsorted")
+    void shouldReturnNullWhenSortIsUnsorted() {
+      assertThat(ApiHelper.buildEmptyFlagFields(Sort.unsorted())).isNull();
+    }
+
+    @Test
+    @DisplayName("should emit _isEmpty flag covering null, empty string, and empty array when sort has one field")
+    void shouldEmitIsEmptyFlagWhenSortHasOneField() {
+      AggregationOperation op = ApiHelper.buildEmptyFlagFields(Sort.by(Sort.Order.asc("name")));
+
+      assertThat(op).isNotNull();
+      String doc = op.toDocument(null).toJson();
+      assertThat(doc)
+        .contains("name_isEmpty")
+        .contains("$or")
+        .contains("$eq")
+        .contains("$isArray")  // empty-array branch
+        .contains("$size");
+    }
+
+    @Test
+    @DisplayName("should emit _isEmpty flags for all fields when sort has multiple fields")
+    void shouldEmitIsEmptyFlagsWhenSortHasMultipleFields() {
+      AggregationOperation op = ApiHelper.buildEmptyFlagFields(
+        Sort.by(Sort.Order.asc("name"), Sort.Order.desc("age"))
+      );
+
+      assertThat(op).isNotNull();
+      String doc = op.toDocument(null).toJson();
+      assertThat(doc).contains("name_isEmpty").contains("age_isEmpty");
+    }
+
+    @Test
+    @DisplayName("should produce the same _isEmpty expression when sort direction differs")
+    void shouldProduceSameExpressionWhenSortDirectionDiffers() {
+      AggregationOperation asc = ApiHelper.buildEmptyFlagFields(Sort.by(Sort.Order.asc("name")));
+      AggregationOperation desc = ApiHelper.buildEmptyFlagFields(Sort.by(Sort.Order.desc("name")));
+
+      assertThat(asc).isNotNull();
+      assertThat(desc).isNotNull();
+      assertThat(asc.toDocument(null).toJson()).isEqualTo(desc.toDocument(null).toJson());
     }
   }
 }

--- a/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ApiHelperTest.java
+++ b/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ApiHelperTest.java
@@ -274,6 +274,18 @@ class ApiHelperTest {
     }
 
     @Test
+    @DisplayName("should throw when a spaced alias resolves to a path with more than one dot")
+    void shouldThrowWhenSpacedAliasHasMoreThanOneDot() {
+      Map<String, String> aliases = Map.of("4 months", "4 months.nested.value");
+      assertThatThrownBy(() ->
+        ApiHelper.buildEmptyFlagFields(Sort.by(Sort.Order.asc("4 months")), aliases)
+      )
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("4 months.nested.value")
+        .hasMessageContaining("one level of nesting");
+    }
+
+    @Test
     @DisplayName("should use aliased path in isEmpty expression when aliases map is provided")
     void shouldUseAliasedPathInIsEmptyExpressionWhenAliasesMapIsProvided() {
       Map<String, String> aliases = Map.of("4 months", "4 months.log2_fc");
@@ -297,9 +309,13 @@ class ApiHelperTest {
         .as("isEmpty expression should reference log2_fc as the child field")
         .contains("log2_fc");
       assertThat(doc)
-        .as("isEmpty expression should use $type for null/missing and cover empty string and empty array")
-        .contains("$type").contains("missing")
-        .contains("$isArray").contains("$size");
+        .as(
+          "isEmpty expression should use $type for null/missing and cover empty string and empty array"
+        )
+        .contains("$type")
+        .contains("missing")
+        .contains("$isArray")
+        .contains("$size");
     }
   }
 }

--- a/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ApiHelperTest.java
+++ b/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ApiHelperTest.java
@@ -288,7 +288,7 @@ class ApiHelperTest {
         .as("flag name should use the sort key with spaces replaced by underscores")
         .contains("4_months_isEmpty");
       assertThat(doc)
-        .as("isEmpty expression should use $let to bind the field access to $$val")
+        .as("isEmpty expression should use $let to bind $$val to the $getField access expression")
         .contains("$let");
       assertThat(doc)
         .as("isEmpty expression should use $getField to navigate the spaced parent field")
@@ -297,10 +297,9 @@ class ApiHelperTest {
         .as("isEmpty expression should reference log2_fc as the child field")
         .contains("log2_fc");
       assertThat(doc)
-        .as("isEmpty expression should cover null, empty string, and empty array via $$val")
-        .contains("$$val")
-        .contains("$isArray")
-        .contains("$size");
+        .as("isEmpty expression should use $type for null/missing and cover empty string and empty array")
+        .contains("$type").contains("missing")
+        .contains("$isArray").contains("$size");
     }
   }
 }

--- a/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupportTest.java
+++ b/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupportTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import org.bson.Document;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -48,12 +49,13 @@ class ComparisonToolRepositorySupportTest {
 
     String pipeline = capturePipeline().toString();
     assertThat(pipeline).contains("$match").contains("$sort").contains("$skip").contains("$limit");
-    assertThat(pipeline).doesNotContain("$addFields");
+    // isEmpty stage is always present; no computed-sort _sort addFields expected
+    assertThat(pipeline).contains("name_isEmpty").doesNotContain("name_sort");
     assertThat(pipeline).contains("\"name\" : 1");
   }
 
   @Test
-  @DisplayName("should resolve sort field aliases to the aliased name (no $addFields)")
+  @DisplayName("should resolve sort field aliases to the aliased name without a computed-sort $addFields")
   void shouldResolveSortFieldAliases() {
     AliasingRepo repo = new AliasingRepo(mongoTemplate);
     stubMongoTemplate(0L);
@@ -63,7 +65,8 @@ class ComparisonToolRepositorySupportTest {
 
     String pipeline = capturePipeline().toString();
     assertThat(pipeline).contains("\"age_numeric\" : -1");
-    assertThat(pipeline).doesNotContain("$addFields");
+    // isEmpty stage present but no computed-sort alias _sort addFields
+    assertThat(pipeline).contains("age_isEmpty").doesNotContain("age_sort");
   }
 
   @Test
@@ -83,7 +86,7 @@ class ComparisonToolRepositorySupportTest {
   }
 
   @Test
-  @DisplayName("should skip $addFields when the sort doesn't include any computed field")
+  @DisplayName("should skip computed-sort $addFields when the sort does not include any computed field")
   void shouldSkipComputedAddFieldsWhenUnused() {
     ComputedRepo repo = new ComputedRepo(mongoTemplate);
     stubMongoTemplate(0L);
@@ -92,7 +95,8 @@ class ComparisonToolRepositorySupportTest {
     repo.run(new Criteria(), pageable);
 
     String pipeline = capturePipeline().toString();
-    assertThat(pipeline).doesNotContain("$addFields").doesNotContain("name_sort");
+    // isEmpty stage is still present, but no computed-sort _sort addFields
+    assertThat(pipeline).contains("hgnc_symbol_isEmpty").doesNotContain("name_sort");
     assertThat(pipeline).contains("\"hgnc_symbol\" : 1");
   }
 
@@ -279,6 +283,68 @@ class ComparisonToolRepositorySupportTest {
 
     Page<TestDocument> run(Criteria criteria, Pageable pageable) {
       return executePagedAggregation(criteria, pageable);
+    }
+  }
+
+  @Nested
+  @DisplayName("null-last sort")
+  class NullLastSort {
+
+    @Test
+    @DisplayName("should include _isEmpty $addFields stage before $sort when sort is provided")
+    void shouldIncludeIsEmptyAddFieldsBeforeSortWhenSortIsProvided() {
+      BareRepo repo = new BareRepo(mongoTemplate);
+      stubMongoTemplate(0L);
+
+      Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Order.asc("name")));
+      repo.run(new Criteria(), pageable);
+
+      String pipeline = capturePipeline().toString();
+      assertThat(pipeline).contains("name_isEmpty").contains("$or").contains("$eq");
+
+      int isEmptyIdx = pipeline.indexOf("name_isEmpty");
+      int sortIdx = pipeline.indexOf("\"$sort\"");
+      assertThat(isEmptyIdx).isLessThan(sortIdx);
+    }
+
+    @Test
+    @DisplayName("should include _isEmpty: 1 key in $sort doc alongside the resolved sort key")
+    void shouldIncludeIsEmptyKeyInSortDocWhenSortIsProvided() {
+      BareRepo repo = new BareRepo(mongoTemplate);
+      stubMongoTemplate(0L);
+
+      Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Order.asc("name")));
+      repo.run(new Criteria(), pageable);
+
+      String pipeline = capturePipeline().toString();
+      assertThat(pipeline).contains("\"name_isEmpty\" : 1").contains("\"name\" : 1");
+    }
+
+    @Test
+    @DisplayName("should not include _isEmpty stage when sort is unsorted")
+    void shouldNotIncludeIsEmptyStageWhenSortIsUnsorted() {
+      BareRepo repo = new BareRepo(mongoTemplate);
+      stubMongoTemplate(0L);
+
+      Pageable pageable = PageRequest.of(0, 10);
+      repo.run(new Criteria(), pageable);
+
+      String pipeline = capturePipeline().toString();
+      assertThat(pipeline).doesNotContain("_isEmpty");
+    }
+
+    @Test
+    @DisplayName("should use original field name for _isEmpty when sort resolves through a computed alias")
+    void shouldUseOriginalFieldNameForIsEmptyWhenSortResolvesToComputedAlias() {
+      ComputedRepo repo = new ComputedRepo(mongoTemplate);
+      stubMongoTemplate(0L);
+
+      Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Order.asc("name")));
+      repo.run(new Criteria(), pageable);
+
+      String pipeline = capturePipeline().toString();
+      assertThat(pipeline).contains("\"name_isEmpty\" : 1");
+      assertThat(pipeline).contains("\"name_sort\" : 1");
     }
   }
 }

--- a/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupportTest.java
+++ b/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupportTest.java
@@ -55,7 +55,9 @@ class ComparisonToolRepositorySupportTest {
   }
 
   @Test
-  @DisplayName("should resolve sort field aliases to the aliased name without a computed-sort $addFields")
+  @DisplayName(
+    "should resolve sort field aliases to the aliased name without a computed-sort $addFields"
+  )
   void shouldResolveSortFieldAliases() {
     AliasingRepo repo = new AliasingRepo(mongoTemplate);
     stubMongoTemplate(0L);
@@ -86,7 +88,9 @@ class ComparisonToolRepositorySupportTest {
   }
 
   @Test
-  @DisplayName("should skip computed-sort $addFields when the sort does not include any computed field")
+  @DisplayName(
+    "should skip computed-sort $addFields when the sort does not include any computed field"
+  )
   void shouldSkipComputedAddFieldsWhenUnused() {
     ComputedRepo repo = new ComputedRepo(mongoTemplate);
     stubMongoTemplate(0L);
@@ -120,6 +124,37 @@ class ComparisonToolRepositorySupportTest {
   }
 
   @Test
+  @DisplayName(
+    "should use $let/$getField and cover null, empty string, and empty array when sort alias contains spaces"
+  )
+  void shouldUseGetFieldWhenSortAliasContainsSpaces() {
+    SpacedAliasRepo repo = new SpacedAliasRepo(mongoTemplate);
+    stubMongoTemplate(0L);
+
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Order.asc("4 months")));
+    repo.run(new Criteria(), pageable);
+
+    String pipeline = capturePipeline().toString();
+    assertThat(pipeline)
+      .as("isEmpty key should have spaces replaced with underscores")
+      .contains("4_months_isEmpty");
+    assertThat(pipeline)
+      .as("$sort should use the nested alias path directly")
+      .contains("4 months.log2_fc");
+    assertThat(pipeline).as("isEmpty expression must use $let to bind $$val").contains("$let");
+    assertThat(pipeline)
+      .as(
+        "isEmpty expression must use $getField for spaced field names, not $-prefix expression syntax"
+      )
+      .contains("$getField");
+    assertThat(pipeline)
+      .as("isEmpty expression must cover null, empty string, and empty array via $$val")
+      .contains("$$val")
+      .contains("$isArray")
+      .contains("$size");
+  }
+
+  @Test
   @DisplayName("should throw UnsupportedOperationException when getFilterConfig is not overridden")
   void shouldThrowWhenGetFilterConfigNotOverridden() {
     BareRepo repo = new BareRepo(mongoTemplate);
@@ -142,8 +177,9 @@ class ComparisonToolRepositorySupportTest {
 
   private void stubMongoTemplate(long total) {
     when(mongoTemplate.count(any(Query.class), eq(COLLECTION))).thenReturn(total);
-    when(mongoTemplate.aggregate(any(Aggregation.class), eq(COLLECTION), eq(TestDocument.class)))
-      .thenReturn(aggregationResults);
+    when(
+      mongoTemplate.aggregate(any(Aggregation.class), eq(COLLECTION), eq(TestDocument.class))
+    ).thenReturn(aggregationResults);
     when(aggregationResults.getMappedResults()).thenReturn(List.of());
   }
 
@@ -208,6 +244,33 @@ class ComparisonToolRepositorySupportTest {
     @Override
     protected Map<String, String> getSortFieldAliases() {
       return Map.of("age", "age_numeric");
+    }
+
+    Page<TestDocument> run(Criteria criteria, Pageable pageable) {
+      return executePagedAggregation(criteria, pageable);
+    }
+  }
+
+  /** Subclass that exercises a sort alias whose key and value both contain spaces. */
+  private static final class SpacedAliasRepo extends ComparisonToolRepositorySupport<TestDocument> {
+
+    SpacedAliasRepo(MongoTemplate mongoTemplate) {
+      super(mongoTemplate);
+    }
+
+    @Override
+    protected String getCollectionName() {
+      return COLLECTION;
+    }
+
+    @Override
+    protected Class<TestDocument> getDocumentClass() {
+      return TestDocument.class;
+    }
+
+    @Override
+    protected Map<String, String> getSortFieldAliases() {
+      return Map.of("4 months", "4 months.log2_fc");
     }
 
     Page<TestDocument> run(Criteria criteria, Pageable pageable) {
@@ -334,7 +397,9 @@ class ComparisonToolRepositorySupportTest {
     }
 
     @Test
-    @DisplayName("should use original field name for _isEmpty when sort resolves through a computed alias")
+    @DisplayName(
+      "should use original field name for _isEmpty when sort resolves through a computed alias"
+    )
     void shouldUseOriginalFieldNameForIsEmptyWhenSortResolvesToComputedAlias() {
       ComputedRepo repo = new ComputedRepo(mongoTemplate);
       stubMongoTemplate(0L);

--- a/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupportTest.java
+++ b/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupportTest.java
@@ -125,7 +125,7 @@ class ComparisonToolRepositorySupportTest {
 
   @Test
   @DisplayName(
-    "should use $let/$getField and cover null, empty string, and empty array when sort alias contains spaces"
+    "should use $let/$getField/$type and cover null, empty string, and empty array when sort alias contains spaces"
   )
   void shouldUseGetFieldWhenSortAliasContainsSpaces() {
     SpacedAliasRepo repo = new SpacedAliasRepo(mongoTemplate);
@@ -141,17 +141,16 @@ class ComparisonToolRepositorySupportTest {
     assertThat(pipeline)
       .as("$sort should use the nested alias path directly")
       .contains("4 months.log2_fc");
-    assertThat(pipeline).as("isEmpty expression must use $let to bind $$val").contains("$let");
     assertThat(pipeline)
-      .as(
-        "isEmpty expression must use $getField for spaced field names, not $-prefix expression syntax"
-      )
+      .as("isEmpty expression must use $let to bind $$val to the $getField result")
+      .contains("$let");
+    assertThat(pipeline)
+      .as("isEmpty expression must use $getField for spaced field names, not $-prefix expression syntax")
       .contains("$getField");
     assertThat(pipeline)
-      .as("isEmpty expression must cover null, empty string, and empty array via $$val")
-      .contains("$$val")
-      .contains("$isArray")
-      .contains("$size");
+      .as("isEmpty expression must use $type for null/missing and cover empty string and empty array")
+      .contains("$type").contains("missing")
+      .contains("$isArray").contains("$size");
   }
 
   @Test


### PR DESCRIPTION
## Description

When sorting a CT column with sparse data, null and empty values previously floated to the top on ascending sorts, burying the real data. This PR pushes them to the tail regardless of sort direction across all five server-paginated CT repositories. It also hardens sort correctness for nested-object heatmap columns (Disease Correlation, Transcriptomics) and fixes the Model Overview "Matched Controls" array column sort.

## Related Issue

- [AG-2087](https://sagebionetworks.jira.com/browse/AG-2087)
- [MG-923](https://sagebionetworks.jira.com/browse/MG-923)
- [MG-924](https://sagebionetworks.jira.com/browse/MG-924)

## Changelog

- Add `ApiHelper.buildEmptyFlagFields` -- prepends a `<field>_isEmpty` flag to every `$sort` key so null/empty rows always sort to the tail; evaluates against the aliased path (e.g. `gene_symbol` → `display_gene_symbol`) so the isEmpty check matches what the table displays; handles field names with spaces via `$getField`/`$let`/`$type` since MongoDB's `"$field"` expression syntax silently fails on spaced names; normalizes isEmpty key names to underscores since spaces in `$addFields` keys are unreliable in DocumentDB
- Wire empty-flag stage into `ComparisonToolRepositorySupport.executePagedAggregation`; all five CT repositories inherit it automatically via the base class
- Enable `allowDiskUse: true` on all CT aggregations to prevent sort OOM on large collections
- Fix Disease Correlation heatmap column sort -- add `getSortFieldAliases` entries mapping each brain-region column to its nested `correlation` sub-field (e.g. `"CBE" → "CBE.correlation"`) so `$sort` targets the numeric value rather than the full object
- Fix Transcriptomics heatmap column sort -- add `getSortFieldAliases` entries mapping each time-point column to its nested `log2_fc` sub-field (e.g. `"4 months" → "4 months.log2_fc"`); alias `gene_symbol → display_gene_symbol` so rows with a blank gene symbol but a populated ensembl ID sort among their peers rather than to the tail
- Fix Model Overview "Matched Controls" array column sort -- was sorted by MongoDB's minimum-element heuristic; now uses `arrayToLoweredStringExpr` reduction consistent with other array columns across the codebase
- Add `.claude/rules/ct-repository.md` and `.claude/skills/ct-repository/SKILL.md` documenting the full CT repository pattern, all five sort column types, spaced field name constraints, and all existing implementations as reference examples

## Testing

- On the Model Overview CT, navigate to `/comparison/model?sortFields=matched_controls&sortOrders=1` and confirm that rows sort alphabetically by concatenated control values: B6129 rows first, then C57BL/6J rows, then multi-value rows like `C57BL/6J + 5xFAD` last.
- On the Agora nominated targets CT, sort by an array column such as "Cohorts" -- confirm that rows with empty arrays sort to the bottom alongside rows with null values, in both ascending and descending order.
- On the Agora nominated drugs CT, sort by a string column such as "Combined With" -- confirm that rows with empty strings sort to the bottom alongside rows with null values, in both ascending and descending order.
- On the Transcriptomics CT, navigate to Tissue: Hippocampus / Sex: Females & Males, filter by Biodomain: RNA Spliceosome and Model: 3xTg-AD, and sort by gene symbol ascending. Confirm that `ENSMUSG00000118669` (which has no gene symbol and displays its ensembl ID as its label) appears sorted among other `E`-starting gene symbols rather than at the end of the results.
- On the Transcriptomics CT, navigate to Tissue: Hippocampus / Sex: Females & Males and sort by `4 months` ascending. Confirm that page 1 contains rows with non-null `4 months` values (negative log2 fold change values first), and that rows with `"4 months": null` appear at the end of the results.
- On the Disease Correlation CT, sort by any heatmap column and confirm rows sort by correlation value. (No cluster currently has nulls in its visible heatmap columns, so null-last behavior cannot be verified with current data.)

## Preview

#### Agora

`agora-build-images && agora-docker-start`

#### Nominated Targets

Previously, empty arrays were sorted to top: 

https://github.com/user-attachments/assets/53c99a45-9ad7-4880-9a7a-71d810ff3570

Now, empty arrays are always sorted to the bottom in either direction:

https://github.com/user-attachments/assets/fceb03e6-4d9e-4017-8550-f13117b2e835

#### Nominated Drugs

Previously, empty strings / nulls were sorted to top: 

https://github.com/user-attachments/assets/ce2daa36-dd7e-43dd-a190-ea93759dbbed

Now, empty strings / nulls are always sorted to bottom in either direction: 

https://github.com/user-attachments/assets/6da78b8a-476d-4883-ae2d-c8a15f2ad1d3

### Model-AD

`model-ad-build-images && model-ad-docker-start`

#### Differential Expression

##### Confirm fallback from `gene_symbol` to `ensembl_gene_id` is respected in sort: 

1. Navigate to Differential Expression CT
2. Select Tissue: Hippocampus, Sex: Females & Males dropdowns
3. Filter by Biodomain: RNA Spliceosome and Model: 3xTg-AD
4. Search for 'e' in the filterbox
5. Sort by gene symbol ascending
6. Confirm that `ENSMUSG00000118669` (which has no gene symbol and displays its ensembl ID as its label) appears sorted among other `E`-starting gene symbols rather than at the end of the results.

No change in the PR screenshot, still see fallback ensembl ID displayed among gene symbols: 

dev | this PR 
:---: | :---: 
<img width="1894" height="1429" alt="AG-2087_differentialExpression_filter_dev" src="https://github.com/user-attachments/assets/cb6affe7-861a-4676-a47d-4e28c248ed72" /> | <img width="1894" height="1429" alt="AG-2087_differentialExpression_filter_pr" src="https://github.com/user-attachments/assets/d3007ad3-59c5-45bb-a0d3-0a97afed76be" />

##### Confirm null heatmap values are sorted to the end:

Before, empty objects were sorted to top: 

https://github.com/user-attachments/assets/c734f767-ec1f-47bb-9d78-8a6e5d9da464

Now, empty objects are sorted to bottom: 

https://github.com/user-attachments/assets/adb50ff5-c290-4512-9447-f1c4369f3c6f

#### Model Overview

Confirm matched controls is ordered as displayed: 

1. Navigate to `/comparison/model?sortFields=matched_controls&sortOrders=1`
2. Confirm that rows sort alphabetically by concatenated control values: B6129 rows first, then C57BL/6J rows, then multi-value rows like `C57BL/6J + 5xFAD` last.

dev | this PR 
:---: | :---: 
<img width="1992" height="1283" alt="AG-2087_modelOverview_dev" src="https://github.com/user-attachments/assets/57516810-464c-4f69-bb49-9cf10a61d061" /> | <img width="1992" height="1283" alt="AG-2087_modelOverview_pr" src="https://github.com/user-attachments/assets/cbfe7734-69bb-4692-bb7e-35c41da13f2c" />


[AG-2087]: https://sagebionetworks.jira.com/browse/AG-2087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-923]: https://sagebionetworks.jira.com/browse/MG-923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-924]: https://sagebionetworks.jira.com/browse/MG-924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ