### PR TITLE
feat(agora): update linked targets display in drug details summary (AG-2083)

### DIFF
--- a/apps/agora/app/e2e/drug-details.spec.ts
+++ b/apps/agora/app/e2e/drug-details.spec.ts
@@ -63,7 +63,7 @@ test.describe('drug details - summary', () => {
 
   test('displays linked targets with links', async ({ page }) => {
     await page.goto(summaryUrl);
-    await expect(page.getByText('Linked Targets')).toBeVisible();
+    await expect(page.getByText(`Targets linked to ${drugName}`)).toBeVisible();
     const jak1Link = page.getByRole('link', { name: 'JAK1' });
     await expect(jak1Link).toBeVisible();
     await expect(jak1Link).toHaveAttribute('href', '/genes/ENSG00000162434');

--- a/libs/agora/drug-details/src/lib/components/drug-details-nomination-details/drug-details-nomination-details.component.stories.ts
+++ b/libs/agora/drug-details/src/lib/components/drug-details-nomination-details/drug-details-nomination-details.component.stories.ts
@@ -1,0 +1,16 @@
+import { drugMock } from '@sagebionetworks/agora/testing';
+import { type Meta, type StoryObj } from '@storybook/angular';
+import { DrugDetailsNominationDetailsComponent } from './drug-details-nomination-details.component';
+
+const meta: Meta<DrugDetailsNominationDetailsComponent> = {
+  component: DrugDetailsNominationDetailsComponent,
+  title: 'DrugDetails/DrugDetailsNominationDetails',
+};
+export default meta;
+type Story = StoryObj<DrugDetailsNominationDetailsComponent>;
+
+export const DrugDetailsNominationDetails: Story = {
+  args: {
+    drug: drugMock,
+  },
+};

--- a/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.html
+++ b/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.html
@@ -32,6 +32,9 @@
             <a [routerLink]="['/' + ROUTE_PATHS.DETAILS, target.ensembl_gene_id]">{{
               target.hgnc_symbol || target.ensembl_gene_id
             }}</a>
+            @if (target.is_nominated_target) {
+              - Nominated Target
+            }
           </li>
         }
       </ul>

--- a/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.html
+++ b/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.html
@@ -25,7 +25,7 @@
     }
 
     @if (drug().linked_targets.length > 0) {
-      <p class="drug-details-label">Linked Targets</p>
+      <p class="drug-details-label">Targets linked to {{ drug().common_name }}</p>
       <ul>
         @for (target of drug().linked_targets; track target) {
           <li>

--- a/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.spec.ts
+++ b/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.spec.ts
@@ -53,12 +53,28 @@ describe('DrugDetailsSummaryComponent', () => {
   });
 
   describe('linked targets', () => {
-    it('should display linked targets when present', async () => {
+    it('should show "- Nominated Target" as plain text beside the link when target is nominated', async () => {
       await setup();
       expect(screen.getByText('Linked Targets')).toBeInTheDocument();
       const link = screen.getByRole('link', { name: 'CYP19A1' });
       expect(link).toBeInTheDocument();
       expect(link).toHaveAttribute('href', '/genes/ENSG00000137869');
+      expect(link).not.toHaveTextContent('Nominated Target');
+      expect(screen.getByText('- Nominated Target')).toBeInTheDocument();
+    });
+
+    it('should not show "- Nominated Target" when target is not nominated', async () => {
+      await setup({
+        linked_targets: [
+          {
+            ensembl_gene_id: 'ENSG00000137869',
+            hgnc_symbol: 'CYP19A1',
+            is_nominated_target: false,
+          },
+        ],
+      });
+      expect(screen.getByRole('link', { name: 'CYP19A1' })).toBeInTheDocument();
+      expect(screen.queryByText('- Nominated Target')).not.toBeInTheDocument();
     });
 
     it('should fall back to ensembl_gene_id when hgnc_symbol is missing', async () => {

--- a/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.spec.ts
+++ b/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.spec.ts
@@ -55,7 +55,7 @@ describe('DrugDetailsSummaryComponent', () => {
   describe('linked targets', () => {
     it('should show "- Nominated Target" as plain text beside the link when target is nominated', async () => {
       await setup();
-      expect(screen.getByText('Linked Targets')).toBeInTheDocument();
+      expect(screen.getByText(`Targets linked to ${drugMock.common_name}`)).toBeInTheDocument();
       const link = screen.getByRole('link', { name: 'CYP19A1' });
       expect(link).toBeInTheDocument();
       expect(link).toHaveAttribute('href', '/genes/ENSG00000137869');
@@ -90,7 +90,7 @@ describe('DrugDetailsSummaryComponent', () => {
 
     it('should not display linked targets section when empty', async () => {
       await setup({ linked_targets: [] });
-      expect(screen.queryByText('Linked Targets')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Targets linked to/)).not.toBeInTheDocument();
     });
   });
 });

--- a/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.stories.ts
+++ b/libs/agora/drug-details/src/lib/components/drug-details-summary/drug-details-summary.component.stories.ts
@@ -1,0 +1,24 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import { provideRouter } from '@angular/router';
+import { drugMock } from '@sagebionetworks/agora/testing';
+import { applicationConfig } from '@storybook/angular';
+import { type Meta, type StoryObj } from '@storybook/angular';
+import { DrugDetailsSummaryComponent } from './drug-details-summary.component';
+
+const meta: Meta<DrugDetailsSummaryComponent> = {
+  component: DrugDetailsSummaryComponent,
+  title: 'DrugDetails/DrugDetailsSummary',
+  decorators: [
+    applicationConfig({
+      providers: [provideRouter([]), provideLocationMocks()],
+    }),
+  ],
+};
+export default meta;
+type Story = StoryObj<DrugDetailsSummaryComponent>;
+
+export const DrugDetailsSummary: Story = {
+  args: {
+    drug: drugMock,
+  },
+};


### PR DESCRIPTION
## Description

Updates the drug details summary page to align the linked targets section heading with the design and to conditionally show "- Nominated Target" as plain text beside any target that is also a nominated target.

> [!NOTE]
> Depends on #4117 -- should be kept as a draft until that PR is merged and this branch updated accordingly.

## Related Issue

- [AG-2083](https://sagebionetworks.jira.com/browse/AG-2083)

## Changelog

- Update linked targets section heading from "Linked Targets" to "Targets linked to {drug name}"
- Add "- Nominated Target" plain-text suffix beside links for nominated targets

## Testing

- Navigate to a drug details page (e.g., `/drugs/CHEMBL19449` for Ibudilast)
- Confirm the linked targets section heading reads "Targets linked to Ibudilast" (not "Linked Targets")
- Confirm each gene name is a clickable link that navigates to the correct gene details page
- For a target that is a nominated target (e.g. PDE10A), confirm "- Nominated Target" appears as plain text after the link
- For a target that is not nominated (e.g. PDE3A), confirm no "- Nominated Target" suffix appears

### Preview

| dev | pr |
| --- | --- |
<img width="317" height="202" alt="AG-2083_dev" src="https://github.com/user-attachments/assets/84db72d7-7321-4d91-a5ef-a13838e10a7f" /> | <img width="276" height="209" alt="AG-2083_pr" src="https://github.com/user-attachments/assets/365c4fe5-2e45-4271-816b-ea15182d78c1" />


[AG-2083]: https://sagebionetworks.jira.com/browse/AG-2083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ