### PR TITLE
fix(agora): vertically align info buttons with adjacent text (AG-2154)

### DIFF
--- a/libs/agora/genes/src/lib/components/gene-evidence-rna/gene-evidence-rna.component.html
+++ b/libs/agora/genes/src/lib/components/gene-evidence-rna/gene-evidence-rna.component.html
@@ -55,7 +55,7 @@
     <div class="section">
       <div class="section-inner pb-0">
         <div class="container-sm">
-          <h2 class="text-default mb-sm">
+          <h2 class="text-default mb-sm filter-heading">
             Filter the following charts by statistical model
             <explorers-modal-link
               text=""

--- a/libs/agora/genes/src/lib/components/gene-evidence-rna/gene-evidence-rna.component.scss
+++ b/libs/agora/genes/src/lib/components/gene-evidence-rna/gene-evidence-rna.component.scss
@@ -1,3 +1,13 @@
 explorers-download-dom-image {
   float: right;
 }
+
+h2.filter-heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  explorers-modal-link {
+    margin-left: auto;
+  }
+}

--- a/libs/agora/styles/src/lib/components/_typography.scss
+++ b/libs/agora/styles/src/lib/components/_typography.scss
@@ -38,12 +38,6 @@ h6 {
   }
 }
 
-h2 {
-  explorers-modal-link {
-    transform: translateY(-3px);
-  }
-}
-
 p {
   margin-top: 0;
 }

--- a/libs/explorers/util/src/lib/popover-link/popover-link.component.scss
+++ b/libs/explorers/util/src/lib/popover-link/popover-link.component.scss
@@ -1,6 +1,12 @@
 @use 'explorers/styles/src/mixins' as mixins;
 
+:host {
+  align-self: center;
+}
+
 .popover-link-container {
+  display: flex;
+
   button {
     @include mixins.reset-button;
   }
@@ -9,6 +15,7 @@
     display: flex;
 
     .popover-link-icon {
+      display: flex;
       color: var(--color-gray-600);
       transform: translateY(1px);
 


### PR DESCRIPTION
## Description

Info icon buttons were vertically misaligned relative to adjacent text in several places across explorers apps. These changes fix the layout so icons are properly centered, and remove a global typography hack that was masking the underlying issue.

## Related Issue

- [AG-2154](https://sagebionetworks.jira.com/browse/AG-2154)

## Changelog

- Add `display: flex` to `popover-link` internal containers so the icon is not affected by the inherited line-height of surrounding text, and add `align-self: center` to the host so it centers within its flex parent
- Replace global `h2 explorers-modal-link { translateY }` rule with a scoped flex layout on the specific RNA evidence heading that contains an info button

## Testing

- In the Agora **Gene Details > RNA tab**, confirm the info button next to "Filter the following charts by statistical model" is vertically centered with the heading text
- In the Agora **Gene Comparison Tool**, confirm the info buttons next to the category dropdowns are vertically centered with the selected label text
- In the Agora **Nominated Targets** and **Nominated Drugs** comparison tools, confirm the info button in the CT header title row is vertically centered
- In the Model AD **Differential Expression** and **Disease Correlation** comparison tools, confirm the info button in the CT selector controls is vertically centered
- In the Model AD mouse details pages biomarkers/pathology tabs, confirm the info button is vertically centered in the wiki link text

### Preview

app | feature | dev | this PR | change in PR
:---: | :---: | :---: | :---: | :---: 
model-ad | mouse details page - wiki link | <img width="293" height="39" alt="AG-2154_modelad_mouse_details_wiki_dev" src="https://github.com/user-attachments/assets/96aaae18-95d7-4ab4-b285-d6e52da1e5b3" /> | <img width="302" height="38" alt="AG-2154_modelad_mouse_details_wiki_pr" src="https://github.com/user-attachments/assets/f981dd57-9dcf-4c5b-9c51-7bee5e4e889c" /> | no change
model-ad | disease correlation CT | <img width="541" height="159" alt="AG-2154_modelad_diseasecorrelation_title_dev" src="https://github.com/user-attachments/assets/cf025b66-438c-4299-9f32-8d906a44c037" /> | <img width="554" height="162" alt="AG-2154_modelad_diseasecorrelation_title_pr" src="https://github.com/user-attachments/assets/87d7e51f-ba04-4d40-b6d8-3c221443dcb4" /> | vertically centered
model-ad | differential expression CT | <img width="563" height="185" alt="AG-2154_modelad_differential_expression_title_dev" src="https://github.com/user-attachments/assets/39fb9e30-3210-4723-8850-83dfc302a1bf" /> | <img width="570" height="183" alt="AG-2154_modelad_differential_expression_title_pr" src="https://github.com/user-attachments/assets/e05e5d7c-81a6-4f82-9f9a-2d58f31127c7" /> | vertically centered
agora | gene details - rna tab - filter link |  <img width="953" height="121" alt="AG-2154_agora_gene_details_rna_filter_dev" src="https://github.com/user-attachments/assets/0bf4e39f-8ec9-4567-a383-ec9214a4d572" /> | <img width="974" height="122" alt="AG-2154_agora_gene_details_rna_filter_pr" src="https://github.com/user-attachments/assets/091430d2-3f08-458d-aafa-70519f72835c" /> | vertically centered
agora | gene details - rna tab - wiki link | <img width="192" height="35" alt="AG-2154_agora_gene_details_rna_wiki_dev" src="https://github.com/user-attachments/assets/15fcb562-3118-4dd0-b914-5178b221144f" /> | <img width="184" height="28" alt="AG-2154_agora_gene_details_rna_wiki_pr" src="https://github.com/user-attachments/assets/473a995a-7246-4307-b023-1ba550ef1de7" /> | no change
agora | gene details - summary - tab - SOE chart link | <img width="242" height="59" alt="AG-2154_agora_gene_details_summary_soe_chart_dev" src="https://github.com/user-attachments/assets/1cd1e26f-29e1-4798-8982-68bb99db451e" /> | <img width="240" height="51" alt="AG-2154_agora_gene_details_summary_soe_chart_pr" src="https://github.com/user-attachments/assets/9643f4bd-c4f9-47f6-9e43-03afba3fa1a4" /> | vertically centered
agora | nominated drugs CT | <img width="260" height="58" alt="AG-2154_agora_nominated_drugs_dev" src="https://github.com/user-attachments/assets/afcad751-9e34-4206-9ebb-136c01527b82" /> | <img width="293" height="64" alt="AG-2154_agora_nominated_drugs_pr" src="https://github.com/user-attachments/assets/fbf3c800-64d9-4b3d-ab51-fec572eb2856" /> | vertically centered
agora | nominated targets CT | <img width="290" height="63" alt="AG-2154_agora_nominated_targets_dev" src="https://github.com/user-attachments/assets/c59dcd41-a5cd-4c53-bb5b-a1860feeb3de" /> | <img width="359" height="61" alt="AG-2154_agora_nominated_targets_pr" src="https://github.com/user-attachments/assets/3f5f5776-eae1-4e7b-a80c-99ddd7f72ffa" /> | vertically centered
agora | GCT | <img width="532" height="175" alt="AG-2154_agora_gct_dev" src="https://github.com/user-attachments/assets/af85a156-df34-4e65-829f-3c680533e182" /> | <img width="587" height="184" alt="AG-2154_agora_gct_pr" src="https://github.com/user-attachments/assets/d1e3fa2c-9d87-421e-b468-1c5fcd5b61ef" /> | vertically centered

[AG-2154]: https://sagebionetworks.jira.com/browse/AG-2154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ