### PR TITLE
feat(explorers): conditionally hide filter button and search input in comparison tool (QTL-116, QTL-117)

### DIFF
--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-controls/comparison-tool-controls.component.html
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-controls/comparison-tool-controls.component.html
@@ -1,7 +1,9 @@
 <div class="controls">
   <div class="controls-left">
     <explorers-displayed-results />
-    <explorers-comparison-tool-search-input />
+    @if (viewConfig().showTableSearch) {
+      <explorers-comparison-tool-search-input />
+    }
   </div>
   <div class="controls-right">
     <explorers-comparison-tool-category-selectors />

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-controls/comparison-tool-controls.component.spec.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-controls/comparison-tool-controls.component.spec.ts
@@ -1,0 +1,40 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
+import {
+  HelperService,
+  provideComparisonToolFilterService,
+  provideComparisonToolService,
+  SvgIconService,
+} from '@sagebionetworks/explorers/services';
+import { SvgIconServiceStub } from '@sagebionetworks/explorers/testing';
+import { render, screen } from '@testing-library/angular';
+import { MessageService } from 'primeng/api';
+import { ComparisonToolControlsComponent } from './comparison-tool-controls.component';
+
+async function setup(showTableSearch: boolean) {
+  const component = await render(ComparisonToolControlsComponent, {
+    providers: [
+      provideRouter([]),
+      HelperService,
+      provideHttpClient(),
+      MessageService,
+      ...provideComparisonToolService({ viewConfig: { showTableSearch } }),
+      ...provideComparisonToolFilterService(),
+      { provide: SvgIconService, useClass: SvgIconServiceStub },
+    ],
+  });
+  component.fixture.detectChanges();
+  return component;
+}
+
+describe('ComparisonToolControlsComponent', () => {
+  it('should show search input when showTableSearch is true', async () => {
+    await setup(true);
+    expect(screen.queryByPlaceholderText('Value1, Value2')).toBeInTheDocument();
+  });
+
+  it('should hide search input when showTableSearch is false', async () => {
+    await setup(false);
+    expect(screen.queryByPlaceholderText('Value1, Value2')).not.toBeInTheDocument();
+  });
+});

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-header/comparison-tool-header.component.html
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-header/comparison-tool-header.component.html
@@ -1,14 +1,20 @@
 <div class="comparison-tool-header">
   <div class="comparison-tool-header-inner">
-    <explorers-comparison-tool-filter-results-button
-      [tooltip]="viewConfig().filterResultsButtonTooltip"
-    />
+    <div class="comparison-tool-header-left">
+      @if (currentConfig()?.filters?.length) {
+        <explorers-comparison-tool-filter-results-button
+          [tooltip]="viewConfig().filterResultsButtonTooltip"
+        />
+      }
+    </div>
     <div class="comparison-tool-header-title">
       <h1>{{ viewConfig().headerTitle }}</h1>
       @if (viewConfig().headerTitleWikiParams) {
         <explorers-popover-link [wikiParams]="viewConfig().headerTitleWikiParams!" />
       }
     </div>
-    <explorers-comparison-tool-share-url-button />
+    <div class="comparison-tool-header-right">
+      <explorers-comparison-tool-share-url-button />
+    </div>
   </div>
 </div>

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-header/comparison-tool-header.component.scss
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-header/comparison-tool-header.component.scss
@@ -13,6 +13,16 @@
     align-items: center;
     width: 100%;
 
+    .comparison-tool-header-left,
+    .comparison-tool-header-right {
+      flex: 1;
+    }
+
+    .comparison-tool-header-right {
+      display: flex;
+      justify-content: flex-end;
+    }
+
     .comparison-tool-header-title {
       display: flex;
       gap: 5px;

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-header/comparison-tool-header.component.spec.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-header/comparison-tool-header.component.spec.ts
@@ -1,0 +1,69 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
+import {
+  ComparisonToolService,
+  HelperService,
+  provideComparisonToolFilterService,
+  provideComparisonToolService,
+  SvgIconService,
+} from '@sagebionetworks/explorers/services';
+import { SvgIconServiceStub } from '@sagebionetworks/explorers/testing';
+import { render, screen } from '@testing-library/angular';
+import { MessageService } from 'primeng/api';
+import { ComparisonToolHeaderComponent } from './comparison-tool-header.component';
+
+const configWithFilters = {
+  page: 'Model Overview' as const,
+  dropdowns: ['Option A'],
+  row_count: null,
+  columns: [],
+  filters: [{ name: 'Type', data_key: 'type', query_param_key: 'type', values: ['A', 'B'] }],
+};
+
+const configWithNoFilters = {
+  page: 'Model Overview' as const,
+  dropdowns: ['Option B'],
+  row_count: null,
+  columns: [],
+  filters: [],
+};
+
+async function setup(configs: (typeof configWithFilters)[]) {
+  const component = await render(ComparisonToolHeaderComponent, {
+    providers: [
+      provideRouter([]),
+      HelperService,
+      provideHttpClient(),
+      MessageService,
+      ...provideComparisonToolService({ configs }),
+      ...provideComparisonToolFilterService(),
+      { provide: SvgIconService, useClass: SvgIconServiceStub },
+    ],
+  });
+  const ctService = component.fixture.debugElement.injector.get(ComparisonToolService);
+  component.fixture.detectChanges();
+  return { component, ctService };
+}
+
+describe('ComparisonToolHeaderComponent', () => {
+  it('should show Filter Results button when current config has filters', async () => {
+    await setup([configWithFilters]);
+    expect(screen.queryByRole('button', { name: 'Filter Results' })).toBeInTheDocument();
+  });
+
+  it('should hide Filter Results button when current config has no filters', async () => {
+    await setup([configWithNoFilters]);
+    expect(screen.queryByRole('button', { name: 'Filter Results' })).not.toBeInTheDocument();
+  });
+
+  it('should close filter panel when switching to a config with no filters', async () => {
+    const { ctService, component } = await setup([configWithFilters, configWithNoFilters]);
+    ctService.openFilterPanel();
+    component.fixture.detectChanges();
+    expect(ctService.isFilterPanelOpen()).toBe(true);
+
+    ctService.setDropdownSelection(['Option B']);
+    component.fixture.detectChanges();
+    expect(ctService.isFilterPanelOpen()).toBe(false);
+  });
+});

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-header/comparison-tool-header.component.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-header/comparison-tool-header.component.ts
@@ -18,4 +18,5 @@ export class ComparisonToolHeaderComponent {
   private readonly comparisonToolService = inject(ComparisonToolService);
 
   viewConfig = this.comparisonToolService.viewConfig;
+  currentConfig = this.comparisonToolService.currentConfig;
 }

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool.component.stories.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool.component.stories.ts
@@ -325,7 +325,9 @@ const meta: Meta<StoryArgs> = {
       description:
         'Array of comparison tool configurations defining columns, filters, and dropdowns. ' +
         'Each config defines the table structure with columns, filters, and dropdown options for different data views. ' +
-        'For story configuration, only include one value for `page` across all objects.',
+        'For story configuration, only include one value for `page` across all objects. ' +
+        'The Filter Results button is hidden when the currently selected config has an empty `filters` array, ' +
+        'and reappears when switching to a config that has filters.',
       table: { category: 'Data' },
     },
     data: {
@@ -405,7 +407,9 @@ export const Demo: Story = {
     ],
     linkExportField: 'link_text',
     // Data
-    configs: mockComparisonToolDataConfigWithDropdowns,
+    configs: mockComparisonToolDataConfigWithDropdowns.map((c, i) =>
+      i === mockComparisonToolDataConfigWithDropdowns.length - 1 ? { ...c, filters: [] } : c,
+    ),
     data: mockComparisonToolData,
     pinnedItems: ['3xTg-AD', '5xFAD (UCI)', '5xFAD (IU/Jax/Pitt)'],
     // Panel visibility

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool.component.stories.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool.component.stories.ts
@@ -70,6 +70,7 @@ class ComparisonToolInnerComponent {
   // Controls inputs
   filterResultsButtonTooltip = input<string>();
   showSignificanceControls = input<boolean>();
+  showTableSearch = input<boolean>();
   viewDetailsTooltip = input<string>();
   // Legend inputs
   legendEnabled = input<boolean>();
@@ -122,6 +123,7 @@ class ComparisonToolInnerComponent {
       viewConfig.selectorsWikiParams = this.selectorsWikiParams();
       viewConfig.filterResultsButtonTooltip = this.filterResultsButtonTooltip();
       viewConfig.showSignificanceControls = this.showSignificanceControls();
+      viewConfig.showTableSearch = this.showTableSearch();
       viewConfig.viewDetailsTooltip = this.viewDetailsTooltip();
       viewConfig.legendEnabled = this.legendEnabled();
       viewConfig.legendPanelConfig = this.legendPanelConfig();
@@ -185,6 +187,7 @@ class ComparisonToolInnerComponent {
         [selectorsWikiParams]="selectorsWikiParams()"
         [filterResultsButtonTooltip]="filterResultsButtonTooltip()"
         [showSignificanceControls]="showSignificanceControls()"
+        [showTableSearch]="showTableSearch()"
         [viewDetailsTooltip]="viewDetailsTooltip()"
         [legendEnabled]="legendEnabled()"
         [legendPanelConfig]="legendPanelConfig()"
@@ -209,6 +212,7 @@ class ComparisonToolStoryWrapperComponent {
   selectorsWikiParams = input<Record<string, SynapseWikiParams>>();
   filterResultsButtonTooltip = input<string>();
   showSignificanceControls = input<boolean>();
+  showTableSearch = input<boolean>();
   viewDetailsTooltip = input<string>();
   legendEnabled = input<boolean>();
   legendPanelConfig = input<LegendPanelConfig>();
@@ -267,6 +271,11 @@ const meta: Meta<StoryArgs> = {
     showSignificanceControls: {
       control: 'boolean',
       description: 'Whether to show significance threshold controls',
+      table: { category: 'Controls' },
+    },
+    showTableSearch: {
+      control: 'boolean',
+      description: 'Whether to show the search input in the controls bar',
       table: { category: 'Controls' },
     },
     viewDetailsTooltip: {
@@ -385,6 +394,7 @@ export const Demo: Story = {
     // Controls
     filterResultsButtonTooltip: 'Filter the results based on the selected criteria',
     showSignificanceControls: true,
+    showTableSearch: true,
     viewDetailsTooltip: 'View details',
     // Legend
     legendEnabled: true,

--- a/libs/explorers/models/src/lib/comparison-tool.ts
+++ b/libs/explorers/models/src/lib/comparison-tool.ts
@@ -69,6 +69,7 @@ export interface ComparisonToolViewConfig {
   defaultSort?: readonly { readonly field: string; readonly order: 1 | -1 }[];
   heatmapCircleClickTransformFn?: heatmapCircleClickTransformFn;
   linkExportField: 'link_url' | 'link_text';
+  showTableSearch?: boolean;
 }
 
 export interface ComparisonToolFilterOption {

--- a/libs/explorers/services/src/lib/comparison-tool.service.ts
+++ b/libs/explorers/services/src/lib/comparison-tool.service.ts
@@ -643,6 +643,10 @@ export class ComparisonToolService<T> {
       pinnedItems: currentPins,
       pageNumber: this.FIRST_PAGE_NUMBER,
     });
+
+    if (!newFilters.length && this.isFilterPanelOpenSignal()) {
+      this.isFilterPanelOpenSignal.set(false);
+    }
   }
 
   private normalizeSelection(selection: string[], configs: ComparisonToolConfig[]): string[] {

--- a/libs/explorers/services/src/lib/comparison-tool.service.ts
+++ b/libs/explorers/services/src/lib/comparison-tool.service.ts
@@ -64,6 +64,7 @@ export class ComparisonToolService<T> {
     rowIdDataKey: '_id',
     allowPinnedImageDownload: true,
     linkExportField: 'link_url',
+    showTableSearch: true,
   };
 
   // Private State Signals

--- a/libs/explorers/services/src/lib/comparison-tool.service.ts
+++ b/libs/explorers/services/src/lib/comparison-tool.service.ts
@@ -143,6 +143,14 @@ export class ComparisonToolService<T> {
   });
 
   constructor() {
+    // Close the filter panel when the current config has no filters to avoid showing an empty panel.
+    effect(() => {
+      const config = this.currentConfig();
+      if (config !== null && !config.filters?.length && this.isFilterPanelOpenSignal()) {
+        this.isFilterPanelOpenSignal.set(false);
+      }
+    });
+
     // Automatically sync state changes to URL.
     // This effect re-runs whenever any of the tracked signals change,
     // keeping the URL in sync with the component's state.
@@ -644,10 +652,6 @@ export class ComparisonToolService<T> {
       pinnedItems: currentPins,
       pageNumber: this.FIRST_PAGE_NUMBER,
     });
-
-    if (!newFilters.length && this.isFilterPanelOpenSignal()) {
-      this.isFilterPanelOpenSignal.set(false);
-    }
   }
 
   private normalizeSelection(selection: string[], configs: ComparisonToolConfig[]): string[] {


### PR DESCRIPTION
## Description

New QTL comparison tools will not need a filter panel or a search input, but both UI elements were always rendered regardless of config. This PR makes the Filter Results button reactive -- it hides when the currently selected config has no filters and reappears when switching to one that does, with the filter panel also auto-closing on such transitions. It also adds a `showTableSearch` option to `ComparisonToolViewConfig` so callers can opt out of rendering the search filterbox input entirely.

## Related Issue

- [QTL-116](https://sagebionetworks.jira.com/browse/QTL-116)
- [QTL-117](https://sagebionetworks.jira.com/browse/QTL-117)

## Changelog

- Hide Filter Results button when the currently selected `ComparisonToolConfig` has an empty `filters` array
- Auto-close the filter panel when switching to a config with no filters
- Fix header layout so the title stays centered when the Filter Results button is absent
- Add `showTableSearch?: boolean` to `ComparisonToolViewConfig` (default `true`) to allow hiding the search input
- Update Storybook Demo story to demonstrate reactive filter button visibility across dropdown selections
- Add unit tests for filter button visibility, filter panel auto-close, and search input visibility

## Testing

- Open the Storybook `ComparisonToolComponent` Demo story -- the Filter Results button should be visible for the default dropdown selection (configs with filters)
- In the Demo story, switch the first dropdown to the second option, then switch the second dropdown to its last option -- the Filter Results button should disappear
- Open the filter panel, then switch to a dropdown option whose config has no filters -- confirm the filter panel closes automatically
- In the Storybook controls panel, toggle `showTableSearch` to `false` -- the search input should disappear from the controls bar; toggling back to `true` should restore it
- Verify the header title remains horizontally centered regardless of whether the Filter Results button is visible

### Preview

`nx start explorers-storybook`

Filter results button is shown when current config has filters and hidden otherwise: 

https://github.com/user-attachments/assets/d5ea2102-86c2-4adf-96cf-decbc2f0c064

Table search filterbox can be optionally hidden via viewConfig option: 

https://github.com/user-attachments/assets/3b38fec3-851e-413c-86d6-83da72666113

[QTL-116]: https://sagebionetworks.jira.com/browse/QTL-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QTL-117]: https://sagebionetworks.jira.com/browse/QTL-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ