### PR TITLE
feat(agora): add line break between badges in gene details hero (AG-2152)

### DIFF
--- a/libs/agora/genes/src/lib/components/gene-hero/gene-hero.component.html
+++ b/libs/agora/genes/src/lib/components/gene-hero/gene-hero.component.html
@@ -13,7 +13,12 @@
         </h2>
         @if (showNominationsOrTEP()) {
           <div class="gene-hero-nominated">
-            {{ getNominationText() }}
+            @if (gene.total_nominations) {
+              <div>Nominated Target</div>
+            }
+            @if (gene.is_adi || gene.is_tep) {
+              <div>Selected for Target Enabling Resource Development</div>
+            }
           </div>
         }
         <p class="gene-hero-summary">

--- a/libs/agora/genes/src/lib/components/gene-hero/gene-hero.component.scss
+++ b/libs/agora/genes/src/lib/components/gene-hero/gene-hero.component.scss
@@ -29,12 +29,8 @@ hr {
 
 .gene-hero-nominated {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   margin-bottom: 15px;
-
-  svg {
-    margin-right: 6px;
-  }
 }
 
 .gene-hero-biodomains {

--- a/libs/agora/genes/src/lib/components/gene-hero/gene-hero.component.spec.ts
+++ b/libs/agora/genes/src/lib/components/gene-hero/gene-hero.component.spec.ts
@@ -33,25 +33,30 @@ describe('Component: Gene Hero', () => {
   });
 
   it('should show nomination and TEP text for MSN if nomination exists and is either is_tep or is_adi is true', () => {
-    const expected = 'Nominated Target, Selected for Target Enabling Resource Development';
+    const nominatedTargetText = 'Nominated Target';
+    const tepText = 'Selected for Target Enabling Resource Development';
 
     component.gene = geneMock1;
     component.gene.is_tep = true;
     component.gene.is_adi = false;
     fixture.detectChanges();
 
-    let el = element.querySelector('.gene-hero-nominated') as HTMLElement;
+    let lines = element.querySelectorAll('.gene-hero-nominated div');
 
-    expect(el.textContent?.trim()).toBe(expected);
+    expect(lines.length).toBe(2);
+    expect(lines[0].textContent?.trim()).toBe(nominatedTargetText);
+    expect(lines[1].textContent?.trim()).toBe(tepText);
 
     component.gene = geneMock1;
     component.gene.is_tep = false;
     component.gene.is_adi = true;
     fixture.detectChanges();
 
-    el = element.querySelector('.gene-hero-nominated') as HTMLElement;
+    lines = element.querySelectorAll('.gene-hero-nominated div');
 
-    expect(el.textContent?.trim()).toBe(expected);
+    expect(lines.length).toBe(2);
+    expect(lines[0].textContent?.trim()).toBe(nominatedTargetText);
+    expect(lines[1].textContent?.trim()).toBe(tepText);
   });
 
   it('should show nomination and not show TEP text for MSN if both is_tep and is_adi is false', () => {

--- a/libs/agora/genes/src/lib/components/gene-hero/gene-hero.component.ts
+++ b/libs/agora/genes/src/lib/components/gene-hero/gene-hero.component.ts
@@ -19,19 +19,6 @@ export class GeneHeroComponent {
     return this.gene.total_nominations || this.gene.is_adi || this.gene.is_tep;
   }
 
-  getNominationText() {
-    if (!this.gene) return '';
-    let result = '';
-    if (this.gene.total_nominations) {
-      result += 'Nominated Target';
-    }
-    if (this.gene.is_adi || this.gene.is_tep) {
-      result += this.gene.total_nominations ? ', ' : '';
-      return (result += 'Selected for Target Enabling Resource Development');
-    }
-    return result;
-  }
-
   getSummary(body = false): string {
     if (this.gene?.summary) {
       let finalString = '';


### PR DESCRIPTION
## Description

The "Nominated Target" and "Selected for Target Enabling Resource Development" badges in the gene details hero were rendered as a single comma-separated string. This splits them into separate block elements so they appear on their own lines.

## Related Issue

- [AG-2152](https://sagebionetworks.jira.com/browse/AG-2152)

## Changelog

- Render nomination badges as separate block elements in the gene hero template

## Testing

- Navigate to a gene that is both a Nominated Target and TEP/ADI (e.g. PLEC) and confirm the two badges appear on separate lines in the hero section
- Navigate to a gene that is only a Nominated Target (e.g. CLU) and confirm that the Nominated Target badge appears
- Navigate to a gene that is only a TEP/ADI (e.g. MAPK3 ) and confirm that the Selected badge appears
- Navigate to a gene that is neither nominated or TEP/ADI (e.g. BOC ) and confirm that neither badge appears

### Preview

| nominated | TEP/ADI |  gene | dev | this PR | change
:---: | :---: | :---: | :---: | :---: | :---: 
yes | yes | PLEC | <img width="955" height="199" alt="AG-2152_PLEC_dev" src="https://github.com/user-attachments/assets/8e63297a-361d-4811-942f-861c0c9a7501" /> | <img width="957" height="208" alt="AG-2152_PLEC_pr" src="https://github.com/user-attachments/assets/1d30efa5-3bde-452a-ab69-94e19f15cba0" /> | new break
yes | no | CLU | <img width="929" height="159" alt="AG-2152_CLU_dev" src="https://github.com/user-attachments/assets/089a424f-1c34-4cf6-884c-e36f2538647d" /> | <img width="923" height="163" alt="AG-2152_CLU_pr" src="https://github.com/user-attachments/assets/abbf4c99-b54f-4f22-86a1-11d08adba168" /> | none 
no | yes | MAPK3 | <img width="914" height="180" alt="AG-2152_MAPK3_dev" src="https://github.com/user-attachments/assets/54fea4e1-2048-4f4e-a8d7-614d0679f2d6" /> | <img width="930" height="186" alt="AG-2152_MAPK3_pr" src="https://github.com/user-attachments/assets/4da3639f-42ad-4171-a0c1-e0beaa7a36ea" /> | none
no | no | BOC | <img width="942" height="199" alt="AG-2152_BOC_dev" src="https://github.com/user-attachments/assets/2af914ed-d364-45d0-aa48-c7c5ad31dc68" /> | <img width="960" height="202" alt="AG-2152_BOC_pr" src="https://github.com/user-attachments/assets/72d442de-58fe-4ecd-87e9-8a70663746ca" /> | none

[AG-2152]: https://sagebionetworks.jira.com/browse/AG-2152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ