### PR TITLE
feat(sage-monorepo): add Claude Code worktree support (SMR-739)

### DIFF
--- a/.claude/hooks/SessionStart.js
+++ b/.claude/hooks/SessionStart.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+// SessionStart hook for Claude Code
+//
+// Notifies the user if workspace-install is still running in the background
+// after a worktree session starts.
+//
+// Uses plain Node.js (no tsx) so it works even before workspace-install completes.
+
+const fs = require('fs');
+
+if (fs.existsSync('.workspace-installing')) {
+  process.stdout.write(
+    JSON.stringify({
+      systemMessage:
+        'workspace-install is running in the background. Run: tail -f .workspace-install.log to follow progress.',
+    }) + '\n',
+  );
+}

--- a/.claude/hooks/WorktreeCreate.js
+++ b/.claude/hooks/WorktreeCreate.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// WorktreeCreate hook for Claude Code
+//
+// Handles worktree creation for `claude -w`:
+// reuses an existing branch if found, otherwise creates a new one,
+// copies gitignored files listed in .worktreeinclude into the worktree,
+// then runs workspace-install in the background.
+//
+// Input (JSON on stdin): { "name": "<slug>", "cwd": "<project-root>", ... }
+// Output (stdout):       Absolute path to the created worktree directory
+
+const { execFileSync, spawnSync, spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const input = JSON.parse(fs.readFileSync(process.stdin.fd, 'utf8'));
+const { name, cwd } = input;
+const worktreePath = path.join(cwd, '.claude', 'worktrees', name);
+
+// If the worktree directory already exists, reuse it as-is
+if (fs.existsSync(worktreePath)) {
+  process.stdout.write(worktreePath + '\n');
+  process.exit(0);
+}
+
+// Reuse existing branch if it exists, otherwise create a new one
+let branchExists = false;
+try {
+  execFileSync('git', ['-C', cwd, 'show-ref', '--verify', '--quiet', `refs/heads/${name}`]);
+  branchExists = true;
+} catch {
+  // branch does not exist yet
+}
+
+if (branchExists) {
+  execFileSync('git', ['-C', cwd, 'worktree', 'add', worktreePath, name], {
+    stdio: ['ignore', 'ignore', 'inherit'],
+  });
+} else {
+  execFileSync('git', ['-C', cwd, 'worktree', 'add', '-b', name, worktreePath, 'HEAD'], {
+    stdio: ['ignore', 'ignore', 'inherit'],
+  });
+}
+
+// Copy gitignored files listed in .worktreeinclude into the new worktree.
+// Uses git ls-files to enumerate matches (supports full gitignore pattern syntax),
+// then pipes through tar for an atomic bulk copy.
+const worktreeInclude = path.join(cwd, '.worktreeinclude');
+if (fs.existsSync(worktreeInclude)) {
+  const ls = spawnSync(
+    'git',
+    ['ls-files', '--others', '--ignored', '--exclude-from=.worktreeinclude', '-z'],
+    { cwd, encoding: 'buffer' },
+  );
+  if (ls.stdout && ls.stdout.length > 0) {
+    const tar = spawnSync('tar', ['-C', cwd, '--null', '-T', '-', '-cf', '-'], {
+      input: ls.stdout,
+      encoding: 'buffer',
+    });
+    if (tar.stderr && tar.stderr.length > 0) process.stderr.write(tar.stderr);
+    if (tar.stdout && tar.stdout.length > 0) {
+      const extract = spawnSync('tar', ['-C', worktreePath, '-xf', '-'], {
+        input: tar.stdout,
+        encoding: 'buffer',
+      });
+      if (extract.stderr && extract.stderr.length > 0) process.stderr.write(extract.stderr);
+    }
+  }
+  if (ls.stderr && ls.stderr.length > 0) process.stderr.write(ls.stderr);
+}
+
+// Run workspace-install in the background; SessionStart hook will notify the user.
+// Output is logged to .workspace-install.log — tail it to follow progress.
+//
+// We wrap the install in a Node.js child process so it can delete the sentinel
+// file when the install finishes. Spawning bash directly with child.unref() causes
+// WorktreeCreate to exit before the install completes, so child.on('close') never fires.
+const pidFile = path.join(worktreePath, '.workspace-installing');
+const logFile = fs.openSync(path.join(worktreePath, '.workspace-install.log'), 'w');
+const installWrapper = [
+  `const {spawnSync} = require('child_process'), fs = require('fs'), path = require('path');`,
+  `const devEnvPath = path.join(${JSON.stringify(cwd)}, 'dev-env.sh');`,
+  `spawnSync('bash', ['-c', 'shopt -s expand_aliases && source "$1" && workspace-install', '--', devEnvPath], {cwd: ${JSON.stringify(worktreePath)}, stdio: 'inherit'});`,
+  `fs.rmSync(${JSON.stringify(pidFile)}, {force: true});`,
+].join(' ');
+const child = spawn(process.execPath, ['-e', installWrapper], {
+  cwd: worktreePath,
+  detached: true,
+  windowsHide: true,
+  stdio: ['ignore', logFile, logFile],
+});
+child.unref();
+if (child.pid != null) {
+  fs.writeFileSync(pidFile, String(child.pid));
+}
+
+process.stdout.write(worktreePath + '\n');

--- a/.claude/hooks/WorktreeRemove.js
+++ b/.claude/hooks/WorktreeRemove.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// WorktreeRemove hook for Claude Code
+//
+// Handles cleanup when a worktree session ends.
+// Since WorktreeCreate replaces the default git behavior,
+// we need this hook to properly run git worktree remove.
+//
+// Input (JSON on stdin): { "worktree_path": "<absolute-path>", ... }
+
+const { execFileSync, spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const input = JSON.parse(fs.readFileSync(process.stdin.fd, 'utf8'));
+const { worktree_path: worktreePath } = input;
+
+// Kill any in-progress workspace-install before removing the worktree
+const pidFile = path.join(worktreePath, '.workspace-installing');
+if (fs.existsSync(pidFile)) {
+  const pid = parseInt(fs.readFileSync(pidFile, 'utf8').trim(), 10);
+  if (!isNaN(pid)) {
+    try {
+      // On Unix, negative PID kills the entire process group (pnpm + children).
+      // On Windows, only the pnpm process is killed; orphaned children will exit when the worktree is deleted.
+      process.kill(process.platform === 'win32' ? pid : -pid, 'SIGKILL');
+    } catch {
+      // process may have already exited
+    }
+  }
+}
+
+// Rename the entire worktree directory atomically so git worktree prune can clean up
+// the stale metadata instantly, then delete the renamed directory in the background.
+// This makes the hook return in milliseconds rather than waiting on rm -rf.
+const tempPath = path.join(
+  path.dirname(worktreePath),
+  `.removing_${path.basename(worktreePath)}_${Date.now()}`,
+);
+
+try {
+  fs.renameSync(worktreePath, tempPath);
+  execFileSync('git', ['worktree', 'prune'], { stdio: 'ignore' });
+  const child = spawn(
+    process.platform === 'win32' ? 'cmd.exe' : 'rm',
+    process.platform === 'win32' ? ['/c', 'rd', '/s', '/q', tempPath] : ['-rf', tempPath],
+    { detached: true, stdio: 'ignore' },
+  );
+  child.unref();
+} catch {
+  // rename failed (e.g. cross-device) — fall back to synchronous removal
+  try {
+    execFileSync('git', ['worktree', 'remove', worktreePath, '--force'], {
+      stdio: 'ignore',
+    });
+  } catch {
+    /* ignore */
+  }
+  try {
+    execFileSync('git', ['worktree', 'prune'], { stdio: 'ignore' });
+  } catch {
+    /* ignore */
+  }
+  try {
+    fs.rmSync(worktreePath, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,26 @@
 {
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "matcher": "",
+        "hooks": [{ "type": "command", "command": "node .claude/hooks/WorktreeCreate.js" }],
+        "statusMessage": "Creating worktree..."
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "matcher": "",
+        "hooks": [{ "type": "command", "command": "node .claude/hooks/WorktreeRemove.js" }],
+        "statusMessage": "Removing worktree..."
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [{ "type": "command", "command": "node .claude/hooks/SessionStart.js" }]
+      }
+    ]
+  },
   "permissions": {
     "deny": [
       "Read(./.env)",

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .claude-user/
+.claude/worktrees/
 .nx-container/
 .nx/
 .pnpm-store/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+apps/**/.env
+apps/**/.env.*

--- a/docs/develop/advanced/working-with-git-worktrees.md
+++ b/docs/develop/advanced/working-with-git-worktrees.md
@@ -1,0 +1,27 @@
+# Working with Git Worktrees
+
+Claude worktrees are created inside `.claude/worktrees/` (e.g. via `claude -w my-branch`). This directory is listed in `.gitignore` to prevent the worktree contents from appearing as untracked files in the parent repo.
+
+## Opening a worktree in VS Code
+
+Because `.claude/worktrees` is gitignored, VS Code's file indexer excludes worktree files from Cmd+P and file search when viewed from the parent window. The correct workflow is to open the worktree as its own VS Code window:
+
+```sh
+code .claude/worktrees/my-branch
+```
+
+This opens a new window rooted at the worktree. Cmd+P, the Explorer, and file search all work normally against the worktree's files.
+
+## Background install
+
+When a worktree is created, `workspace-install` runs in the background to set up Node.js, Python, and other dependencies for the branch. A sentinel file `.workspace-installing` is written to the worktree root while it runs.
+
+If you open a Claude session in the worktree before the install completes, you will see a notification:
+
+```
+workspace-install is running in the background. Run: tail -f .workspace-install.log to follow progress.
+```
+
+## Environment files
+
+Files matching `apps/**/.env` and `apps/**/.env.*` are copied from the parent repo into the worktree automatically on creation, so projects like `model-ad-data` have their credentials available without any manual setup.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
       - Advanced:
           - Remote Development: develop/advanced/developing-on-a-remote-host.md
           - Multi-author Commits: develop/advanced/creating-a-commit-with-multiple-authors.md
+          - Git Worktrees with Claude Code: develop/advanced/working-with-git-worktrees.md
   - API:
       - Overview: api/overview.md
       - Agora: api/agora.md


### PR DESCRIPTION
## Description

Adds Claude Code worktree support via custom `WorktreeCreate`, `WorktreeRemove`, and `SessionStart` hooks. Git worktrees allow multiple isolated working directories from the same repository, enabling Claude to work on separate tasks in parallel without branch conflicts -- each `claude -w <name>` session gets its own worktree. Custom hooks are used instead of the default `claude -w` behavior to branch from HEAD (not the remote default), reuse existing branches, run `workspace-install` in the background after worktree creation, and copy gitignored `.env` files into the worktree so credentials are available immediately.

The table below summarizes differences between the default Claude worktree behavior and the custom hooks:

| Behavior | Default `claude -w` | Custom hooks |
| :--- | :---: | :---: |
| Branch name | always prepended with `worktree-` | exact name provided |
| Branched from | default remote branch | HEAD -- can create from any branch |
| Reuse existing branch | only a `worktree-` branch | any branch |
| Dependency install after creation | manual | `workspace-install` runs in background |
| `.env` files | not copied | copied via `.worktreeinclude` |

Relevant docs:
- [Run parallel sessions with git worktrees](https://code.claude.com/docs/en/common-workflows#run-parallel-claude-code-sessions-with-git-worktrees)
- [WorktreeCreate hook](https://code.claude.com/docs/en/hooks#worktreecreate)
- [WorktreeRemove hook](https://code.claude.com/docs/en/hooks#worktreeremove)
- [Claude worktree hook examples](https://mattbrailsford.dev/replacing-my-custom-git-worktree-skill-with-claude-code-hooks)

## Related Issue

- [SMR-739](https://sagebionetworks.jira.com/browse/SMR-739)

## Changelog

- Add `WorktreeCreate` hook that creates a worktree, copies `.env` files, and runs `workspace-install` in the background
- Add `WorktreeRemove` hook that kills any in-progress install, renames the worktree atomically, and background-deletes it
- Add `SessionStart` hook that notifies the user if `workspace-install` is still running
- Add `.worktreeinclude` to copy `apps/**/.env` and `apps/**/.env.*` into new worktrees
- Wire all three hooks in `.claude/settings.json`
- Add `.claude/worktrees/` to `.gitignore`
- Add `docs/develop/advanced/working-with-git-worktrees.md` with usage instructions

## Testing

1. Run `claude -w my-feature` from the repo root.
   - Approve MCP servers for the Claude session, if necessary.
   - Confirm `.claude/worktrees/my-feature/` is created with a `my-feature` branch (`git worktree list`).
   - Confirm `.workspace-installing` sentinel file exists in the worktree root while the install runs.
   - Confirm `apps/**/.env` files are present in the worktree (e.g. `ls .claude/worktrees/my-feature/apps/model-ad/data/.env`).
   - Follow install progress: `tail -f .claude/worktrees/my-feature/.workspace-install.log`.
2. Open the worktree in a new VS Code window: `code .claude/worktrees/my-feature`.
   - Confirm new window opens within the Dev Container
   - Confirm Cmd+P and file search work against the worktree's files (not the parent repo).
   - Open a terminal in the new window and run `claude`.
   - If `workspace-install` is still running, confirm the session opens with the system message: _"workspace-install is running in the background. Run: tail -f .workspace-install.log to follow progress."_
3. Run `claude -w my-feature` a second time (from the root not the worktree before removing the worktree).
   - Confirm it reuses the existing worktree without reinstalling.
4. Exit the session with `ctrl+d`. Confirm "Removing worktree..." appears while the hook runs.
   - Confirm the worktree directory is gone after cleanup.
   - Confirm `git worktree list` shows only the main repo.
   - Confirm the `my-feature` branch still exists (`git branch`).
5. Run `claude -w my-feature` again (branch exists, worktree does not).
   - Confirm the existing branch is checked out rather than a new one being created.

> [!IMPORTANT]
> If the worktree branch has uncommitted changes when you exit, Claude will display a menu asking how to proceed. If there are no uncommitted changes, the worktree is deleted silently and only the branch is kept.

> [!NOTE]
> Resuming a worktree session after the worktree directory has been deleted is not supported -- Claude derives the project key from the worktree's absolute path, so `claude --resume` will fail once the directory is gone. If the worktree was not deleted, the session can be resumed: `cd .claude/worktrees/my-feature && claude --resume <sessionId>`.


[SMR-739]: https://sagebionetworks.jira.com/browse/SMR-739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ