### PR TITLE
fix(agora): evenly space team members across rows and teams (AG-2116)

### DIFF
--- a/libs/agora/teams/src/lib/team-card/team-card.component.scss
+++ b/libs/agora/teams/src/lib/team-card/team-card.component.scss
@@ -24,8 +24,8 @@
 }
 
 .team-card-members {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
   gap: 30px;
 }
 


### PR DESCRIPTION
## Description

Team member cards on the teams page were sizing to their content width, causing members with longer names or the "Primary Investigator" badge to appear wider than others. This switches the member grid to CSS Grid so all cards are uniformly sized and fill the available width.

## Related Issue

- [AG-2116](https://sagebionetworks.jira.com/browse/AG-2116)

## Changelog

- Switch team member grid from flexbox to CSS Grid with `auto-fill` columns for uniform sizing

## Testing

- Navigate to the teams page
- Confirm all team member cards are the same width within each team
- Confirm card widths are consistent across different teams on the page
- Confirm "Primary Investigator" badge and member names display correctly at various viewport widths

### Preview

main | this pr 
:---: | :---: 
<img width="775" height="823" alt="AG-2116_main" src="https://github.com/user-attachments/assets/73cd3ae0-2e22-41e7-b332-c4a58f5cbd1e" /> | <img width="802" height="841" alt="AG-2116_pr" src="https://github.com/user-attachments/assets/eccc2d3a-da63-439f-9642-3df33c5cfb2e" />


[AG-2116]: https://sagebionetworks.jira.com/browse/AG-2116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ