### PR TITLE
feat(explorers): add opt-in row selection and hover highlighting to comparison tool (QTL-49)

### DIFF
--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.html
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.html
@@ -22,11 +22,21 @@
     </ng-template>
 
     <ng-template pTemplate="body" let-rowData>
-      <tr>
+      @let rowId = rowData[viewConfig().rowIdDataKey];
+      <tr
+        (click)="onRowClick(rowId)"
+        (mouseenter)="onRowMouseEnter(rowId)"
+        (mouseleave)="onRowMouseLeave()"
+        [class.selected]="
+          viewConfig().rowSelectionEnabled && comparisonToolService.selectedRowId() === rowId
+        "
+        [class.hovered]="
+          viewConfig().rowHoverEnabled && comparisonToolService.hoveredRowId() === rowId
+        "
+      >
         @for (column of selectedColumns(); track column) {
           @let columnType = column.type;
           @let cellData = rowData[column.data_key];
-          @let rowId = rowData[this.viewConfig().rowIdDataKey];
           <td
             [style]="{ width: columnWidths()[column.data_key] || 'auto' }"
             [class]="columnType"

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.html
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.html
@@ -22,7 +22,7 @@
     </ng-template>
 
     <ng-template pTemplate="body" let-rowData>
-      @let rowId = rowData[viewConfig().rowIdDataKey];
+      @let rowId = String(rowData[viewConfig().rowIdDataKey]);
       <tr
         (click)="onRowClick(rowId)"
         (mouseenter)="onRowMouseEnter(rowId)"

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.scss
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.scss
@@ -22,6 +22,21 @@
       word-wrap: break-word;
       overflow-wrap: break-word;
     }
+
+    tr {
+      &.hovered,
+      &.selected {
+        background-color: var(--color-comparison-tool-row-highlight) !important;
+
+        // PrimeNG transitions background on `tr` but not on `td`, so the trailing area
+        // past the last column would animate while cells snap. Suppressing it keeps the row in sync.
+        transition: none !important;
+
+        td {
+          background-color: var(--color-comparison-tool-row-highlight) !important;
+        }
+      }
+    }
   }
 
   .heatmap-circle-button {

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.spec.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.spec.ts
@@ -20,7 +20,10 @@ import userEvent from '@testing-library/user-event';
 import { MessageService } from 'primeng/api';
 import { BaseTableComponent } from './base-table.component';
 
-async function setup(viewConfig?: Partial<ComparisonToolViewConfig>) {
+async function setup(
+  viewConfig?: Partial<ComparisonToolViewConfig>,
+  data: Record<string, unknown>[] = mockComparisonToolData,
+) {
   const user = userEvent.setup();
   const component = await render(BaseTableComponent, {
     imports: [RouterModule],
@@ -35,9 +38,7 @@ async function setup(viewConfig?: Partial<ComparisonToolViewConfig>) {
       ...provideComparisonToolFilterService({ significanceThresholdActive: false }),
       { provide: SvgIconService, useClass: SvgIconServiceStub },
     ],
-    componentInputs: {
-      data: mockComparisonToolData,
-    },
+    componentInputs: { data },
   });
 
   const fixture = component.fixture;
@@ -232,6 +233,23 @@ describe('BaseTableComponent', () => {
 
       const firstRowId = String(mockComparisonToolData[0]['_id']);
       service.selectRow(firstRowId);
+      fixture.detectChanges();
+
+      const rows = nativeElement.querySelectorAll('tr.selected');
+      expect(rows.length).toBe(1);
+    });
+
+    it('.selected class appears when rowIdDataKey is a numeric value', async () => {
+      const numericData = [
+        { id: 1, name: 'Row One' },
+        { id: 2, name: 'Row Two' },
+      ];
+      const { fixture, service, nativeElement } = await setup(
+        { rowSelectionEnabled: true, rowIdDataKey: 'id' },
+        numericData,
+      );
+
+      service.selectRow('1');
       fixture.detectChanges();
 
       const rows = nativeElement.querySelectorAll('tr.selected');

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.spec.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.spec.ts
@@ -15,12 +15,12 @@ import {
   mockComparisonToolDataConfig,
   SvgIconServiceStub,
 } from '@sagebionetworks/explorers/testing';
-import { MessageService } from 'primeng/api';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
+import { MessageService } from 'primeng/api';
 import { BaseTableComponent } from './base-table.component';
 
-async function setup() {
+async function setup(viewConfig?: Partial<ComparisonToolViewConfig>) {
   const user = userEvent.setup();
   const component = await render(BaseTableComponent, {
     imports: [RouterModule],
@@ -28,7 +28,10 @@ async function setup() {
       provideRouter([]),
       provideHttpClient(withInterceptorsFromDi()),
       MessageService,
-      ...provideComparisonToolService({ configs: mockComparisonToolDataConfig }),
+      ...provideComparisonToolService({
+        configs: mockComparisonToolDataConfig,
+        viewConfig,
+      }),
       ...provideComparisonToolFilterService({ significanceThresholdActive: false }),
       { provide: SvgIconService, useClass: SvgIconServiceStub },
     ],
@@ -149,6 +152,107 @@ describe('BaseTableComponent', () => {
         expect.any(String),
         expect.any(MouseEvent),
       );
+    });
+  });
+
+  describe('row selection and hover', () => {
+    it('clicking a row calls selectRow() when rowSelectionEnabled=true', async () => {
+      const { fixture, service, nativeElement, user } = await setup({
+        rowSelectionEnabled: true,
+        rowIdDataKey: '_id',
+      });
+      fixture.detectChanges();
+
+      const selectSpy = jest.spyOn(service, 'selectRow');
+      const firstRow =
+        nativeElement.querySelector('tr[class]') ?? nativeElement.querySelector('tr');
+      if (firstRow) {
+        await user.click(firstRow);
+      }
+      expect(selectSpy).toHaveBeenCalled();
+    });
+
+    it('clicking a row does nothing when rowSelectionEnabled=false', async () => {
+      const { fixture, service, nativeElement, user } = await setup({ rowIdDataKey: '_id' });
+      fixture.detectChanges();
+
+      const firstRow = nativeElement.querySelector('tr');
+      if (firstRow) {
+        await user.click(firstRow);
+      }
+      expect(service.selectedRowId()).toBeNull();
+    });
+
+    it('mouseenter calls setHoveredRowId() when rowHoverEnabled=true', async () => {
+      const { fixture, service, nativeElement } = await setup({
+        rowHoverEnabled: true,
+        rowIdDataKey: '_id',
+      });
+      fixture.detectChanges();
+
+      const hoverSpy = jest.spyOn(service, 'setHoveredRowId');
+      const firstRow =
+        nativeElement.querySelector('tr[class]') ?? nativeElement.querySelector('tr');
+      if (firstRow) {
+        firstRow.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      }
+      expect(hoverSpy).toHaveBeenCalled();
+    });
+
+    it('mouseleave calls setHoveredRowId(null) when rowHoverEnabled=true', async () => {
+      const { fixture, service, nativeElement } = await setup({
+        rowHoverEnabled: true,
+        rowIdDataKey: '_id',
+      });
+      fixture.detectChanges();
+
+      const hoverSpy = jest.spyOn(service, 'setHoveredRowId');
+      const firstRow =
+        nativeElement.querySelector('tr[class]') ?? nativeElement.querySelector('tr');
+      if (firstRow) {
+        firstRow.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+      }
+      expect(hoverSpy).toHaveBeenCalledWith(null);
+    });
+
+    it('mouse events do nothing when rowHoverEnabled=false', async () => {
+      const { fixture, service, nativeElement } = await setup({ rowIdDataKey: '_id' });
+      fixture.detectChanges();
+
+      const firstRow = nativeElement.querySelector('tr');
+      if (firstRow) {
+        firstRow.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+        firstRow.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+      }
+      expect(service.hoveredRowId()).toBeNull();
+    });
+
+    it('.selected class appears on the correct row', async () => {
+      const { fixture, service, nativeElement } = await setup({
+        rowSelectionEnabled: true,
+        rowIdDataKey: '_id',
+      });
+
+      const firstRowId = String(mockComparisonToolData[0]['_id']);
+      service.selectRow(firstRowId);
+      fixture.detectChanges();
+
+      const rows = nativeElement.querySelectorAll('tr.selected');
+      expect(rows.length).toBe(1);
+    });
+
+    it('.hovered class appears on the correct row', async () => {
+      const { fixture, service, nativeElement } = await setup({
+        rowHoverEnabled: true,
+        rowIdDataKey: '_id',
+      });
+
+      const firstRowId = String(mockComparisonToolData[0]['_id']);
+      service.setHoveredRowId(firstRowId);
+      fixture.detectChanges();
+
+      const rows = nativeElement.querySelectorAll('tr.hovered');
+      expect(rows.length).toBe(1);
     });
   });
 });

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.spec.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.spec.ts
@@ -164,8 +164,7 @@ describe('BaseTableComponent', () => {
       fixture.detectChanges();
 
       const selectSpy = jest.spyOn(service, 'selectRow');
-      const firstRow =
-        nativeElement.querySelector('tr[class]') ?? nativeElement.querySelector('tr');
+      const firstRow = nativeElement.querySelector('tbody tr');
       if (firstRow) {
         await user.click(firstRow);
       }
@@ -176,7 +175,7 @@ describe('BaseTableComponent', () => {
       const { fixture, service, nativeElement, user } = await setup({ rowIdDataKey: '_id' });
       fixture.detectChanges();
 
-      const firstRow = nativeElement.querySelector('tr');
+      const firstRow = nativeElement.querySelector('tbody tr');
       if (firstRow) {
         await user.click(firstRow);
       }
@@ -191,8 +190,7 @@ describe('BaseTableComponent', () => {
       fixture.detectChanges();
 
       const hoverSpy = jest.spyOn(service, 'setHoveredRowId');
-      const firstRow =
-        nativeElement.querySelector('tr[class]') ?? nativeElement.querySelector('tr');
+      const firstRow = nativeElement.querySelector('tbody tr');
       if (firstRow) {
         firstRow.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
       }
@@ -207,8 +205,7 @@ describe('BaseTableComponent', () => {
       fixture.detectChanges();
 
       const hoverSpy = jest.spyOn(service, 'setHoveredRowId');
-      const firstRow =
-        nativeElement.querySelector('tr[class]') ?? nativeElement.querySelector('tr');
+      const firstRow = nativeElement.querySelector('tbody tr');
       if (firstRow) {
         firstRow.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
       }
@@ -219,7 +216,7 @@ describe('BaseTableComponent', () => {
       const { fixture, service, nativeElement } = await setup({ rowIdDataKey: '_id' });
       fixture.detectChanges();
 
-      const firstRow = nativeElement.querySelector('tr');
+      const firstRow = nativeElement.querySelector('tbody tr');
       if (firstRow) {
         firstRow.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
         firstRow.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.ts
@@ -23,6 +23,7 @@ import { PrimaryIdentifierControlsComponent } from '../primary-identifier-contro
 })
 export class BaseTableComponent {
   protected readonly comparisonToolService = inject(ComparisonToolService);
+  protected readonly String = String;
 
   selectedColumns = this.comparisonToolService.selectedColumns;
   viewConfig = this.comparisonToolService.viewConfig;

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.ts
@@ -43,4 +43,16 @@ export class BaseTableComponent {
   onHeatmapCircleClick(rowData: unknown, cellData: unknown, columnKey: string, event: Event): void {
     this.comparisonToolService.showHeatmapDetailsPanel(rowData, cellData, columnKey, event);
   }
+
+  onRowClick(rowId: string): void {
+    this.comparisonToolService.selectRow(rowId);
+  }
+
+  onRowMouseEnter(rowId: string): void {
+    this.comparisonToolService.setHoveredRowId(rowId);
+  }
+
+  onRowMouseLeave(): void {
+    this.comparisonToolService.setHoveredRowId(null);
+  }
 }

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/base-table/base-table.component.ts
@@ -22,7 +22,7 @@ import { PrimaryIdentifierControlsComponent } from '../primary-identifier-contro
   encapsulation: ViewEncapsulation.None,
 })
 export class BaseTableComponent {
-  readonly comparisonToolService = inject(ComparisonToolService);
+  protected readonly comparisonToolService = inject(ComparisonToolService);
 
   selectedColumns = this.comparisonToolService.selectedColumns;
   viewConfig = this.comparisonToolService.viewConfig;

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-table.component.stories.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-table.component.stories.ts
@@ -109,3 +109,25 @@ export const FiltersActiveMaxPinned: Story = {
     }),
   ],
 };
+
+export const RowSelectionAndHover: Story = {
+  args: {},
+  decorators: [
+    applicationConfig({
+      providers: [
+        MessageService,
+        ...provideComparisonToolService({
+          pinnedItems: [],
+          maxPinnedItems: 5,
+          pinnedData: [],
+          unpinnedData: mockComparisonToolData,
+          configs: mockComparisonToolDataConfig,
+          viewConfig: {
+            rowSelectionEnabled: true,
+            rowHoverEnabled: true,
+          },
+        }),
+      ],
+    }),
+  ],
+};

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-table.component.stories.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-table.component.stories.ts
@@ -125,6 +125,7 @@ export const RowSelectionAndHover: Story = {
           viewConfig: {
             rowSelectionEnabled: true,
             rowHoverEnabled: true,
+            rowIdDataKey: '_id',
           },
         }),
       ],

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool.component.stories.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool.component.stories.ts
@@ -5,6 +5,7 @@ import { provideRouter } from '@angular/router';
 import {
   ComparisonToolConfig,
   ComparisonToolViewConfig,
+  HeatmapCircleClickTransformFnContext,
   LegendPanelConfig,
   SynapseWikiParams,
 } from '@sagebionetworks/explorers/models';
@@ -38,6 +39,9 @@ type StoryArgs = Omit<
   visualizationOverviewVisible?: boolean;
   // Sidebar
   hasSidebar?: boolean;
+  // Row interaction
+  rowSelectionEnabled?: boolean;
+  rowHoverEnabled?: boolean;
 };
 
 // Inner component that provides services - will be remounted when configs change
@@ -89,6 +93,9 @@ class ComparisonToolInnerComponent {
   visualizationOverviewVisible = input<boolean>();
   // Sidebar input
   hasSidebar = input<boolean>();
+  // Row interaction inputs
+  rowSelectionEnabled = input<boolean>();
+  rowHoverEnabled = input<boolean>();
 
   private readonly comparisonToolService = inject(ComparisonToolService);
 
@@ -131,6 +138,24 @@ class ComparisonToolInnerComponent {
       viewConfig.allowPinnedImageDownload = this.allowPinnedImageDownload();
       viewConfig.defaultSort = this.defaultSort();
       viewConfig.linkExportField = this.linkExportField();
+      viewConfig.rowSelectionEnabled = this.rowSelectionEnabled();
+      viewConfig.rowHoverEnabled = this.rowHoverEnabled();
+      viewConfig.heatmapCircleClickTransformFn = ({
+        rowData,
+        cellData,
+        columnKey,
+      }: HeatmapCircleClickTransformFnContext) => {
+        const row = rowData as Record<string, unknown>;
+        const cell = cellData as Record<string, unknown>;
+        return {
+          heading: String(row['name']),
+          subHeadings: [columnKey],
+          value: cell['correlation'] as number,
+          valueLabel: 'Correlation',
+          pValue: cell['adj_p_val'] as number,
+          footer: 'Significance is considered to be an adjusted p-value < 0.05',
+        };
+      };
 
       this.comparisonToolService.setViewConfig(viewConfig);
 
@@ -201,6 +226,8 @@ class ComparisonToolInnerComponent {
         [legendVisible]="legendVisible()"
         [visualizationOverviewVisible]="visualizationOverviewVisible()"
         [hasSidebar]="hasSidebar()"
+        [rowSelectionEnabled]="rowSelectionEnabled()"
+        [rowHoverEnabled]="rowHoverEnabled()"
       />
     }
   `,
@@ -226,6 +253,8 @@ class ComparisonToolStoryWrapperComponent {
   legendVisible = input<boolean>();
   visualizationOverviewVisible = input<boolean>();
   hasSidebar = input<boolean>();
+  rowSelectionEnabled = input<boolean>();
+  rowHoverEnabled = input<boolean>();
 
   // Key changes when configs or defaultSort change, triggering inner component remount
   protected readonly configKey = computed(() => {
@@ -358,6 +387,19 @@ const meta: Meta<StoryArgs> = {
         'User can toggle visibility afterward.',
       table: { category: 'Controls' },
     },
+    // Row interaction category
+    rowSelectionEnabled: {
+      control: 'boolean',
+      description:
+        'Enables click-to-select row highlighting. The selected row ID is available via `comparisonToolService.selectedRowId()`. Auto-selects the first unpinned row on initial data load.',
+      table: { category: 'Table' },
+    },
+    rowHoverEnabled: {
+      control: 'boolean',
+      description:
+        'Enables hover row highlighting. The hovered row ID is available via `comparisonToolService.hoveredRowId()` for use by other components.',
+      table: { category: 'Table' },
+    },
     // Sidebar category
     hasSidebar: {
       control: 'boolean',
@@ -425,6 +467,9 @@ export const Demo: Story = {
     // Panel visibility
     legendVisible: false,
     visualizationOverviewVisible: false,
+    // Row interaction
+    rowSelectionEnabled: true,
+    rowHoverEnabled: true,
   },
 };
 

--- a/libs/explorers/models/src/lib/comparison-tool.ts
+++ b/libs/explorers/models/src/lib/comparison-tool.ts
@@ -69,6 +69,8 @@ export interface ComparisonToolViewConfig {
   defaultSort?: readonly { readonly field: string; readonly order: 1 | -1 }[];
   heatmapCircleClickTransformFn?: heatmapCircleClickTransformFn;
   linkExportField: 'link_url' | 'link_text';
+  rowSelectionEnabled?: boolean;
+  rowHoverEnabled?: boolean;
   showTableSearch?: boolean;
 }
 

--- a/libs/explorers/services/src/lib/comparison-tool.service.spec.ts
+++ b/libs/explorers/services/src/lib/comparison-tool.service.spec.ts
@@ -860,6 +860,117 @@ describe('ComparisonToolService', () => {
     });
   });
 
+  describe('row selection', () => {
+    it('selectRow() sets selectedRowId', () => {
+      connectService();
+      service.setViewConfig({ rowSelectionEnabled: true });
+      service.selectRow('row-1');
+      expect(service.selectedRowId()).toBe('row-1');
+    });
+
+    it('selectRow() is a no-op when same ID is already selected', () => {
+      connectService();
+      service.setViewConfig({ rowSelectionEnabled: true });
+      service.selectRow('row-1');
+      expect(service.selectedRowId()).toBe('row-1');
+      service.selectRow('row-1');
+      expect(service.selectedRowId()).toBe('row-1');
+    });
+
+    it('selectRow() is a no-op when rowSelectionEnabled is false', () => {
+      connectService();
+      service.selectRow('row-1');
+      expect(service.selectedRowId()).toBeNull();
+    });
+
+    it('setHoveredRowId() sets hoveredRowId', () => {
+      connectService();
+      service.setViewConfig({ rowHoverEnabled: true });
+      service.setHoveredRowId('row-1');
+      expect(service.hoveredRowId()).toBe('row-1');
+    });
+
+    it('setHoveredRowId() clears hoveredRowId when null is passed', () => {
+      connectService();
+      service.setViewConfig({ rowHoverEnabled: true });
+      service.setHoveredRowId('row-1');
+      service.setHoveredRowId(null);
+      expect(service.hoveredRowId()).toBeNull();
+    });
+
+    it('setHoveredRowId() is a no-op when rowHoverEnabled is false', () => {
+      connectService();
+      service.setHoveredRowId('row-1');
+      expect(service.hoveredRowId()).toBeNull();
+    });
+
+    it('setUnpinnedData() auto-selects first unpinned row when rowSelectionEnabled=true and selectedRowId is null', () => {
+      connectService();
+      service.setViewConfig({ rowSelectionEnabled: true, rowIdDataKey: '_id' });
+      service.setUnpinnedData([{ _id: 'row-1' }, { _id: 'row-2' }]);
+      expect(service.selectedRowId()).toBe('row-1');
+    });
+
+    it('setUnpinnedData() falls back to first pinned row when unpinned is empty and selectedRowId is null', () => {
+      connectService();
+      service.setViewConfig({ rowSelectionEnabled: true, rowIdDataKey: '_id' });
+      service.setPinnedData([{ _id: 'pinned-1' }]);
+      service.setUnpinnedData([]);
+      expect(service.selectedRowId()).toBe('pinned-1');
+    });
+
+    it('setUnpinnedData() does not auto-select when rowSelectionEnabled is false', () => {
+      connectService();
+      service.setUnpinnedData([{ _id: 'row-1' }]);
+      expect(service.selectedRowId()).toBeNull();
+    });
+
+    it('setUnpinnedData() does not overwrite an existing selection', () => {
+      connectService();
+      service.setViewConfig({ rowSelectionEnabled: true, rowIdDataKey: '_id' });
+      service.setUnpinnedData([{ _id: 'row-1' }]);
+      expect(service.selectedRowId()).toBe('row-1');
+      service.selectRow('row-2');
+      service.setUnpinnedData([{ _id: 'row-1' }, { _id: 'row-2' }]);
+      expect(service.selectedRowId()).toBe('row-2');
+    });
+
+    it('notifySelectedRowValidity(false) resets and re-selects first row', () => {
+      connectService();
+      service.setViewConfig({ rowSelectionEnabled: true, rowIdDataKey: '_id' });
+      service.setUnpinnedData([{ _id: 'row-1' }, { _id: 'row-2' }]);
+      service.selectRow('row-2');
+      service.notifySelectedRowValidity(false);
+      expect(service.selectedRowId()).toBe('row-1');
+    });
+
+    it('notifySelectedRowValidity(false) is a no-op when selected row is in pinned data', () => {
+      connectService();
+      service.setViewConfig({ rowSelectionEnabled: true, rowIdDataKey: '_id' });
+      service.setPinnedData([{ _id: 'pinned-1' }]);
+      service.setUnpinnedData([{ _id: 'row-1' }]);
+      service.selectRow('pinned-1');
+      service.notifySelectedRowValidity(false);
+      expect(service.selectedRowId()).toBe('pinned-1');
+    });
+
+    it('notifySelectedRowValidity(true) is a no-op', () => {
+      connectService();
+      service.setViewConfig({ rowSelectionEnabled: true, rowIdDataKey: '_id' });
+      service.setUnpinnedData([{ _id: 'row-1' }]);
+      service.selectRow('row-1');
+      service.notifySelectedRowValidity(true);
+      expect(service.selectedRowId()).toBe('row-1');
+    });
+
+    it('notifySelectedRowValidity() is a no-op when rowSelectionEnabled is false', () => {
+      connectService();
+      service.setUnpinnedData([{ _id: 'row-1' }]);
+      service.notifySelectedRowValidity(false);
+      expect(service.selectedRowId()).toBeNull();
+    });
+  });
+
   describe('loading state', () => {
     it('should have isLoading false initially', () => {
       connectService();

--- a/libs/explorers/services/src/lib/comparison-tool.service.spec.ts
+++ b/libs/explorers/services/src/lib/comparison-tool.service.spec.ts
@@ -904,36 +904,72 @@ describe('ComparisonToolService', () => {
       expect(service.hoveredRowId()).toBeNull();
     });
 
-    it('setUnpinnedData() auto-selects first unpinned row when rowSelectionEnabled=true and selectedRowId is null', () => {
+    it('auto-selects first unpinned row when fetches complete and rowSelectionEnabled=true', fakeAsync(() => {
       connectService();
       service.setViewConfig({ rowSelectionEnabled: true, rowIdDataKey: '_id' });
+      service.startFetch();
       service.setUnpinnedData([{ _id: 'row-1' }, { _id: 'row-2' }]);
+      tick();
       expect(service.selectedRowId()).toBe('row-1');
-    });
+    }));
 
-    it('setUnpinnedData() falls back to first pinned row when unpinned is empty and selectedRowId is null', () => {
+    it('falls back to first pinned row when unpinned is empty and fetches complete', fakeAsync(() => {
       connectService();
       service.setViewConfig({ rowSelectionEnabled: true, rowIdDataKey: '_id' });
+      service.startFetch();
+      service.startFetch();
       service.setPinnedData([{ _id: 'pinned-1' }]);
       service.setUnpinnedData([]);
+      tick();
       expect(service.selectedRowId()).toBe('pinned-1');
-    });
+    }));
 
-    it('setUnpinnedData() does not auto-select when rowSelectionEnabled is false', () => {
-      connectService();
-      service.setUnpinnedData([{ _id: 'row-1' }]);
-      expect(service.selectedRowId()).toBeNull();
-    });
-
-    it('setUnpinnedData() does not overwrite an existing selection', () => {
+    it('auto-selects regardless of which fetch completes first', fakeAsync(() => {
       connectService();
       service.setViewConfig({ rowSelectionEnabled: true, rowIdDataKey: '_id' });
+      service.startFetch();
+      service.startFetch();
       service.setUnpinnedData([{ _id: 'row-1' }]);
+      tick();
+      expect(service.selectedRowId()).toBeNull();
+      service.setPinnedData([]);
+      tick();
+      expect(service.selectedRowId()).toBe('row-1');
+    }));
+
+    it('auto-selects unpinned[0] whether pinned or unpinned data arrives first', fakeAsync(() => {
+      // pinned arrives first
+      connectService();
+      service.setViewConfig({ rowSelectionEnabled: true, rowIdDataKey: '_id' });
+      service.startFetch();
+      service.startFetch();
+      service.setPinnedData([{ _id: 'pinned-1' }]);
+      service.setUnpinnedData([{ _id: 'row-1' }]);
+      tick();
+      expect(service.selectedRowId()).toBe('row-1');
+    }));
+
+    it('does not auto-select when rowSelectionEnabled is false', fakeAsync(() => {
+      connectService();
+      service.startFetch();
+      service.setUnpinnedData([{ _id: 'row-1' }]);
+      tick();
+      expect(service.selectedRowId()).toBeNull();
+    }));
+
+    it('does not overwrite an existing selection when new data arrives', fakeAsync(() => {
+      connectService();
+      service.setViewConfig({ rowSelectionEnabled: true, rowIdDataKey: '_id' });
+      service.startFetch();
+      service.setUnpinnedData([{ _id: 'row-1' }]);
+      tick();
       expect(service.selectedRowId()).toBe('row-1');
       service.selectRow('row-2');
+      service.startFetch();
       service.setUnpinnedData([{ _id: 'row-1' }, { _id: 'row-2' }]);
+      tick();
       expect(service.selectedRowId()).toBe('row-2');
-    });
+    }));
 
     it('notifySelectedRowValidity(false) resets and re-selects first row', () => {
       connectService();

--- a/libs/explorers/services/src/lib/comparison-tool.service.ts
+++ b/libs/explorers/services/src/lib/comparison-tool.service.ts
@@ -96,6 +96,8 @@ export class ComparisonToolService<T> {
   } | null>(null);
   private readonly isFilterPanelOpenSignal = signal(false);
   private readonly pendingFetchesSignal = signal(0);
+  private readonly selectedRowIdSignal = signal<string | null>(null);
+  private readonly hoveredRowIdSignal = signal<string | null>(null);
 
   // URL Sync State
   private lastSyncedUrlParamsState: ComparisonToolUrlParams | null = null;
@@ -113,6 +115,8 @@ export class ComparisonToolService<T> {
   readonly heatmapDetailsPanelData = this.heatmapDetailsPanelDataSignal.asReadonly();
   readonly isFilterPanelOpen = this.isFilterPanelOpenSignal.asReadonly();
   readonly pendingFetches = this.pendingFetchesSignal.asReadonly();
+  readonly selectedRowId = this.selectedRowIdSignal.asReadonly();
+  readonly hoveredRowId = this.hoveredRowIdSignal.asReadonly();
   readonly isLoadingTableData = computed(() => this.pendingFetches() > 0);
 
   // Computed Query Accessors
@@ -441,6 +445,11 @@ export class ComparisonToolService<T> {
       return;
     }
 
+    // PrimeNG Popover.show() calls stopPropagation, so the click never reaches the <tr>.
+    // Select the row here so heatmap circle clicks still update the selection.
+    const rowIdKey = this.viewConfig().rowIdDataKey;
+    this.selectRow(String((rowData as Record<string, unknown>)[rowIdKey]));
+
     const data = transform({
       rowData,
       cellData,
@@ -588,11 +597,57 @@ export class ComparisonToolService<T> {
   setUnpinnedData(unpinnedData: T[]) {
     this.unpinnedDataSignal.set(unpinnedData);
     this.completeFetch();
+
+    if (this.viewConfig().rowSelectionEnabled && this.selectedRowIdSignal() === null) {
+      this.autoSelectFirstRow();
+    }
   }
 
   setPinnedData(pinnedData: T[]) {
     this.pinnedDataSignal.set(pinnedData);
     this.completeFetch();
+  }
+
+  private autoSelectFirstRow(): void {
+    const unpinned = this.unpinnedDataSignal();
+    const pinned = this.pinnedDataSignal();
+    const rowIdKey = this.viewConfig().rowIdDataKey;
+
+    if (unpinned.length > 0) {
+      this.selectedRowIdSignal.set(String((unpinned[0] as Record<string, unknown>)[rowIdKey]));
+    } else if (pinned.length > 0) {
+      this.selectedRowIdSignal.set(String((pinned[0] as Record<string, unknown>)[rowIdKey]));
+    }
+  }
+
+  selectRow(id: string): void {
+    if (!this.viewConfig().rowSelectionEnabled) return;
+    if (this.selectedRowIdSignal() === id) return;
+    this.selectedRowIdSignal.set(id);
+  }
+
+  setHoveredRowId(id: string | null): void {
+    if (!this.viewConfig().rowHoverEnabled) return;
+    this.hoveredRowIdSignal.set(id);
+  }
+
+  /** Call after a filtered fetch to report whether the selected row exists in the full result set;
+   * resets to first row if not */
+  notifySelectedRowValidity(isInResults: boolean): void {
+    if (!this.viewConfig().rowSelectionEnabled) return;
+    if (isInResults) return;
+
+    const selectedId = this.selectedRowIdSignal();
+    if (selectedId !== null) {
+      const rowIdKey = this.viewConfig().rowIdDataKey;
+      const isInPinned = this.pinnedDataSignal().some(
+        (row) => String((row as Record<string, unknown>)[rowIdKey]) === selectedId,
+      );
+      if (isInPinned) return;
+    }
+
+    this.selectedRowIdSignal.set(null);
+    this.autoSelectFirstRow();
   }
 
   /** Call before starting a data fetch to increment loading counter */

--- a/libs/explorers/services/src/lib/comparison-tool.service.ts
+++ b/libs/explorers/services/src/lib/comparison-tool.service.ts
@@ -147,6 +147,13 @@ export class ComparisonToolService<T> {
   });
 
   constructor() {
+    effect(() => {
+      if (this.isLoadingTableData()) return;
+      if (!this.viewConfig().rowSelectionEnabled) return;
+      if (this.selectedRowIdSignal() !== null) return;
+      this.autoSelectFirstRow();
+    });
+
     // Close the filter panel when the current config has no filters to avoid showing an empty panel.
     effect(() => {
       const config = this.currentConfig();
@@ -597,10 +604,6 @@ export class ComparisonToolService<T> {
   setUnpinnedData(unpinnedData: T[]) {
     this.unpinnedDataSignal.set(unpinnedData);
     this.completeFetch();
-
-    if (this.viewConfig().rowSelectionEnabled && this.selectedRowIdSignal() === null) {
-      this.autoSelectFirstRow();
-    }
   }
 
   setPinnedData(pinnedData: T[]) {

--- a/libs/explorers/styles/src/lib/_root.scss
+++ b/libs/explorers/styles/src/lib/_root.scss
@@ -9,6 +9,10 @@
     --color-#{$key}: #{$color};
   }
 
+  @each $key, $color in vars.$comparison-tool-colors {
+    --color-comparison-tool-#{$key}: #{$color};
+  }
+
   @each $size, $properties in vars.$headings {
     @each $property, $value in $properties {
       --#{$property}-#{$size}: #{$value};

--- a/libs/explorers/styles/src/lib/_variables.scss
+++ b/libs/explorers/styles/src/lib/_variables.scss
@@ -33,6 +33,9 @@ $extra-colors: (
   shadow: #c7c5c5,
   tooltip: #63676c,
 );
+$comparison-tool-colors: (
+  row-highlight: #ebf2fa,
+);
 
 // -------------------------------------------------------------------------- //
 // Fonts

--- a/libs/qtl/eqtl-comparison-tool/src/lib/eqtl-comparison-tool.component.ts
+++ b/libs/qtl/eqtl-comparison-tool/src/lib/eqtl-comparison-tool.component.ts
@@ -23,10 +23,77 @@ import { SidebarComponent } from './components/sidebar/sidebar.component';
 export class EqtlComparisonToolComponent {
   private readonly comparisonToolService = inject(ComparisonToolService);
 
+  // TODO(QTL-113): uncomment and populate when CT data fetching is implemented
+  // viewConfig: Partial<ComparisonToolViewConfig> = {
+  //   rowSelectionEnabled: true,
+  //   rowHoverEnabled: true,
+  //   rowIdDataKey: 'some_id_field',
+  //   // ... other config
+  // };
+
   constructor() {
+    // TODO(QTL-113): uncomment when CT data fetching is implemented
+    // this.comparisonToolService.setViewConfig(this.viewConfig);
     this.comparisonToolService.connect({
       config$: of([]),
       queryParams$: of({}),
     });
   }
+
+  // TODO(QTL-113): add effects and fetch methods when CT data fetching is implemented.
+  // Follow the same pattern as agora CTs (e.g. NominatedTargetsComparisonToolComponent):
+  //
+  // readonly unpinnedDataEffect = effect(() => {
+  //   if (this.platformService.isBrowser && this.comparisonToolService.isInitialized()) {
+  //     const query = this.comparisonToolService.query();
+  //     this.getUnpinnedData(query);
+  //   }
+  // });
+  //
+  // readonly pinnedDataEffect = effect(() => {
+  //   if (this.platformService.isBrowser && this.comparisonToolService.isInitialized()) {
+  //     const pinnedItems = this.comparisonToolService.pinnedItems();
+  //     const sortMeta = this.comparisonToolService.multiSortMeta();
+  //     this.getPinnedData(pinnedItems, sortMeta);
+  //   }
+  // });
+  //
+  // getUnpinnedData(query: ComparisonToolQuery) {
+  //   const selectedRowId = this.comparisonToolService.selectedRowId();
+  //   this.comparisonToolService.startFetch();
+  //   this.eqtlService.getEqtlData({ ...query, selectedRowId })
+  //     .pipe(takeUntilDestroyed(this.destroyRef))
+  //     .subscribe({
+  //       next: (response) => {
+  //         this.comparisonToolService.setUnpinnedData(response.data);
+  //         this.comparisonToolService.totalResultsCount.set(response.page.totalElements);
+  //         // NOTE: selectedRowId and notifySelectedRowValidity are specific to the
+  //         // selected row feature (rowSelectionEnabled) -- other CTs do not use them.
+  //         // The backend must check whether selectedRowId exists anywhere in the full
+  //         // filtered result set (not just the current page) and return
+  //         // selectedRowInResults: boolean in the response.
+  //         this.comparisonToolService.notifySelectedRowValidity(response.selectedRowInResults);
+  //       },
+  //       error: () => {
+  //         this.comparisonToolService.setUnpinnedData([]);
+  //         this.comparisonToolService.totalResultsCount.set(0);
+  //       },
+  //     });
+  // }
+  //
+  // getPinnedData(pinnedItems: string[], sortMeta: SortMeta[]) {
+  //   this.comparisonToolService.startFetch();
+  //   this.eqtlService.getEqtlData({ items: pinnedItems, itemFilterType: 'Include', ...sortMeta })
+  //     .pipe(takeUntilDestroyed(this.destroyRef))
+  //     .subscribe({
+  //       next: (response) => {
+  //         this.comparisonToolService.setPinnedData(response.data);
+  //         this.comparisonToolService.pinnedResultsCount.set(response.data.length);
+  //       },
+  //       error: () => {
+  //         this.comparisonToolService.setPinnedData([]);
+  //         this.comparisonToolService.pinnedResultsCount.set(0);
+  //       },
+  //     });
+  // }
 }


### PR DESCRIPTION
## Description

Adds opt-in row selection and hover highlighting to the comparison tool. When enabled, the first row is automatically selected on load; clicking a different row moves the selection to it; the selection persists across sorting and pagination and resets to the first row only when filters remove it from all results. Hovering a row highlights it independently of the selection. Both behaviors are off by default and can be enabled per CT instance.

## Related Issue

- [QTL-49](https://sagebionetworks.jira.com/browse/QTL-49)

## Changelog

- Add opt-in row selection: auto-selects the first row on load, persists across sort and pagination, resets to first row when filters remove the selection from all results
- Add opt-in row hover highlighting that appears on mouseenter and clears on mouseleave
- Clicking a heatmap circle also updates the selected row
- Add `notifySelectedRowValidity(isInResults: boolean)` to `ComparisonToolService` -- consumers must call this after each filtered fetch to trigger selection reset when the selected row is no longer in results
- Introduce `--color-comparison-tool-row-highlight` CSS custom property (via `$comparison-tool-colors` in explorers `_variables.scss`) for per-product override
- Add unit tests and Storybook stories for both behaviors
- Add scaffolding to `EqtlComparisonToolComponent` for wiring up row selection when CT data fetching is implemented (QTL-113)

## Testing

> [!NOTE]
> Pin/unpin and sort/pagination behavior with row selection will be tested fully once the eQTL CT data fetching is implemented. Tracked in [QTL-113](https://sagebionetworks.jira.com/browse/QTL-113).

- Open the CT Demo story in Storybook with `rowSelectionEnabled` and `rowHoverEnabled` toggled on and confirm the first unpinned row is highlighted on load.
- Click a different row and confirm the highlight moves to it; click the same row again and confirm nothing changes.
- Click a heatmap circle and confirm the popover opens and the row selection moves to that row.
- Click within the primary column (model name / pin button area) and confirm the row selection moves.
- Hover over any row and confirm the blue highlight appears only while the cursor is on that row.
- Toggle `rowSelectionEnabled` off in the Storybook controls and confirm no rows are highlighted, clicking does nothing, and heatmap circle popovers still open.

### Preview

`nx start explorers-storybook`

https://github.com/user-attachments/assets/5d8322f8-507d-455a-a504-ef4564bed7a6



[QTL-49]: https://sagebionetworks.jira.com/browse/QTL-49?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QTL-113]: https://sagebionetworks.jira.com/browse/QTL-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ