### PR TITLE
feat(explorers): modernize ResourceCardComponent (AG-2118)

### DIFF
--- a/libs/agora/genes/src/lib/components/gene-resources/gene-resources.component.ts
+++ b/libs/agora/genes/src/lib/components/gene-resources/gene-resources.component.ts
@@ -1,7 +1,8 @@
 import { Component, computed, input } from '@angular/core';
 
 import { Gene } from '@sagebionetworks/agora/api-client';
-import { ResourceCardComponent, ResourceCardsComponent } from '@sagebionetworks/explorers/ui';
+import { ResourceCardData } from '@sagebionetworks/explorers/models';
+import { ResourceCardsComponent } from '@sagebionetworks/explorers/ui';
 
 @Component({
   selector: 'agora-gene-resources',
@@ -16,7 +17,7 @@ export class GeneResourcesComponent {
     const gene = this.gene();
     if (!gene) return [];
 
-    const cards: Partial<ResourceCardComponent>[] = [
+    const cards: ResourceCardData[] = [
       {
         imagePath: 'explorers-assets/images/ad-knowledge-portal-logo.svg',
         description: `View the openly available TREAT-AD resources for experimental validation of ${gene.hgnc_symbol || gene.ensembl_gene_id} in the AD Knowledge Portal.`,
@@ -45,7 +46,7 @@ export class GeneResourcesComponent {
     return cards;
   });
 
-  drugDevelopmentResources = computed((): Partial<ResourceCardComponent>[] => {
+  drugDevelopmentResources = computed((): ResourceCardData[] => {
     const gene = this.gene();
     if (!gene) return [];
 
@@ -82,7 +83,7 @@ export class GeneResourcesComponent {
     ];
   });
 
-  additionalResources = computed((): Partial<ResourceCardComponent>[] => {
+  additionalResources = computed((): ResourceCardData[] => {
     const gene = this.gene();
     if (!gene) return [];
 

--- a/libs/explorers/models/src/index.ts
+++ b/libs/explorers/models/src/index.ts
@@ -3,6 +3,7 @@ export * from './lib/comparison-tool';
 export * from './lib/loading-icon-colors';
 export * from './lib/navigation-link';
 export * from './lib/panel';
+export * from './lib/resource-card-data';
 export * from './lib/search-result';
 export * from './lib/simple-table';
 export * from './lib/synapse-wiki';

--- a/libs/explorers/models/src/lib/resource-card-data.ts
+++ b/libs/explorers/models/src/lib/resource-card-data.ts
@@ -1,0 +1,7 @@
+export interface ResourceCardData {
+  link: string;
+  description: string;
+  imagePath: string;
+  title?: string;
+  altText?: string;
+}

--- a/libs/explorers/ui/src/lib/components/resource-card/resource-card.component.html
+++ b/libs/explorers/ui/src/lib/components/resource-card/resource-card.component.html
@@ -1,14 +1,14 @@
 <div class="resource-card">
-  <a target="_blank" [href]="link" [attr.aria-label]="description">
-    <div [class]="`content ${title ? 'row' : 'column'}`">
+  <a target="_blank" [href]="link()" [attr.aria-label]="description()">
+    <div [class]="'content ' + (title() ? 'row' : 'column')">
       <div class="image">
-        <explorers-svg-image [imagePath]="imagePath" [altText]="altText" />
+        <explorers-svg-image [imagePath]="imagePath()" [altText]="altText()" />
       </div>
       <div class="text-content">
-        @if (title) {
-          <div class="title">{{ title }}</div>
+        @if (title()) {
+          <div class="title">{{ title() }}</div>
         }
-        <div class="description">{{ description }}</div>
+        <div class="description">{{ description() }}</div>
       </div>
     </div>
   </a>

--- a/libs/explorers/ui/src/lib/components/resource-card/resource-card.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/resource-card/resource-card.component.spec.ts
@@ -1,3 +1,4 @@
+import { ResourceCardData } from '@sagebionetworks/explorers/models';
 import { render, screen } from '@testing-library/angular';
 import { ResourceCardComponent } from './resource-card.component';
 
@@ -9,7 +10,7 @@ const mockExternalLink = 'https://synapse.org';
 const mockAltText = 'Test alt text';
 
 describe('ResourceCardComponent', () => {
-  async function setup(inputs?: Partial<ResourceCardComponent>) {
+  async function setup(inputs?: Partial<ResourceCardData>) {
     const component = await render(ResourceCardComponent, {
       componentInputs: {
         imagePath: '/assets/test.svg',

--- a/libs/explorers/ui/src/lib/components/resource-card/resource-card.component.ts
+++ b/libs/explorers/ui/src/lib/components/resource-card/resource-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { SvgImageComponent } from '../svg-image/svg-image.component';
 
 @Component({
@@ -8,10 +8,9 @@ import { SvgImageComponent } from '../svg-image/svg-image.component';
   styleUrls: ['./resource-card.component.scss'],
 })
 export class ResourceCardComponent {
-  @Input({ required: true }) link = '';
-  @Input({ required: true }) description = '';
-  @Input() title: string | undefined = undefined;
-
-  @Input({ required: true }) imagePath = '';
-  @Input() altText = '';
+  link = input.required<string>();
+  description = input.required<string>();
+  imagePath = input.required<string>();
+  title = input<string | undefined>();
+  altText = input<string>('');
 }

--- a/libs/explorers/ui/src/lib/components/resource-cards/resource-cards.component.html
+++ b/libs/explorers/ui/src/lib/components/resource-cards/resource-cards.component.html
@@ -1,11 +1,11 @@
 <div class="resource-cards">
   @for (card of cards(); track $index) {
     <explorers-resource-card
-      [link]="card.link || ''"
-      [description]="card.description || ''"
+      [link]="card.link"
+      [description]="card.description"
+      [imagePath]="card.imagePath"
       [title]="card.title"
-      [imagePath]="card.imagePath || ''"
-      [altText]="card.altText || ''"
+      [altText]="card.altText ?? ''"
     />
   }
 </div>

--- a/libs/explorers/ui/src/lib/components/resource-cards/resource-cards.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/resource-cards/resource-cards.component.spec.ts
@@ -1,8 +1,8 @@
+import { ResourceCardData } from '@sagebionetworks/explorers/models';
 import { render, screen } from '@testing-library/angular';
-import { ResourceCardComponent } from '../resource-card/resource-card.component';
 import { ResourceCardsComponent } from './resource-cards.component';
 
-async function setup(cards: Partial<ResourceCardComponent>[]) {
+async function setup(cards: ResourceCardData[]) {
   return render(ResourceCardsComponent, {
     componentInputs: {
       cards,
@@ -12,12 +12,31 @@ async function setup(cards: Partial<ResourceCardComponent>[]) {
 
 describe('ResourceCardsComponent', () => {
   it('should render one resource card for each item in cards', async () => {
-    const cards = [{ title: 'Card 1' }, { title: 'Card 2' }, { title: 'Card 3' }];
+    const cards: ResourceCardData[] = [
+      {
+        title: 'Card 1',
+        description: 'Description 1',
+        link: 'https://example.com/1',
+        imagePath: '/img1.svg',
+      },
+      {
+        title: 'Card 2',
+        description: 'Description 2',
+        link: 'https://example.com/2',
+        imagePath: '/img2.svg',
+      },
+      {
+        title: 'Card 3',
+        description: 'Description 3',
+        link: 'https://example.com/3',
+        imagePath: '/img3.svg',
+      },
+    ];
     await setup(cards);
 
-    expect(screen.getByText(cards[0].title)).toBeInTheDocument();
-    expect(screen.getByText(cards[1].title)).toBeInTheDocument();
-    expect(screen.getByText(cards[2].title)).toBeInTheDocument();
+    expect(screen.getByText('Card 1')).toBeInTheDocument();
+    expect(screen.getByText('Card 2')).toBeInTheDocument();
+    expect(screen.getByText('Card 3')).toBeInTheDocument();
   });
 
   it('should handle empty cards array gracefully', async () => {

--- a/libs/explorers/ui/src/lib/components/resource-cards/resource-cards.component.ts
+++ b/libs/explorers/ui/src/lib/components/resource-cards/resource-cards.component.ts
@@ -1,5 +1,5 @@
-
 import { Component, input } from '@angular/core';
+import { ResourceCardData } from '@sagebionetworks/explorers/models';
 import { ResourceCardComponent } from '../resource-card/resource-card.component';
 
 @Component({
@@ -9,5 +9,5 @@ import { ResourceCardComponent } from '../resource-card/resource-card.component'
   styleUrls: ['./resource-cards.component.scss'],
 })
 export class ResourceCardsComponent {
-  cards = input.required<Partial<ResourceCardComponent>[]>();
+  cards = input.required<ResourceCardData[]>();
 }


### PR DESCRIPTION
## Description

`ResourceCardComponent` still used the legacy decorator-based `@Input()` API, and its container `ResourceCardsComponent` typed its data as `Partial<ResourceCardComponent>` — leaking the component type into data contracts and weakening type safety. This PR modernizes the component to the signal `input()` API and introduces a dedicated `ResourceCardData` model so cards are described by a real data interface rather than a partial of the component.

## Related Issue

- [AG-2118](https://sagebionetworks.jira.com/browse/AG-2118) — Modernize ResourceCardComponent Shared Component

## Changelog

- Convert `ResourceCardComponent` from `@Input()` decorators to the signal `input()` API
- Add a `ResourceCardData` model and export it from `explorers/models`
- Type `ResourceCardsComponent.cards` as `ResourceCardData[]` instead of `Partial<ResourceCardComponent>[]`
- Update the Agora `GeneResourcesComponent` consumer to type its card arrays as `ResourceCardData[]`
- Update resource-card and resource-cards specs to use the `ResourceCardData` contract

## Testing

- View a gene details page in Agora (e.g. `/genes/<ensembl-id>`) and confirm the resource cards still render with correct images, titles, descriptions, and external links
- Confirm cards with a `title` render in the row layout and cards without a title render in the column layout
- Confirm each card link still opens in a new tab and exposes the description as its `aria-label`


## Preview

Agora (Resources tab)

| Before                   | After (should be same as before):                   |
| ------------------------ | ----------------------- |
| <img width="950" height="663" alt="image" src="https://github.com/user-attachments/assets/a74a6036-0539-4d69-b03b-d001efcdf254" /> | <img width="989" height="706" alt="image" src="https://github.com/user-attachments/assets/c19c8bd1-6437-459c-aa2f-5a83d2b2a073" /> |

Model-AD (Resources tab)

| Before                   | After (should be same as before):                   |
| ------------------------ | ----------------------- |
| <img width="1100" height="568" alt="image" src="https://github.com/user-attachments/assets/c348f485-3d4c-49f4-adc2-7809db15d191" /> | <img width="1106" height="604" alt="image" src="https://github.com/user-attachments/assets/01f323e1-fae0-4a27-a5e6-fecf562db116" /> |


[AG-2118]: https://sagebionetworks.jira.com/browse/AG-2118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ