### PR TITLE
fix(agora): fix drug hero badge comma, home card icon padding, and CT divider scroll (AG-2126, AG-2127, AG-2114)

### DIFF
--- a/libs/agora/drug-details/src/lib/components/drug-details-hero/drug-details-hero.component.spec.ts
+++ b/libs/agora/drug-details/src/lib/components/drug-details-hero/drug-details-hero.component.spec.ts
@@ -31,7 +31,7 @@ describe('DrugDetailsHeroComponent', () => {
       await setup({
         drug_nominations: [drugMock.drug_nominations[1]],
       });
-      expect(screen.getByText(/Nominated Combination Therapy, with/)).toBeInTheDocument();
+      expect(screen.getByText(/Nominated Combination Therapy with/)).toBeInTheDocument();
       const link = screen.getByRole('link', { name: /Irinotecan/ });
       expect(link).toBeInTheDocument();
       expect(link).toHaveAttribute('href', '/drugs/CHEMBL481');
@@ -40,7 +40,7 @@ describe('DrugDetailsHeroComponent', () => {
     it('should display both badges when drug has solo and combo nominations', async () => {
       await setup();
       expect(screen.getByText(/Nominated Drug/)).toBeInTheDocument();
-      expect(screen.getByText(/Nominated Combination Therapy, with/)).toBeInTheDocument();
+      expect(screen.getByText(/Nominated Combination Therapy with/)).toBeInTheDocument();
     });
   });
 

--- a/libs/agora/drug-details/src/lib/components/drug-details-hero/drug-details-hero.component.stories.ts
+++ b/libs/agora/drug-details/src/lib/components/drug-details-hero/drug-details-hero.component.stories.ts
@@ -1,0 +1,24 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import { provideRouter } from '@angular/router';
+import { drugMock } from '@sagebionetworks/agora/testing';
+import { applicationConfig } from '@storybook/angular';
+import { type Meta, type StoryObj } from '@storybook/angular';
+import { DrugDetailsHeroComponent } from './drug-details-hero.component';
+
+const meta: Meta<DrugDetailsHeroComponent> = {
+  component: DrugDetailsHeroComponent,
+  title: 'DrugDetails/DrugDetailsHero',
+  decorators: [
+    applicationConfig({
+      providers: [provideRouter([]), provideLocationMocks()],
+    }),
+  ],
+};
+export default meta;
+type Story = StoryObj<DrugDetailsHeroComponent>;
+
+export const DrugDetailsHero: Story = {
+  args: {
+    drug: drugMock,
+  },
+};

--- a/libs/agora/drug-details/src/lib/components/drug-details-hero/drug-details-hero.component.ts
+++ b/libs/agora/drug-details/src/lib/components/drug-details-hero/drug-details-hero.component.ts
@@ -28,7 +28,7 @@ export class DrugDetailsHeroComponent {
       } else {
         const link = `/${ROUTE_PATHS.DRUG_DETAILS}/${evidence.combined_with_chembl_id}`;
         const linkText = evidence.combined_with_common_name || evidence.combined_with_chembl_id;
-        badges.set(link, { label: 'Nominated Combination Therapy, with', link, linkText });
+        badges.set(link, { label: 'Nominated Combination Therapy with', link, linkText });
       }
     }
     return Array.from(badges.values());

--- a/libs/agora/home/src/lib/home.component.scss
+++ b/libs/agora/home/src/lib/home.component.scss
@@ -6,6 +6,10 @@ explorers-home-card {
   --color-arrow: var(--color-action-primary);
   --description-font-size: 16px;
   --description-line-height: 20px;
+
+  display: flex;
+  height: 100%;
+  min-height: 300px;
 }
 
 .section {

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-table.component.scss
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-table.component.scss
@@ -2,6 +2,8 @@
 @use 'explorers/styles/src/mixins' as mixins;
 
 .comparison-tool-table {
+  min-width: max-content;
+
   .table-divider {
     background-color: var(--color-gray-300);
     font-size: var(--font-size-sm);


### PR DESCRIPTION
## Description

Three small visual bugs in the Agora app: an extra comma in the drug details hero combination therapy badge, missing vertical space between home card icons and their text, and the gray section header bar in the comparison tool not extending to the right edge when the table overflows horizontally.

## Related Issue

- [AG-2126](https://sagebionetworks.jira.com/browse/AG-2126)
- [AG-2127](https://sagebionetworks.jira.com/browse/AG-2127)
- [AG-2114](https://sagebionetworks.jira.com/browse/AG-2114)

## Changelog

- Fix extra comma in "Nominated Combination Therapy with [drug]" badge in drug details hero
- Add `min-height` and flex sizing to home card to restore spacing between description text and icon
- Fix comparison tool "Pinned Results" and "All Results" dividers not extending to full scrollable table width
- Add Storybook story for `DrugDetailsHeroComponent`

## Testing

- Navigate to a drug details page for a drug with a combination therapy nomination (e.g., Letrozole) and confirm the badge reads "Nominated Combination Therapy with Irinotecan" with no comma before "with"
- Navigate to the Agora home page and confirm there is visible vertical space between the card description text and the icon/arrow row for all four cards (Gene Comparison, Nominated Targets, Nominated Drugs)
- Open the nominated drugs or nominated targets comparison tool, pin one or more rows, then narrow the browser window so the table scrolls horizontally -- scroll to the right and confirm the "Pinned Results" and "All Results" gray bars extend to the far right edge of the table

### Preview

| dev | this pr | difference | 
| --- | --- | --- | 
| <img width="1081" height="337" alt="image" src="https://github.com/user-attachments/assets/21aec4e9-54d3-4b52-a9c1-59188d3ae23d" /> | <img width="1082" height="318" alt="image" src="https://github.com/user-attachments/assets/9deca71b-530b-4dfb-9867-2033aec652b8" /> | extra comma removed from combination therapy drug badge |
| <img width="1373" height="605" alt="image" src="https://github.com/user-attachments/assets/f69f756e-4c83-468a-a126-37e5bcf82d35" /> | <img width="1380" height="656" alt="image" src="https://github.com/user-attachments/assets/5f740916-889b-45b1-8f0a-a2d953dc1819" /> | added padding between icon and text in home page tiles | 

CT section header when items are pinned and table is wider than screen -- 

in dev, the gray bar does not extend the full scrollable width: 

https://github.com/user-attachments/assets/b0c54063-0858-43b2-b745-92713df22205

in this PR, the gray bar does extend the full scrollable width: 

https://github.com/user-attachments/assets/dcb0b41d-499a-488e-b88d-4cbcf257d3f2

[AG-2126]: https://sagebionetworks.jira.com/browse/AG-2126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-2127]: https://sagebionetworks.jira.com/browse/AG-2127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-2114]: https://sagebionetworks.jira.com/browse/AG-2114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ