### PR TITLE
feat(explorers): extract CopyLinkButtonComponent to explorers-ui (MG-954)

### DIFF
--- a/libs/agora/CLAUDE.md
+++ b/libs/agora/CLAUDE.md
@@ -11,7 +11,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 nx test agora-<lib-name>   # run unit tests for a lib
 nx lint agora-<lib-name>   # lint a lib
+nx start agora-storybook   # serve Storybook (port 4401)
 ```
+
+## Storybook
+
+For components that don't call our own backend APIs (third-party service calls are fine): add a `.stories.ts` file for new components; for changes to existing components, adjust the existing story if the new behavior fits naturally, or add a new story variant for sufficiently distinct behavior. When it's unclear whether a new story is warranted, ask the user. Follow the same pattern as existing stories in `libs/agora/`.
 
 For serving the Agora app, see the "Serving an App" section in the root `CLAUDE.md` — the full stack must be running first.
 

--- a/libs/explorers/CLAUDE.md
+++ b/libs/explorers/CLAUDE.md
@@ -65,3 +65,7 @@ comparison-tool / charts-angular / ui / util / shared   (feature/UI)
 ```
 
 All imports use `@sagebionetworks/explorers/<lib-name>` path aliases. Never use relative paths across library boundaries.
+
+## Storybook
+
+For components that don't call our own backend APIs (third-party service calls like Synapse wiki fetches are fine): add a `.stories.ts` file for new components; for changes to existing components, adjust the existing story if the new behavior fits naturally, or add a new story variant for sufficiently distinct behavior. When it's unclear whether a new story is warranted, ask the user. See `libs/explorers/util/src/lib/tooltip-button/tooltip-button.component.stories.ts` for the canonical pattern.

--- a/libs/explorers/ui/src/index.ts
+++ b/libs/explorers/ui/src/index.ts
@@ -1,6 +1,7 @@
 export * from './lib/components/base-download-dom-image/base-download-dom-image.component';
 export * from './lib/components/chiclet-card/chiclet-card.component';
 export * from './lib/components/chiclet/chiclet.component';
+export * from './lib/components/copy-link-button/copy-link-button.component';
 export * from './lib/components/download-dom-image/download-dom-image.component';
 export * from './lib/components/download-dom-images-zip/download-dom-images-zip.component';
 export * from './lib/components/error-overlay/error-overlay.component';

--- a/libs/explorers/ui/src/lib/components/copy-link-button/copy-link-button.component.html
+++ b/libs/explorers/ui/src/lib/components/copy-link-button/copy-link-button.component.html
@@ -1,0 +1,11 @@
+<explorers-tooltip-button
+  [onClick]="onClick()"
+  [buttonAriaDescribedBy]="anchorId()"
+  [buttonProps]="{ ariaLabel: ariaLabel(), link: true, style: { padding: '0' } }"
+  [tooltipText]="tooltipText()"
+  iconImagePath="explorers-assets/icons/link.svg"
+  iconAltText="link"
+  iconColor="#878E95"
+  [iconHeight]="12"
+  [iconWidth]="24"
+/>

--- a/libs/explorers/ui/src/lib/components/copy-link-button/copy-link-button.component.html
+++ b/libs/explorers/ui/src/lib/components/copy-link-button/copy-link-button.component.html
@@ -5,7 +5,7 @@
   [tooltipText]="tooltipText()"
   iconImagePath="explorers-assets/icons/link.svg"
   iconAltText="link"
-  iconColor="#878E95"
+  iconColor="var(--color-gray-700)"
   [iconHeight]="12"
   [iconWidth]="24"
 />

--- a/libs/explorers/ui/src/lib/components/copy-link-button/copy-link-button.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/copy-link-button/copy-link-button.component.spec.ts
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+import { CopyLinkButtonComponent } from './copy-link-button.component';
+
+describe('CopyLinkButtonComponent', () => {
+  const onClickSpy = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  async function setup(inputs: Partial<Record<string, any>> = {}) {
+    const user = userEvent.setup();
+    await render(CopyLinkButtonComponent, {
+      componentInputs: {
+        onClick: onClickSpy,
+        anchorId: 'test-anchor',
+        ariaLabel: 'Copy link to Test Section',
+        tooltipText: 'Copy link',
+        ...inputs,
+      },
+    });
+    return { user };
+  }
+
+  it('should render the button', async () => {
+    await setup();
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('should pass through aria label', async () => {
+    await setup();
+    expect(screen.getByRole('button', { name: /copy link to test section/i })).toBeInTheDocument();
+  });
+
+  it('should call onClick when clicked', async () => {
+    const { user } = await setup();
+    await user.click(screen.getByRole('button', { name: /copy link to test section/i }));
+    expect(onClickSpy).toHaveBeenCalled();
+  });
+});

--- a/libs/explorers/ui/src/lib/components/copy-link-button/copy-link-button.component.stories.ts
+++ b/libs/explorers/ui/src/lib/components/copy-link-button/copy-link-button.component.stories.ts
@@ -1,0 +1,38 @@
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideLocationMocks } from '@angular/common/testing';
+import { provideRouter } from '@angular/router';
+import type { Meta, StoryObj } from '@storybook/angular';
+import { applicationConfig } from '@storybook/angular';
+import { CopyLinkButtonComponent } from './copy-link-button.component';
+
+const meta: Meta<CopyLinkButtonComponent> = {
+  component: CopyLinkButtonComponent,
+  title: 'UI/CopyLinkButton',
+  decorators: [
+    applicationConfig({
+      providers: [
+        provideRouter([]),
+        provideLocationMocks(),
+        provideHttpClient(withInterceptorsFromDi()),
+      ],
+    }),
+  ],
+  argTypes: {
+    onClick: { control: false },
+  },
+};
+export default meta;
+type Story = StoryObj<CopyLinkButtonComponent>;
+
+const mockOnClick = (): void => {
+  console.log('link copied!');
+};
+
+export const CopyLinkButton: Story = {
+  args: {
+    onClick: mockOnClick,
+    anchorId: 'evidence-type-anchor',
+    ariaLabel: 'Copy link to RNA - Differential Expression',
+    tooltipText: 'Copy link',
+  },
+};

--- a/libs/explorers/ui/src/lib/components/copy-link-button/copy-link-button.component.ts
+++ b/libs/explorers/ui/src/lib/components/copy-link-button/copy-link-button.component.ts
@@ -1,0 +1,15 @@
+import { Component, input } from '@angular/core';
+import { TooltipButtonComponent } from '@sagebionetworks/explorers/util';
+
+@Component({
+  selector: 'explorers-copy-link-button',
+  imports: [TooltipButtonComponent],
+  templateUrl: './copy-link-button.component.html',
+  styleUrls: ['./copy-link-button.component.scss'],
+})
+export class CopyLinkButtonComponent {
+  onClick = input.required<() => void>();
+  anchorId = input.required<string>();
+  ariaLabel = input.required<string>();
+  tooltipText = input.required<string>();
+}

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
@@ -82,20 +82,11 @@
           <div class="boxplots-evidence-type-title">
             <h2>{{ evidenceType | decodeGreekEntity }}</h2>
             @if (activeShareLink() === evidenceType) {
-              <explorers-tooltip-button
+              <explorers-copy-link-button
                 [onClick]="copyShareLinkCallbackFn(evidenceType)"
-                [buttonAriaDescribedBy]="generateAnchorId(evidenceType)"
-                [buttonProps]="{
-                  ariaLabel: `Copy link to ${evidenceType | decodeGreekEntity }`,
-                  link: true,
-                  style: { 'padding': '0' }
-                }"
+                [anchorId]="generateAnchorId(evidenceType)"
+                [ariaLabel]="'Copy link to ' + (evidenceType | decodeGreekEntity)"
                 [tooltipText]="getShareLinkTooltipText(evidenceType)"
-                iconImagePath="explorers-assets/icons/link.svg"
-                iconAltText="link"
-                iconColor="#878E95"
-                [iconHeight]="12"
-                [iconWidth]="24"
               />
             }
           </div>

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -18,14 +18,11 @@ import { FormsModule } from '@angular/forms';
 import { SynapseWikiParams } from '@sagebionetworks/explorers/models';
 import { HelperService, PlatformService } from '@sagebionetworks/explorers/services';
 import {
+  CopyLinkButtonComponent,
   DownloadDomImageComponent,
   DownloadDomImagesZipComponent,
 } from '@sagebionetworks/explorers/ui';
-import {
-  DecodeGreekEntityPipe,
-  ModalLinkComponent,
-  TooltipButtonComponent,
-} from '@sagebionetworks/explorers/util';
+import { DecodeGreekEntityPipe, ModalLinkComponent } from '@sagebionetworks/explorers/util';
 import { ModelData, Sex } from '@sagebionetworks/model-ad/api-client';
 import { BoxplotsGridComponent } from '@sagebionetworks/model-ad/ui';
 import { SelectModule } from 'primeng/select';
@@ -40,7 +37,7 @@ import { SelectModule } from 'primeng/select';
     DecodeGreekEntityPipe,
     DownloadDomImageComponent,
     DownloadDomImagesZipComponent,
-    TooltipButtonComponent,
+    CopyLinkButtonComponent,
   ],
   templateUrl: './model-details-boxplots-selector.component.html',
   styleUrls: ['./model-details-boxplots-selector.component.scss'],

--- a/libs/qtl/CLAUDE.md
+++ b/libs/qtl/CLAUDE.md
@@ -1,0 +1,15 @@
+# CLAUDE.md
+
+`libs/qtl/` is a collection of Angular libraries for the QTL analysis explorer.
+
+## Commands
+
+```bash
+nx test qtl-<lib-name>    # run unit tests for a lib
+nx lint qtl-<lib-name>    # lint a lib
+nx start qtl-storybook    # serve Storybook (port 4403)
+```
+
+## Storybook
+
+For components that don't call our own backend APIs (third-party service calls are fine): add a `.stories.ts` file for new components; for changes to existing components, adjust the existing story if the new behavior fits naturally, or add a new story variant for sufficiently distinct behavior. When it's unclear whether a new story is warranted, ask the user. Follow the same pattern as existing stories in `libs/qtl/`.


### PR DESCRIPTION
## Description

The share link button in `model-details-boxplots-selector` hardcoded 10 lines of icon configuration inline. To make this reusable across other consumers, `CopyLinkButtonComponent` has been extracted into `explorers-ui`, encapsulating the link icon, color, and dimensions and exposing only the four domain-meaningful inputs: `onClick`, `anchorId`, `ariaLabel`, and `tooltipText`.

## Related Issue

- [MG-954](https://sagebionetworks.jira.com/browse/MG-954)

## Changelog

- Add `CopyLinkButtonComponent` to `explorers-ui` with story and unit tests
- Replace `explorers-tooltip-button` usage in `model-details-boxplots-selector` with `explorers-copy-link-button`
- Add Storybook conventions to `libs/explorers/`, `libs/agora/`, and `libs/qtl/` CLAUDE.md files

## Testing

- Navigate to a model details page, biomarkers tab (e.g. `/models/Abca7*V1599M/biomarkers`)
- Hover over an evidence type section heading -- confirm the link icon appears
- Click the link icon -- confirm the tooltip changes to confirm the copy
- Paste the clipboard contents -- confirm the URL points to the correct section anchor

### Preview

`model-ad-build-images && model-ad-docker-start`

See that there's no change in behavior after switching to the shared component -- 

Dev: 

https://github.com/user-attachments/assets/68cb6144-c856-494f-9ebe-cf3237067bc1

PR: 

https://github.com/user-attachments/assets/0d414932-594e-41fe-83f6-9c308f38864e



[MG-954]: https://sagebionetworks.jira.com/browse/MG-954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ