### PR TITLE
feat(explorers): add optional subheader support to header dropdown nav menus (MG-943)

### DIFF
--- a/libs/explorers/models/src/lib/navigation-link.ts
+++ b/libs/explorers/models/src/lib/navigation-link.ts
@@ -6,5 +6,6 @@ export type NavigationLink = {
   target?: '_blank' | '_self' | '_parent' | '_top';
   routerLink?: string[];
   activeOptions?: { exact: boolean } | IsActiveMatchOptions;
+  isSubheader?: boolean;
   children?: NavigationLink[];
 };

--- a/libs/explorers/models/src/lib/navigation-link.ts
+++ b/libs/explorers/models/src/lib/navigation-link.ts
@@ -7,5 +7,7 @@ export type NavigationLink = {
   routerLink?: string[];
   activeOptions?: { exact: boolean } | IsActiveMatchOptions;
   isSubheader?: boolean;
+  // Mixing subheader and flat children in the same dropdown is not supported.
+  // All children should be either subheaders (each with their own children) or flat links.
   children?: NavigationLink[];
 };

--- a/libs/explorers/styles/src/index.scss
+++ b/libs/explorers/styles/src/index.scss
@@ -8,3 +8,4 @@
 @forward './lib/components/radio';
 @forward './lib/components/popover';
 @forward './lib/components/typography';
+@forward './lib/components/menu';

--- a/libs/explorers/styles/src/lib/components/_menu.scss
+++ b/libs/explorers/styles/src/lib/components/_menu.scss
@@ -1,0 +1,10 @@
+.header-dropdown-menu {
+  .p-menu-item-label,
+  .p-menu-submenu-label {
+    font-weight: 700;
+  }
+
+  .p-menu-submenu-label ~ .p-menu-item .p-menu-item-label {
+    font-weight: 400;
+  }
+}

--- a/libs/explorers/styles/src/lib/components/_menu.scss
+++ b/libs/explorers/styles/src/lib/components/_menu.scss
@@ -2,9 +2,10 @@
   .p-menu-item-label,
   .p-menu-submenu-label {
     font-weight: 700;
+    color: var(--color-text);
   }
 
-  .p-menu-submenu-label ~ .p-menu-item .p-menu-item-label {
+  .header-dropdown-subheader-child .p-menu-item-label {
     font-weight: 400;
   }
 }

--- a/libs/explorers/testing/src/lib/mocks/navigation-links-mocks.ts
+++ b/libs/explorers/testing/src/lib/mocks/navigation-links-mocks.ts
@@ -14,6 +14,19 @@ export const headerLinks: NavigationLink[] = [
     ],
   },
   {
+    label: 'DropdownWithSubheader',
+    children: [
+      {
+        label: 'SubheaderLabel',
+        isSubheader: true,
+        children: [
+          { label: 'SubChildLink1', routerLink: ['/sub-child-link-1'] },
+          { label: 'SubChildLink2', routerLink: ['/sub-child-link-2'] },
+        ],
+      },
+    ],
+  },
+  {
     label: 'HeaderLink2',
     routerLink: ['/header-link-2'],
   },

--- a/libs/explorers/ui/src/lib/components/header/header.component.html
+++ b/libs/explorers/ui/src/lib/components/header/header.component.html
@@ -40,15 +40,34 @@
                     <span class="mobile-dropdown-label">{{ link.label }}</span>
                     <ul class="mobile-submenu">
                       @for (child of link.children; track child.label) {
-                        <li>
-                          <a
-                            [routerLink]="child.routerLink"
-                            routerLinkActive="active"
-                            (click)="toggleNav()"
-                          >
-                            <span>{{ child.label }}</span>
-                          </a>
-                        </li>
+                        @if (child.isSubheader && child.children) {
+                          <li class="mobile-dropdown-item">
+                            <span class="mobile-dropdown-label">{{ child.label }}</span>
+                            <ul class="mobile-submenu">
+                              @for (grandchild of child.children; track grandchild.label) {
+                                <li>
+                                  <a
+                                    [routerLink]="grandchild.routerLink"
+                                    routerLinkActive="active"
+                                    (click)="toggleNav()"
+                                  >
+                                    <span>{{ grandchild.label }}</span>
+                                  </a>
+                                </li>
+                              }
+                            </ul>
+                          </li>
+                        } @else {
+                          <li>
+                            <a
+                              [routerLink]="child.routerLink"
+                              routerLinkActive="active"
+                              (click)="toggleNav()"
+                            >
+                              <span>{{ child.label }}</span>
+                            </a>
+                          </li>
+                        }
                       }
                     </ul>
                   } @else if (link.routerLink) {

--- a/libs/explorers/ui/src/lib/components/header/header.component.scss
+++ b/libs/explorers/ui/src/lib/components/header/header.component.scss
@@ -76,6 +76,7 @@
 
   a {
     font-size: var(--font-size-lg);
+    font-weight: 700;
     color: var(--color-text);
     text-decoration: none;
   }
@@ -122,7 +123,6 @@
     a {
       position: relative;
       display: flex;
-      font-weight: 700;
       padding: 8px 0;
       color: var(--color-text-secondary);
       transition: var(--transition-duration);
@@ -218,6 +218,7 @@
     .mobile-dropdown-label {
       display: block;
       font-size: var(--font-size-lg);
+      font-weight: 700;
       color: var(--color-text);
       padding: 10px 0;
       cursor: default;
@@ -226,6 +227,10 @@
 
     .mobile-submenu {
       margin-left: 1.25rem;
+
+      .mobile-submenu a {
+        font-weight: 500;
+      }
     }
 
     &.show {

--- a/libs/explorers/ui/src/lib/components/header/header.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/header/header.component.spec.ts
@@ -174,8 +174,8 @@ describe('HeaderComponent', () => {
     expect(component.isMobile).toBe(true);
   });
 
-  it('should throw when a dropdown mixes subheader and flat children', async () => {
-    changeWindowSize(DESKTOP_WIDTH);
+  it('should throw when a dropdown mixes subheader and flat children regardless of screen size', async () => {
+    changeWindowSize(MOBILE_WIDTH);
 
     await expect(
       render(HeaderComponent, {

--- a/libs/explorers/ui/src/lib/components/header/header.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/header/header.component.spec.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
-import { provideRouter } from '@angular/router';
+import { Router, provideRouter } from '@angular/router';
 import { footerLinks, headerLinks } from '@sagebionetworks/explorers/testing';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
@@ -174,6 +174,33 @@ describe('HeaderComponent', () => {
     expect(component.isMobile).toBe(true);
   });
 
+  it('should throw when a dropdown mixes subheader and flat children', async () => {
+    changeWindowSize(DESKTOP_WIDTH);
+
+    await expect(
+      render(HeaderComponent, {
+        componentInputs: {
+          headerLogoPath: 'path/to/logo.svg',
+          headerLinks: [
+            {
+              label: 'MixedDropdown',
+              children: [
+                { label: 'Flat Item', routerLink: ['/flat'] },
+                {
+                  label: 'SubheaderLabel',
+                  isSubheader: true,
+                  children: [{ label: 'Child', routerLink: ['/child'] }],
+                },
+              ],
+            },
+          ],
+        },
+        imports: [CommonModule, SvgImageComponent],
+        providers: [provideRouter([])],
+      }),
+    ).rejects.toThrow('mixing subheader and flat');
+  });
+
   it('should build grouped MenuItem structure for dropdown with subheaders', async () => {
     changeWindowSize(DESKTOP_WIDTH);
     const { component } = await setup();
@@ -186,6 +213,18 @@ describe('HeaderComponent', () => {
     expect(subheaderItem?.items).toHaveLength(2);
     expect(subheaderItem?.items?.[0].label).toBe('SubChildLink1');
     expect(subheaderItem?.items?.[1].label).toBe('SubChildLink2');
+  });
+
+  it('should mark dropdown as active when a subheader grandchild route is active', async () => {
+    changeWindowSize(DESKTOP_WIDTH);
+    const { component, fixture } = await setup();
+
+    const router = fixture.debugElement.injector.get(Router);
+    await router.navigate(['/sub-child-link-1']);
+
+    const subheaderLink = headerLinks.find((l) => l.label === 'DropdownWithSubheader');
+    expect(subheaderLink).toBeDefined();
+    expect(component.isDropdownActive(subheaderLink ?? { label: '' })).toBe(true);
   });
 
   it('should render subheader as non-link text and its children as links in mobile mode', async () => {

--- a/libs/explorers/ui/src/lib/components/header/header.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/header/header.component.spec.ts
@@ -36,6 +36,8 @@ async function setup() {
         { path: 'header-link-2', component: DummyComponent },
         { path: 'child-link-1', component: DummyComponent },
         { path: 'child-link-2', component: DummyComponent },
+        { path: 'sub-child-link-1', component: DummyComponent },
+        { path: 'sub-child-link-2', component: DummyComponent },
         { path: 'footer-link-internal-1', component: DummyComponent },
         { path: 'footer-link-internal-2', component: DummyComponent },
       ]),
@@ -170,6 +172,31 @@ describe('HeaderComponent', () => {
 
     expect(component.isShown).toBe(false);
     expect(component.isMobile).toBe(true);
+  });
+
+  it('should build grouped MenuItem structure for dropdown with subheaders', async () => {
+    changeWindowSize(DESKTOP_WIDTH);
+    const { component } = await setup();
+
+    const items = component.dropdownMenuItems.get('DropdownWithSubheader');
+    expect(items).toHaveLength(1);
+
+    const subheaderItem = items?.[0];
+    expect(subheaderItem?.label).toBe('SubheaderLabel');
+    expect(subheaderItem?.items).toHaveLength(2);
+    expect(subheaderItem?.items?.[0].label).toBe('SubChildLink1');
+    expect(subheaderItem?.items?.[1].label).toBe('SubChildLink2');
+  });
+
+  it('should render subheader as non-link text and its children as links in mobile mode', async () => {
+    changeWindowSize(MOBILE_WIDTH);
+    const { user } = await setup();
+    await user.click(screen.getByRole('button', { name: 'Toggle navigation' }));
+
+    expect(screen.getByText('SubheaderLabel')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'SubheaderLabel' })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'SubChildLink1' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'SubChildLink2' })).toBeInTheDocument();
   });
 
   function verifyHeaderLinks() {

--- a/libs/explorers/ui/src/lib/components/header/header.component.stories.ts
+++ b/libs/explorers/ui/src/lib/components/header/header.component.stories.ts
@@ -1,0 +1,93 @@
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideLocationMocks } from '@angular/common/testing';
+import { Component } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import {
+  mockCheckQueryForErrors,
+  mockGetSearchResults,
+  mockNavigateToResult,
+} from '@sagebionetworks/explorers/testing';
+import type { Meta, StoryObj } from '@storybook/angular';
+import { applicationConfig } from '@storybook/angular';
+import { SearchInputComponent } from '../search-input/search-input.component';
+import { HeaderComponent } from './header.component';
+
+@Component({ template: '', standalone: true })
+class DummyComponent {}
+
+const meta: Meta<HeaderComponent> = {
+  component: HeaderComponent,
+  title: 'UI/Header',
+  decorators: [
+    applicationConfig({
+      providers: [
+        provideRouter([{ path: '**', component: DummyComponent }]),
+        provideLocationMocks(),
+        provideHttpClient(withInterceptorsFromDi()),
+      ],
+    }),
+  ],
+};
+export default meta;
+type Story = StoryObj<HeaderComponent>;
+
+const withSearchInput = (args: Record<string, unknown>) => ({
+  props: args,
+  template: `
+    <explorers-header
+      [headerLogoPath]="headerLogoPath"
+      [headerLinks]="headerLinks"
+    >
+      <explorers-search-input
+        searchPlaceholder="Search genes"
+        [navigateToResult]="navigateToResult"
+        [getSearchResults]="getSearchResults"
+        [checkQueryForErrors]="checkQueryForErrors"
+      />
+    </explorers-header>
+  `,
+  moduleMetadata: {
+    imports: [HeaderComponent, SearchInputComponent],
+  },
+});
+
+export const Header: Story = {
+  render: (args) =>
+    withSearchInput({
+      ...args,
+      navigateToResult: mockNavigateToResult,
+      getSearchResults: mockGetSearchResults,
+      checkQueryForErrors: mockCheckQueryForErrors,
+    }),
+  args: {
+    headerLogoPath: 'model-ad-assets/images/header-logo.svg',
+    headerLinks: [
+      { label: 'Home', routerLink: ['/'], activeOptions: { exact: true } },
+      {
+        label: 'Menu',
+        children: [
+          { label: 'Item A', routerLink: ['/menu/a'] },
+          { label: 'Item B', routerLink: ['/menu/b'] },
+        ],
+      },
+      {
+        label: 'Menu (subheaders)',
+        children: [
+          {
+            label: 'Group One',
+            isSubheader: true,
+            children: [
+              { label: 'Item A', routerLink: ['/grouped/one/a'] },
+              { label: 'Item B', routerLink: ['/grouped/one/b'] },
+            ],
+          },
+          {
+            label: 'Group Two',
+            isSubheader: true,
+            children: [{ label: 'Item A', routerLink: ['/grouped/two/a'] }],
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/libs/explorers/ui/src/lib/components/header/header.component.stories.ts
+++ b/libs/explorers/ui/src/lib/components/header/header.component.stories.ts
@@ -88,6 +88,7 @@ export const Header: Story = {
           },
         ],
       },
+      { label: 'About', routerLink: ['/about'] },
     ],
   },
 };

--- a/libs/explorers/ui/src/lib/components/header/header.component.ts
+++ b/libs/explorers/ui/src/lib/components/header/header.component.ts
@@ -64,30 +64,45 @@ export class HeaderComponent implements OnInit {
 
   isDropdownActive(link: NavigationLink): boolean {
     if (!link.children) return false;
-    return link.children.some((child) =>
-      child.routerLink
-        ? this.router.isActive(child.routerLink.join('/'), {
-            paths: 'subset',
-            queryParams: 'ignored',
-            fragment: 'ignored',
-            matrixParams: 'ignored',
-          })
-        : false,
-    );
+    return link.children.some((child) => {
+      const candidates = child.isSubheader && child.children ? child.children : [child];
+      return candidates.some((c) =>
+        c.routerLink
+          ? this.router.isActive(c.routerLink.join('/'), {
+              paths: 'subset',
+              queryParams: 'ignored',
+              fragment: 'ignored',
+              matrixParams: 'ignored',
+            })
+          : false,
+      );
+    });
   }
 
   private buildDropdownMenuItems(links: NavigationLink[]) {
     this.dropdownMenuItems.clear();
     for (const link of links) {
       if (link.children) {
-        this.dropdownMenuItems.set(
-          link.label,
-          link.children.map((child) => ({
-            label: child.label,
-            routerLink: child.routerLink,
-          })),
-        );
+        this.dropdownMenuItems.set(link.label, this.toMenuItems(link.children));
       }
     }
+  }
+
+  private toMenuItems(children: NavigationLink[]): MenuItem[] {
+    const items: MenuItem[] = [];
+    for (const child of children) {
+      if (child.isSubheader && child.children?.length) {
+        items.push({
+          label: child.label,
+          items: child.children.map((grandchild) => ({
+            label: grandchild.label,
+            routerLink: grandchild.routerLink,
+          })),
+        });
+      } else if (!child.isSubheader) {
+        items.push({ label: child.label, routerLink: child.routerLink });
+      }
+    }
+    return items;
   }
 }

--- a/libs/explorers/ui/src/lib/components/header/header.component.ts
+++ b/libs/explorers/ui/src/lib/components/header/header.component.ts
@@ -34,6 +34,8 @@ export class HeaderComponent implements OnInit {
     const headerLinks = this.headerLinks();
     const footerLinks = this.footerLinks();
 
+    this.validateHeaderLinks(headerLinks);
+
     if (this.isMobile) {
       this.links = [...headerLinks, ...footerLinks];
     } else {
@@ -79,6 +81,21 @@ export class HeaderComponent implements OnInit {
     });
   }
 
+  private validateHeaderLinks(links: NavigationLink[]) {
+    for (const link of links) {
+      if (!link.children) continue;
+      const hasSubheaders = link.children.some((c) => c.isSubheader);
+      const hasFlat = link.children.some((c) => !c.isSubheader);
+      // PrimeNG renders all top-level MenuItem entries as group headers when any entry has nested
+      // `items`, making flat siblings non-clickable. Mixed layouts are therefore not supported.
+      if (hasSubheaders && hasFlat) {
+        throw new Error(
+          'HeaderComponent: mixing subheader and flat children in the same dropdown is not supported. All children should be either subheaders or flat links.',
+        );
+      }
+    }
+  }
+
   private buildDropdownMenuItems(links: NavigationLink[]) {
     this.dropdownMenuItems.clear();
     for (const link of links) {
@@ -89,16 +106,6 @@ export class HeaderComponent implements OnInit {
   }
 
   private toMenuItems(children: NavigationLink[]): MenuItem[] {
-    const hasSubheaders = children.some((c) => c.isSubheader);
-    const hasFlat = children.some((c) => !c.isSubheader);
-    // PrimeNG renders all top-level MenuItem entries as group headers when any entry has nested
-    // `items`, making flat siblings non-clickable. Mixed layouts are therefore not supported.
-    if (hasSubheaders && hasFlat) {
-      throw new Error(
-        'HeaderComponent: mixing subheader and flat children in the same dropdown is not supported. All children should be either subheaders or flat links.',
-      );
-    }
-
     const items: MenuItem[] = [];
     for (const child of children) {
       if (child.isSubheader) {

--- a/libs/explorers/ui/src/lib/components/header/header.component.ts
+++ b/libs/explorers/ui/src/lib/components/header/header.component.ts
@@ -89,17 +89,31 @@ export class HeaderComponent implements OnInit {
   }
 
   private toMenuItems(children: NavigationLink[]): MenuItem[] {
+    const hasSubheaders = children.some((c) => c.isSubheader);
+    const hasFlat = children.some((c) => !c.isSubheader);
+    // PrimeNG renders all top-level MenuItem entries as group headers when any entry has nested
+    // `items`, making flat siblings non-clickable. Mixed layouts are therefore not supported.
+    if (hasSubheaders && hasFlat) {
+      throw new Error(
+        'HeaderComponent: mixing subheader and flat children in the same dropdown is not supported. All children should be either subheaders or flat links.',
+      );
+    }
+
     const items: MenuItem[] = [];
     for (const child of children) {
-      if (child.isSubheader && child.children?.length) {
-        items.push({
-          label: child.label,
-          items: child.children.map((grandchild) => ({
-            label: grandchild.label,
-            routerLink: grandchild.routerLink,
-          })),
-        });
-      } else if (!child.isSubheader) {
+      if (child.isSubheader) {
+        if (child.children?.length) {
+          items.push({
+            label: child.label,
+            items: child.children.map((grandchild) => ({
+              label: grandchild.label,
+              routerLink: grandchild.routerLink,
+              styleClass: 'header-dropdown-subheader-child',
+            })),
+          });
+        }
+        // isSubheader with no children is a no-op
+      } else {
         items.push({ label: child.label, routerLink: child.routerLink });
       }
     }


### PR DESCRIPTION
## Description

The shared `explorers-header` component previously only supported flat lists of links within dropdown menus. This PR extends `NavigationLink` with an optional `isSubheader` flag, allowing dropdown children to act as non-clickable section headers that group child links beneath them. Existing dropdowns (e.g., Agora Nominations) are unaffected since the feature is opt-in.

## Related Issue

- [MG-943](https://sagebionetworks.jira.com/browse/MG-943)

## Changelog

- Add `isSubheader?: boolean` to `NavigationLink` to support non-clickable section headers inside dropdown menus
- Update desktop dropdown to render subheader groups via PrimeNG `MenuItem.items`; subheader labels and flat items render bold (700), child links under a subheader render at normal weight (400)
- Update mobile hamburger menu to render subheaders as non-clickable bold labels with an additional indent level for their child links (normal weight)
- Update `isDropdownActive()` to recurse into subheader grandchildren so the dropdown trigger highlights correctly when a grouped route is active
- Fix mobile nav font weights: top-level links and section labels bold (700), submenu child links normal (400)
- Throw a descriptive error when a dropdown mixes subheader and flat children, which is unsupported due to a PrimeNG rendering limitation
- Add `HeaderComponent` Storybook story demonstrating standalone links, a flat dropdown, and a dropdown with subheaders in a single nav config

## Testing

- In Storybook (`nx start explorers-storybook`, port 4402), open **UI / Header** and verify all three nav variants render correctly
- Click **Menu** -- all child links should be bold and navigable
- Click **Menu (subheaders)** -- group labels should be bold and non-clickable, child links should be normal weight and navigable
- Resize to mobile and open the hamburger menu -- top-level links and subheader labels should appear at one indent (bold, labels non-clickable), their child links at a second indent (normal weight, clickable)

### Preview

| view | type | design | storybook | 
:---: | :---: | :---: | :---:
desktop | no subheaders | <img width="861" height="228" alt="MG-943_desktop_noSubheaders_design" src="https://github.com/user-attachments/assets/9d4ef202-84e9-457e-b61a-5fc6b620cd3a" /> | <img width="550" height="228" alt="image" src="https://github.com/user-attachments/assets/8ff56c48-0701-4ff8-abb5-38f8d656323d" />
desktop | subheaders | <img width="864" height="274" alt="MG-943_desktop_subheaders_design" src="https://github.com/user-attachments/assets/20e6b5c5-42e0-448a-826c-85a54dbc2a05" /> | <img width="566" height="370" alt="image" src="https://github.com/user-attachments/assets/c4d8c951-e5fa-42bb-970d-703e0a5aa33d" />
mobile | no subheaders and subheaders | <img width="439" height="644" alt="MG-943_mobile_design" src="https://github.com/user-attachments/assets/70571196-7f38-4c74-ad92-76f9cf45e752" /> | <img width="341" height="496" alt="image" src="https://github.com/user-attachments/assets/6e1a3345-2721-463d-a1e5-34a1fb1be450" />


[MG-943]: https://sagebionetworks.jira.com/browse/MG-943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ