### PR TITLE
feat(sage-monorepo): add grill-me Claude skill (SMR-793)

### DIFF
--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: grill-me
+description: A relentless interview to sharpen a plan or design.
+disable-model-invocation: true
+---
+
+Run a `/grilling` session.

--- a/.claude/skills/grilling/SKILL.md
+++ b/.claude/skills/grilling/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grilling
+description: Interview the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building, or uses any 'grill' trigger phrases.
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.


### PR DESCRIPTION
## Description

Adds the **grill-me** Claude Code skill so the team can stress-test a plan or design before building it. Sourced from [mattpocock/skills](https://github.com/mattpocock/skills/tree/main/skills/productivity/grill-me).

It ships as two skills:

- **`grill-me`** — manual entry point (`disable-model-invocation: true`); invoke with `/grill-me`.
- **`grilling`** — the engine; interviews you one question at a time, walking each branch of the design tree and recommending an answer for each. Also model-invocable via phrases like "grill me on this plan".

## Related Issue

[SMR-793](https://sagebionetworks.jira.com/browse/SMR-793)

## Changelog

- Add `.claude/skills/grill-me/SKILL.md`
- Add `.claude/skills/grilling/SKILL.md`

## Testing

- Restart Claude Code (skills load at session start), then run `/grill-me` and provide a plan — confirm it asks one question at a time and recommends an answer per question.

[SMR-793]: https://sagebionetworks.jira.com/browse/SMR-793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ