### PR TITLE
docs(sage-monorepo): add code review norms, comments policy, and handoff skill (SMR-794)

### DIFF
--- a/.claude/rules/angular.md
+++ b/.claude/rules/angular.md
@@ -87,3 +87,23 @@ Use these links to look up Angular concepts and APIs:
 - [Style Guide](https://next.angular.dev/style-guide)
 - [API reference](https://angular.dev/api)
 - [Error encyclopedia](https://angular.dev/errors)
+
+## Code Review Norms
+
+Recurring expectations from this repo's PR review history. Following them up front avoids review churn.
+
+### Signals and inputs
+
+- Migrate component inputs from `@Input()` to the `input()` signal function for consistency
+- Use `effect()` for reactive side effects triggered by signal changes instead of calling imperative methods inside `@Input` setters
+
+### Templates
+
+- Omit explicit input bindings that repeat the component's declared default value
+- Track `@for` loops by a stable unique identifier field; use `$index` only when items have no reliable unique key (tracking by a non-unique field causes Angular to reuse wrong DOM nodes)
+
+### Styles
+
+- Replace inline hex color values with the matching `var(--color-*)` CSS custom property whenever one exists
+- Keep `:root { --color-* }` emission blocks in `_root.scss` only; `_variables.scss` must be pure Sass variable declarations with no CSS output (Sass `@use` re-emits any `:root {}` block into every lazy-loaded stylesheet, which can silently override global CSS custom-property values)
+- Place page-specific responsive overrides in the consuming component's stylesheet, not in the shared UI library component

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: handoff
+description: Compact the current conversation into a handoff document for another agent to pick up.
+argument-hint: 'What will the next session be used for?'
+disable-model-invocation: true
+---
+
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save to the temporary directory of the user's OS - not the current workspace.
+
+Include a "suggested skills" section in the document, which suggests skills that the agent should invoke.
+
+Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+
+Redact any sensitive information, such as API keys, passwords, or personally identifiable information.
+
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,4 +131,39 @@ Always refer to `package.json` for exact dependency versions when looking up API
 ## Code Quality
 
 - Write self-documenting code with meaningful names
-- Avoid unnecessary comments; use docstrings/Javadoc for public APIs only
+- Pull magic numbers, repeated strings, and limits into named constants; reference the same constant from both the implementation and its tests so they can't drift.
+- Hardcoding is acceptable when there's genuinely no variation yet -- don't over-parameterize prematurely. But hardcode deliberately: be wary of hardcoding data (counts, stats, page content) that a reader would expect to be query- or config-driven, and be ready to say where a value comes from.
+
+## Reuse over duplication
+
+- Before adding a helper, component, or service, check whether one already exists in the relevant scope libs (`libs/agora/`, `libs/explorers/`, `libs/shared/`, etc.) and reuse it.
+- If a new component would closely duplicate an existing one, extend the existing component to cover the missing case rather than forking a near-copy.
+- Extract repeated style declarations into a shared SCSS class instead of copy-pasting them across component stylesheets.
+
+## Comments
+
+- Default to no comment. Code should be self-explanatory through clear naming and structure; a comment is a last resort for genuinely non-obvious intent -- a subtle invariant, a workaround for external behavior, or a "why this and not the obvious thing" that the code can't express on its own. Never comment to restate what the code does.
+- Never write historical-context comments in a refactor -- e.g. `// previously this used X`, `// changed from the old approach`. Once a PR merges, the old behavior lives in git history. Comment what the code does now, not what it used to do.
+
+## Code Review Norms
+
+Recurring expectations from this repo's PR review history. Following them up front avoids review churn.
+
+### Color tokens
+
+Use CSS custom property tokens (e.g., `--color-action-primary`) instead of inline hex values or raw scale names for any color applied in stylesheets or templates.
+
+### New scope completeness
+
+When a new product scope (e.g., a new app) is introduced, update all supporting cross-repo config and documentation files in the same PR: CLAUDE.md scope table, mkdocs.yml nav, CODEOWNERS, release.yml tag patterns, and any relevant CI workflow matrices.
+
+### Verify impact before deleting shared dependencies
+
+Before removing a shared dependency, devcontainer port, or workspace package, confirm it is not consumed by any product or app that the PR author may not be directly familiar with.
+
+### PR hygiene
+
+- When a reviewer points out an issue, apply the fix consistently across every file the change touches -- not just the first instance flagged.
+- Don't leave `console.*`, commented-out code, or other dead code in the diff.
+- Keep list entries in config and workflow files sorted alphabetically when order is otherwise arbitrary.
+- Whenever code is left incomplete or contains a known placeholder, add a TODO comment with the Jira ticket ID tracking the follow-up work.

--- a/libs/explorers/CLAUDE.md
+++ b/libs/explorers/CLAUDE.md
@@ -66,6 +66,16 @@ comparison-tool / charts-angular / ui / util / shared   (feature/UI)
 
 All imports use `@sagebionetworks/explorers/<lib-name>` path aliases. Never use relative paths across library boundaries.
 
+## Backend and Database
+
+The explorers products use MongoDB locally but Amazon DocumentDB in the deployed stack. Any MongoDB query or aggregation change must be verified for DocumentDB compatibility -- not all MongoDB features are supported. To check the current DocumentDB engine version for a product, ask the user first -- they'll usually know. If not, consult the relevant infra repo:
+
+- agora: https://github.com/Sage-Bionetworks-IT/agora-infra-v3/
+- model-ad: https://github.com/Sage-Bionetworks-IT/modeladexplorer-infra
+- qtl: TBD (infra repo pending)
+
+No external products outside this repo depend on the explorers APIs, so breaking API changes are acceptable as long as all explorer products within this repo continue to work.
+
 ## Storybook
 
 For components that don't call our own backend APIs (third-party service calls like Synapse wiki fetches are fine): add a `.stories.ts` file for new components; for changes to existing components, adjust the existing story if the new behavior fits naturally, or add a new story variant for sufficiently distinct behavior. When it's unclear whether a new story is warranted, ask the user. See `libs/explorers/util/src/lib/tooltip-button/tooltip-button.component.stories.ts` for the canonical pattern.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "skills": {
+    "grill-me": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grill-me/SKILL.md",
+      "computedHash": "f321507f77702a54af1db66549ec1685fc625390d06c57d7949cdcda8eb1b5c7"
+    },
+    "grilling": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grilling/SKILL.md",
+      "computedHash": "ef685a6fa0bbe73b05bbd8dc1ec97258191587f07c6aa7dbc9006675ceb8f90f"
+    },
+    "handoff": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/handoff/SKILL.md",
+      "computedHash": "5d0f81e38abe6b984e1feaa731927de5291d040982106ac513cf54ec240e00ec"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Distills recurring reviewer feedback from the last 100 merged PRs into actionable norms in `CLAUDE.md` and `.claude/rules/angular.md`, so contributors and Claude follow established conventions without needing to rediscover them in review (inspired by [this PR](https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/2950)). Also adds a comments policy, reuse-over-duplication guideline, DocumentDB compatibility context for the explorers stack, and Matt Pocock's [handoff skill](https://github.com/mattpocock/skills#productivity) for compacting conversations between sessions.

## Related Issue

- [SMR-794](https://sagebionetworks.jira.com/browse/SMR-794)

## Changelog

- Add code review norms, comments policy, reuse guideline, and constants guideline to `CLAUDE.md`
- Add code review norms to `.claude/rules/angular.md`
- Add DocumentDB compatibility and API breaking change notes to `libs/explorers/CLAUDE.md`
- Add `handoff` skill and `skills-lock.json`

## Testing

- Review `CLAUDE.md` and confirm the new sections are present and well-formed
- Review `.claude/rules/angular.md` and confirm the `## Code Review Norms` section groups norms under Signals, Templates, and Styles
- Review `libs/explorers/CLAUDE.md` and confirm the `## Backend and Database` section references the correct infra repo URLs
- Run `/handoff` and confirm it produces a handoff document in the OS temp directory


[SMR-794]: https://sagebionetworks.jira.com/browse/SMR-794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ