### PR TITLE
fix(explorers): fix Sentry sourcemap upload (MG-902)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,13 @@ jobs:
       - name: Set short SHA
         run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
 
+      - name: Inject Sentry Debug IDs into the affected projects' bundles
+        # Must run before build-image so Debug IDs are baked into the published artifacts.
+        if: github.event_name == 'push'
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=sentry-sourcemaps-inject"
+
       - name: Build and publish the images of the affected projects
         # Only publish on the post-merge push to main.
         if: github.event_name == 'push'
@@ -99,7 +106,7 @@ jobs:
             --remote-env SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN" \
             --remote-env SENTRY_RELEASE_SUFFIX="$SENTRY_RELEASE_SUFFIX" \
             bash -c ". ./dev-env.sh \
-            && nx affected --target=sentry-sourcemaps"
+            && nx affected --target=sentry-sourcemaps-upload"
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_RELEASE_SUFFIX: edge+${{ env.SHORT_SHA }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,6 @@ jobs:
       - name: Set short SHA
         run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
 
-      - name: Inject Sentry Debug IDs into the affected projects' bundles
-        # Must run before build-image so Debug IDs are baked into the published artifacts.
-        if: github.event_name == 'push'
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=sentry-sourcemaps-inject"
-
       - name: Build and publish the images of the affected projects
         # Only publish on the post-merge push to main.
         if: github.event_name == 'push'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
             --remote-env GH_ACTOR="$GH_ACTOR" \
             bash -c '. ./dev-env.sh \
             && export VERSION="${{ env.VERSION }}" \
+            && nx run-many --target=sentry-sourcemaps-inject --projects="${{ env.PRODUCT }}-*" \
             && echo "$GH_TOKEN" | docker login ghcr.io -u "$GH_ACTOR" --password-stdin \
             && nx run-many --target=build-image --projects="${{ env.PRODUCT }}-*" --configuration=release'
 
@@ -73,7 +74,7 @@ jobs:
             --remote-env SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN" \
             --remote-env SENTRY_RELEASE_SUFFIX="$SENTRY_RELEASE_SUFFIX" \
             bash -c '. ./dev-env.sh \
-            && nx run-many --target=sentry-sourcemaps --projects="${{ env.PRODUCT }}-*"'
+            && nx run-many --target=sentry-sourcemaps-upload --projects="${{ env.PRODUCT }}-*"'
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_RELEASE_SUFFIX: ${{ env.VERSION }}+${{ env.SHORT_SHA }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,6 @@ jobs:
             --remote-env GH_ACTOR="$GH_ACTOR" \
             bash -c '. ./dev-env.sh \
             && export VERSION="${{ env.VERSION }}" \
-            && nx run-many --target=sentry-sourcemaps-inject --projects="${{ env.PRODUCT }}-*" \
             && echo "$GH_TOKEN" | docker login ghcr.io -u "$GH_ACTOR" --password-stdin \
             && nx run-many --target=build-image --projects="${{ env.PRODUCT }}-*" --configuration=release'
 

--- a/apps/agora/app/project.json
+++ b/apps/agora/app/project.json
@@ -149,17 +149,23 @@
       },
       "dependsOn": []
     },
-    "sentry-sourcemaps": {
+    "sentry-sourcemaps-inject": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "sentry-cli sourcemaps inject dist/apps/agora/app"
+      },
+      "dependsOn": ["build"]
+    },
+    "sentry-sourcemaps-upload": {
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "sentry-cli sourcemaps inject dist/apps/agora/app",
           "sentry-cli sourcemaps upload --org sage-bionetworks --project agora --release agora@$SENTRY_RELEASE_SUFFIX dist/apps/agora/app",
           "find dist/apps/agora/app -name '*.map' -delete"
         ],
         "parallel": false
       },
-      "dependsOn": ["build"]
+      "dependsOn": ["sentry-sourcemaps-inject"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/agora/app/project.json
+++ b/apps/agora/app/project.json
@@ -168,7 +168,10 @@
       "dependsOn": ["sentry-sourcemaps-inject"]
     },
     "build-image": {
-      "dependsOn": ["sentry-sourcemaps-inject"]
+      "dependsOn": ["sentry-sourcemaps-inject"],
+      "metadata": {
+        "description": "Depends on sentry-sourcemaps-inject (not build) so the Sentry Debug IDs survive Nx's cached build restore and are baked into the published image. See MG-902."
+      }
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/agora/app/project.json
+++ b/apps/agora/app/project.json
@@ -167,6 +167,9 @@
       },
       "dependsOn": ["sentry-sourcemaps-inject"]
     },
+    "build-image": {
+      "dependsOn": ["sentry-sourcemaps-inject"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/model-ad/app/project.json
+++ b/apps/model-ad/app/project.json
@@ -154,17 +154,23 @@
       },
       "dependsOn": []
     },
-    "sentry-sourcemaps": {
+    "sentry-sourcemaps-inject": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "sentry-cli sourcemaps inject dist/apps/model-ad/app"
+      },
+      "dependsOn": ["build"]
+    },
+    "sentry-sourcemaps-upload": {
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "sentry-cli sourcemaps inject dist/apps/model-ad/app",
           "sentry-cli sourcemaps upload --org sage-bionetworks --project model-ad --release model-ad@$SENTRY_RELEASE_SUFFIX dist/apps/model-ad/app",
           "find dist/apps/model-ad/app -name '*.map' -delete"
         ],
         "parallel": false
       },
-      "dependsOn": ["build"]
+      "dependsOn": ["sentry-sourcemaps-inject"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/model-ad/app/project.json
+++ b/apps/model-ad/app/project.json
@@ -173,7 +173,10 @@
       "dependsOn": ["sentry-sourcemaps-inject"]
     },
     "build-image": {
-      "dependsOn": ["sentry-sourcemaps-inject"]
+      "dependsOn": ["sentry-sourcemaps-inject"],
+      "metadata": {
+        "description": "Depends on sentry-sourcemaps-inject (not build) so the Sentry Debug IDs survive Nx's cached build restore and are baked into the published image. See MG-902."
+      }
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/model-ad/app/project.json
+++ b/apps/model-ad/app/project.json
@@ -172,6 +172,9 @@
       },
       "dependsOn": ["sentry-sourcemaps-inject"]
     },
+    "build-image": {
+      "dependsOn": ["sentry-sourcemaps-inject"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/qtl/app/project.json
+++ b/apps/qtl/app/project.json
@@ -167,7 +167,10 @@
       "dependsOn": ["sentry-sourcemaps-inject"]
     },
     "build-image": {
-      "dependsOn": ["sentry-sourcemaps-inject"]
+      "dependsOn": ["sentry-sourcemaps-inject"],
+      "metadata": {
+        "description": "Depends on sentry-sourcemaps-inject (not build) so the Sentry Debug IDs survive Nx's cached build restore and are baked into the published image. See MG-902."
+      }
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/qtl/app/project.json
+++ b/apps/qtl/app/project.json
@@ -148,17 +148,23 @@
       },
       "dependsOn": []
     },
-    "sentry-sourcemaps": {
+    "sentry-sourcemaps-inject": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "sentry-cli sourcemaps inject dist/apps/qtl/app"
+      },
+      "dependsOn": ["build"]
+    },
+    "sentry-sourcemaps-upload": {
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "sentry-cli sourcemaps inject dist/apps/qtl/app",
           "sentry-cli sourcemaps upload --org sage-bionetworks --project qtl --release qtl@$SENTRY_RELEASE_SUFFIX dist/apps/qtl/app",
           "find dist/apps/qtl/app -name '*.map' -delete"
         ],
         "parallel": false
       },
-      "dependsOn": ["build"]
+      "dependsOn": ["sentry-sourcemaps-inject"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/qtl/app/project.json
+++ b/apps/qtl/app/project.json
@@ -166,6 +166,9 @@
       },
       "dependsOn": ["sentry-sourcemaps-inject"]
     },
+    "build-image": {
+      "dependsOn": ["sentry-sourcemaps-inject"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {


### PR DESCRIPTION
## Description

Sentry stack traces for Agora, Model-AD, and QTL resolved to minified chunk paths instead of
the original TypeScript source, because the deployed bundles and the uploaded sourcemaps
carried mismatched Debug IDs. The Nx `build-image` task depends on the cached `build` output,
so when it ran after the separate `sentry-sourcemaps-inject` step, Nx restored the
pre-injection bundles from cache and stripped the Debug IDs back out before packaging the
image — publishing bundles with no Debug ID while Sentry held maps that did. This change makes
`build-image` depend on `sentry-sourcemaps-inject` so injection happens inside the same Nx task
graph (after the cache restore), guaranteeing the published image and the uploaded sourcemaps
share the same content-derived Debug IDs.

## Related Issue

[MG-902](https://sagebionetworks.jira.com/browse/MG-902)

## Changelog

- Make the `build-image` target depend on `sentry-sourcemaps-inject` in `apps/agora/app`, `apps/model-ad/app`, and `apps/qtl/app`, so Debug IDs are injected within the same task graph and survive the cached `build` restore
- Split the single `sentry-sourcemaps` Nx target into `sentry-sourcemaps-inject` (depends on `build`) and `sentry-sourcemaps-upload` (depends on `sentry-sourcemaps-inject`) across the three apps
- Point the post-image Sentry step in `.github/workflows/ci.yml` and `.github/workflows/release.yml` at `sentry-sourcemaps-upload`
- Rely on the `build-image` → `inject` dependency rather than a manual ordering step in the workflows

## Testing

- Trigger a CI run on `main` (push event) and confirm the `build-image` task graph runs `build` → `sentry-sourcemaps-inject` → `build-image` (visible in the Nx task output)
- Trigger a Sentry error on the Sentry test page
- In Sentry, open a new error event from the edge deployment and confirm the stack frame resolves to a `.ts` source file (e.g. `app.component.ts:42`) instead of `/chunk-XXXXX.js`


[MG-902]: https://sagebionetworks.jira.com/browse/MG-902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ