### PR TITLE
feat(agora): add support for max clinical trial phase filter (AG-2156)

### DIFF
--- a/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/api/NominatedDrugApiDelegateImpl.java
+++ b/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/api/NominatedDrugApiDelegateImpl.java
@@ -27,6 +27,7 @@ public class NominatedDrugApiDelegateImpl implements NominatedDrugApiDelegate {
     "totalNominations",
     "initialNomination",
     "modality",
+    "maximumClinicalTrialPhase",
     "sortFields",
     "sortOrders"
   );

--- a/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/model/dto/NominatedDrugSearchQueryDto.java
+++ b/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/model/dto/NominatedDrugSearchQueryDto.java
@@ -56,6 +56,9 @@ public class NominatedDrugSearchQueryDto {
   private @Nullable List<String> modality;
 
   @Valid
+  private @Nullable List<String> maximumClinicalTrialPhase;
+
+  @Valid
   private List<String> sortFields = new ArrayList<>();
 
   /**
@@ -359,6 +362,34 @@ public class NominatedDrugSearchQueryDto {
     this.modality = modality;
   }
 
+  public NominatedDrugSearchQueryDto maximumClinicalTrialPhase(@Nullable List<String> maximumClinicalTrialPhase) {
+    this.maximumClinicalTrialPhase = maximumClinicalTrialPhase;
+    return this;
+  }
+
+  public NominatedDrugSearchQueryDto addMaximumClinicalTrialPhaseItem(String maximumClinicalTrialPhaseItem) {
+    if (this.maximumClinicalTrialPhase == null) {
+      this.maximumClinicalTrialPhase = new ArrayList<>();
+    }
+    this.maximumClinicalTrialPhase.add(maximumClinicalTrialPhaseItem);
+    return this;
+  }
+
+  /**
+   * Filter by maximum clinical trial phase.
+   * @return maximumClinicalTrialPhase
+   */
+  
+  @Schema(name = "maximumClinicalTrialPhase", example = "[\"Phase I\",\"Phase II\"]", description = "Filter by maximum clinical trial phase.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("maximumClinicalTrialPhase")
+  public @Nullable List<String> getMaximumClinicalTrialPhase() {
+    return maximumClinicalTrialPhase;
+  }
+
+  public void setMaximumClinicalTrialPhase(@Nullable List<String> maximumClinicalTrialPhase) {
+    this.maximumClinicalTrialPhase = maximumClinicalTrialPhase;
+  }
+
   public NominatedDrugSearchQueryDto sortFields(List<String> sortFields) {
     this.sortFields = sortFields;
     return this;
@@ -434,13 +465,14 @@ public class NominatedDrugSearchQueryDto {
         Objects.equals(this.totalNominations, nominatedDrugSearchQuery.totalNominations) &&
         Objects.equals(this.initialNomination, nominatedDrugSearchQuery.initialNomination) &&
         Objects.equals(this.modality, nominatedDrugSearchQuery.modality) &&
+        Objects.equals(this.maximumClinicalTrialPhase, nominatedDrugSearchQuery.maximumClinicalTrialPhase) &&
         Objects.equals(this.sortFields, nominatedDrugSearchQuery.sortFields) &&
         Objects.equals(this.sortOrders, nominatedDrugSearchQuery.sortOrders);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(pageNumber, pageSize, items, itemFilterType, search, principalInvestigators, programs, totalNominations, initialNomination, modality, sortFields, sortOrders);
+    return Objects.hash(pageNumber, pageSize, items, itemFilterType, search, principalInvestigators, programs, totalNominations, initialNomination, modality, maximumClinicalTrialPhase, sortFields, sortOrders);
   }
 
   @Override
@@ -457,6 +489,7 @@ public class NominatedDrugSearchQueryDto {
     sb.append("    totalNominations: ").append(toIndentedString(totalNominations)).append("\n");
     sb.append("    initialNomination: ").append(toIndentedString(initialNomination)).append("\n");
     sb.append("    modality: ").append(toIndentedString(modality)).append("\n");
+    sb.append("    maximumClinicalTrialPhase: ").append(toIndentedString(maximumClinicalTrialPhase)).append("\n");
     sb.append("    sortFields: ").append(toIndentedString(sortFields)).append("\n");
     sb.append("    sortOrders: ").append(toIndentedString(sortOrders)).append("\n");
     sb.append("}");
@@ -497,6 +530,7 @@ public class NominatedDrugSearchQueryDto {
       this.instance.setTotalNominations(value.totalNominations);
       this.instance.setInitialNomination(value.initialNomination);
       this.instance.setModality(value.modality);
+      this.instance.setMaximumClinicalTrialPhase(value.maximumClinicalTrialPhase);
       this.instance.setSortFields(value.sortFields);
       this.instance.setSortOrders(value.sortOrders);
       return this;
@@ -549,6 +583,11 @@ public class NominatedDrugSearchQueryDto {
     
     public NominatedDrugSearchQueryDto.Builder modality(List<String> modality) {
       this.instance.modality(modality);
+      return this;
+    }
+    
+    public NominatedDrugSearchQueryDto.Builder maximumClinicalTrialPhase(List<String> maximumClinicalTrialPhase) {
+      this.instance.maximumClinicalTrialPhase(maximumClinicalTrialPhase);
       return this;
     }
     

--- a/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/model/repository/CustomNominatedDrugRepositoryImpl.java
+++ b/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/model/repository/CustomNominatedDrugRepositoryImpl.java
@@ -69,6 +69,10 @@ public class CustomNominatedDrugRepositoryImpl
       .dataFilter("total_nominations", NominatedDrugSearchQueryDto::getTotalNominations)
       .dataFilter("initial_nomination", NominatedDrugSearchQueryDto::getInitialNomination)
       .dataFilter("modality", NominatedDrugSearchQueryDto::getModality)
+      .dataFilter(
+        "maximum_clinical_trial_phase",
+        NominatedDrugSearchQueryDto::getMaximumClinicalTrialPhase
+      )
       .compositeItemFilter(item -> NominatedDrugIdentifier.parse(item).toCriteria())
       .searchFilter(SEARCH_FIELD)
       .build();

--- a/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/service/NominatedDrugService.java
+++ b/apps/agora/api-next/src/main/java/org/sagebionetworks/agora/api/next/service/NominatedDrugService.java
@@ -36,6 +36,7 @@ public class NominatedDrugService {
     + ".buildCacheKey('nominatedDrug', #query.itemFilterType, "
     + "#query.items, #query.search, #query.principalInvestigators, #query.programs, "
     + "#query.totalNominations, #query.initialNomination, #query.modality, "
+    + "#query.maximumClinicalTrialPhase, "
     + "#query.pageNumber, #query.pageSize, #query.sortFields, #query.sortOrders)"
   )
   public NominatedDrugsPageDto loadNominatedDrugs(NominatedDrugSearchQueryDto query) {

--- a/apps/agora/api-next/src/main/resources/openapi.yaml
+++ b/apps/agora/api-next/src/main/resources/openapi.yaml
@@ -532,6 +532,15 @@ components:
             type: string
           nullable: true
           type: array
+        maximumClinicalTrialPhase:
+          description: Filter by maximum clinical trial phase.
+          example:
+            - Phase I
+            - Phase II
+          items:
+            type: string
+          nullable: true
+          type: array
         sortFields:
           description: |
             List of field names to sort by (e.g., ["total_nominations", "common_name"]).

--- a/apps/agora/api-next/src/test/java/org/sagebionetworks/agora/api/next/model/repository/CustomNominatedDrugRepositoryImplTest.java
+++ b/apps/agora/api-next/src/test/java/org/sagebionetworks/agora/api/next/model/repository/CustomNominatedDrugRepositoryImplTest.java
@@ -332,6 +332,7 @@ class CustomNominatedDrugRepositoryImplTest {
       .totalNominations(List.of(3))
       .initialNomination(List.of(2022))
       .modality(List.of("Small molecule"))
+      .maximumClinicalTrialPhase(List.of("Phase I"))
       .itemFilterType(ItemFilterTypeQueryDto.INCLUDE)
       .build();
 
@@ -353,5 +354,6 @@ class CustomNominatedDrugRepositoryImplTest {
     assertThat(pipelineString).contains("total_nominations");
     assertThat(pipelineString).contains("initial_nomination");
     assertThat(pipelineString).contains("modality");
+    assertThat(pipelineString).contains("maximum_clinical_trial_phase");
   }
 }

--- a/apps/agora/api-next/src/test/java/org/sagebionetworks/agora/api/next/service/NominatedDrugServiceTest.java
+++ b/apps/agora/api-next/src/test/java/org/sagebionetworks/agora/api/next/service/NominatedDrugServiceTest.java
@@ -335,6 +335,7 @@ class NominatedDrugServiceTest {
       .totalNominations(List.of(3))
       .initialNomination(List.of(2022))
       .modality(List.of("Small molecule"))
+      .maximumClinicalTrialPhase(List.of("Phase I"))
       .itemFilterType(ItemFilterTypeQueryDto.INCLUDE)
       .pageNumber(0)
       .pageSize(100)

--- a/apps/agora/app/e2e/helpers/comparison-tool.ts
+++ b/apps/agora/app/e2e/helpers/comparison-tool.ts
@@ -1,13 +1,20 @@
 import { Page, expect } from '@playwright/test';
-import { ComparisonToolConfig } from '@sagebionetworks/agora/api-client';
+import {
+  ComparisonToolConfig,
+  ComparisonToolConfigFilter,
+} from '@sagebionetworks/agora/api-client';
 import { expectComparisonToolTableLoaded } from '@sagebionetworks/explorers/testing/e2e';
 import { baseURL } from '../../playwright.config';
 import {
   COMPARISON_TOOL_API_PATHS,
   COMPARISON_TOOL_CONFIG_PATH,
+  COMPARISON_TOOL_DEFAULT_PAGE_SIZE,
   COMPARISON_TOOL_DEFAULT_SORTS,
   COMPARISON_TOOL_PATHS,
 } from './constants';
+
+const snakeToCamel = (value: string): string =>
+  value.replace(/_([a-z])/g, (_match, char: string) => char.toUpperCase());
 
 export const navigateToComparison = async (
   page: Page,
@@ -68,4 +75,53 @@ export const fetchComparisonToolConfig = async (
   expect(response.ok()).toBeTruthy();
   const data = (await response.json()) as ComparisonToolConfig[];
   return data;
+};
+
+const fetchFilteredPageCount = async (
+  page: Page,
+  name: string,
+  filter: ComparisonToolConfigFilter,
+  value: string,
+): Promise<number> => {
+  const params = new URLSearchParams();
+  params.append('itemFilterType', 'exclude');
+  params.append('pageSize', COMPARISON_TOOL_DEFAULT_PAGE_SIZE.toString());
+
+  // sortFields and sortOrders are required by the API
+  const defaultSort = COMPARISON_TOOL_DEFAULT_SORTS[name];
+  for (const sort of defaultSort) {
+    params.append('sortFields', sort.field);
+    params.append('sortOrders', sort.order.toString());
+  }
+
+  // The config's query_param_key targets the frontend route; the API filters on the
+  // camelCased data_key (e.g. maximum_clinical_trial_phase -> maximumClinicalTrialPhase).
+  params.append(snakeToCamel(filter.data_key), value);
+
+  const response = await page.request.get(`${baseURL}/api/v1/${COMPARISON_TOOL_API_PATHS[name]}`, {
+    params,
+  });
+  expect(response.ok()).toBeTruthy();
+  const data = (await response.json()) as { page: { totalPages: number } };
+  return data.page.totalPages;
+};
+
+/**
+ * Finds the first (filter, value) pair whose applied result still spans more than one
+ * page. Pagination-reset tests need such a pair; some filters (e.g. Max Clinical Trial
+ * Phase) have no single value large enough to paginate.
+ */
+export const findFilterValueSpanningMultiplePages = async (
+  page: Page,
+  name: string,
+  filters: ComparisonToolConfigFilter[],
+): Promise<{ name: string; value: string }> => {
+  for (const filter of filters) {
+    for (const value of filter.values) {
+      if ((await fetchFilteredPageCount(page, name, filter, value)) > 1) {
+        return { name: filter.name, value };
+      }
+    }
+  }
+  throw new Error(`No filter value spans multiple pages for "${name}"`);
 };

--- a/apps/agora/app/e2e/helpers/comparison-tool.ts
+++ b/apps/agora/app/e2e/helpers/comparison-tool.ts
@@ -3,18 +3,16 @@ import {
   ComparisonToolConfig,
   ComparisonToolConfigFilter,
 } from '@sagebionetworks/agora/api-client';
+import { DEFAULT_PAGE_SIZE } from '@sagebionetworks/explorers/constants';
 import { expectComparisonToolTableLoaded } from '@sagebionetworks/explorers/testing/e2e';
+import { camelCase } from 'lodash';
 import { baseURL } from '../../playwright.config';
 import {
   COMPARISON_TOOL_API_PATHS,
   COMPARISON_TOOL_CONFIG_PATH,
-  COMPARISON_TOOL_DEFAULT_PAGE_SIZE,
   COMPARISON_TOOL_DEFAULT_SORTS,
   COMPARISON_TOOL_PATHS,
 } from './constants';
-
-const snakeToCamel = (value: string): string =>
-  value.replace(/_([a-z])/g, (_match, char: string) => char.toUpperCase());
 
 export const navigateToComparison = async (
   page: Page,
@@ -43,6 +41,7 @@ export const fetchComparisonToolData = async <T>(
   page: Page,
   name: string,
   categories: string[] = [],
+  extraParams?: URLSearchParams,
 ): Promise<T> => {
   const params = new URLSearchParams();
   params.append('itemFilterType', 'exclude');
@@ -55,6 +54,12 @@ export const fetchComparisonToolData = async <T>(
   for (const sort of defaultSort) {
     params.append('sortFields', sort.field);
     params.append('sortOrders', sort.order.toString());
+  }
+
+  if (extraParams) {
+    for (const [key, value] of extraParams) {
+      params.append(key, value);
+    }
   }
 
   const response = await page.request.get(`${baseURL}/api/v1/${COMPARISON_TOOL_API_PATHS[name]}`, {
@@ -83,26 +88,19 @@ const fetchFilteredPageCount = async (
   filter: ComparisonToolConfigFilter,
   value: string,
 ): Promise<number> => {
-  const params = new URLSearchParams();
-  params.append('itemFilterType', 'exclude');
-  params.append('pageSize', COMPARISON_TOOL_DEFAULT_PAGE_SIZE.toString());
-
-  // sortFields and sortOrders are required by the API
-  const defaultSort = COMPARISON_TOOL_DEFAULT_SORTS[name];
-  for (const sort of defaultSort) {
-    params.append('sortFields', sort.field);
-    params.append('sortOrders', sort.order.toString());
-  }
+  const extraParams = new URLSearchParams();
+  extraParams.append('pageSize', DEFAULT_PAGE_SIZE.toString());
 
   // The config's query_param_key targets the frontend route; the API filters on the
   // camelCased data_key (e.g. maximum_clinical_trial_phase -> maximumClinicalTrialPhase).
-  params.append(snakeToCamel(filter.data_key), value);
+  extraParams.append(camelCase(filter.data_key), value);
 
-  const response = await page.request.get(`${baseURL}/api/v1/${COMPARISON_TOOL_API_PATHS[name]}`, {
-    params,
-  });
-  expect(response.ok()).toBeTruthy();
-  const data = (await response.json()) as { page: { totalPages: number } };
+  const data = await fetchComparisonToolData<{ page: { totalPages: number } }>(
+    page,
+    name,
+    [],
+    extraParams,
+  );
   return data.page.totalPages;
 };
 

--- a/apps/agora/app/e2e/helpers/constants.ts
+++ b/apps/agora/app/e2e/helpers/constants.ts
@@ -34,6 +34,8 @@ export const COMPARISON_TOOL_API_PATHS: Record<string, string> = {
 
 export const COMPARISON_TOOL_CONFIG_PATH = 'comparison-tools/config';
 
+export const COMPARISON_TOOL_DEFAULT_PAGE_SIZE = 10;
+
 // Default sort configurations for each comparison tool (required by API)
 export const COMPARISON_TOOL_DEFAULT_SORTS: Record<string, { field: string; order: 1 | -1 }[]> = {
   'Nominated Targets': [

--- a/apps/agora/app/e2e/helpers/constants.ts
+++ b/apps/agora/app/e2e/helpers/constants.ts
@@ -34,8 +34,6 @@ export const COMPARISON_TOOL_API_PATHS: Record<string, string> = {
 
 export const COMPARISON_TOOL_CONFIG_PATH = 'comparison-tools/config';
 
-export const COMPARISON_TOOL_DEFAULT_PAGE_SIZE = 10;
-
 // Default sort configurations for each comparison tool (required by API)
 export const COMPARISON_TOOL_DEFAULT_SORTS: Record<string, { field: string; order: 1 | -1 }[]> = {
   'Nominated Targets': [

--- a/apps/agora/app/e2e/nominated-drugs.spec.ts
+++ b/apps/agora/app/e2e/nominated-drugs.spec.ts
@@ -22,7 +22,11 @@ import {
   testTableReturnsToFirstPageWhenSearchTermEnteredAndCleared,
   testTableReturnsToFirstPageWhenSortChanged,
 } from '@sagebionetworks/explorers/testing/e2e';
-import { fetchComparisonToolConfig, navigateToComparison } from './helpers/comparison-tool';
+import {
+  fetchComparisonToolConfig,
+  findFilterValueSpanningMultiplePages,
+  navigateToComparison,
+} from './helpers/comparison-tool';
 
 test.describe('specific viewport block', () => {
   test.use({ viewport: { width: 1600, height: 1200 } });
@@ -92,16 +96,16 @@ test.describe('nominated drugs - comparison tool', () => {
 
     test('table returns to first page when filter selected and removed', async ({ page }) => {
       const configs = await fetchComparisonToolConfig(page, CT_PAGE);
-      const config = configs[0];
-      const filters = config.filters;
+      const filters = configs[0].filters;
       expect(filters.length).toBeGreaterThan(1);
-      const filter = filters[0];
+
+      const selected = await findFilterValueSpanningMultiplePages(page, CT_PAGE, filters);
 
       await navigateToComparison(page, CT_PAGE, true, 'url');
       await testTableReturnsToFirstPageWhenFilterSelectedAndRemoved(
         page,
-        filter.name,
-        filter.values[0],
+        selected.name,
+        selected.value,
       );
     });
 

--- a/libs/agora/api-client-angular/src/lib/model/nominated-drug-search-query.ts
+++ b/libs/agora/api-client-angular/src/lib/model/nominated-drug-search-query.ts
@@ -51,6 +51,10 @@ export interface NominatedDrugSearchQuery {
    */
   modality?: Array<string> | null;
   /**
+   * Filter by maximum clinical trial phase.
+   */
+  maximumClinicalTrialPhase?: Array<string> | null;
+  /**
    * List of field names to sort by (e.g., [\"total_nominations\", \"common_name\"]). Each field in sortFields must have a corresponding order in sortOrders.
    */
   sortFields: Array<string>;

--- a/libs/agora/api-description/openapi/api-next-public.openapi.yaml
+++ b/libs/agora/api-description/openapi/api-next-public.openapi.yaml
@@ -379,6 +379,15 @@ components:
           example:
             - Small molecule
             - Protein
+        maximumClinicalTrialPhase:
+          description: Filter by maximum clinical trial phase.
+          type: array
+          items:
+            type: string
+          nullable: true
+          example:
+            - Phase I
+            - Phase II
         sortFields:
           description: |
             List of field names to sort by (e.g., ["total_nominations", "common_name"]).

--- a/libs/agora/api-description/openapi/api-next-service.openapi.yaml
+++ b/libs/agora/api-description/openapi/api-next-service.openapi.yaml
@@ -379,6 +379,15 @@ components:
           example:
             - Small molecule
             - Protein
+        maximumClinicalTrialPhase:
+          description: Filter by maximum clinical trial phase.
+          type: array
+          items:
+            type: string
+          nullable: true
+          example:
+            - Phase I
+            - Phase II
         sortFields:
           description: |
             List of field names to sort by (e.g., ["total_nominations", "common_name"]).

--- a/libs/agora/api-description/openapi/openapi.yaml
+++ b/libs/agora/api-description/openapi/openapi.yaml
@@ -643,6 +643,15 @@ components:
           example:
             - Small molecule
             - Protein
+        maximumClinicalTrialPhase:
+          description: Filter by maximum clinical trial phase.
+          type: array
+          items:
+            type: string
+          nullable: true
+          example:
+            - Phase I
+            - Phase II
         sortFields:
           description: |
             List of field names to sort by (e.g., ["total_nominations", "common_name"]).

--- a/libs/agora/api-description/src/components/schemas/NominatedDrugSearchQuery.yaml
+++ b/libs/agora/api-description/src/components/schemas/NominatedDrugSearchQuery.yaml
@@ -72,6 +72,13 @@ properties:
       type: string
     nullable: true
     example: ['Small molecule', 'Protein']
+  maximumClinicalTrialPhase:
+    description: Filter by maximum clinical trial phase.
+    type: array
+    items:
+      type: string
+    nullable: true
+    example: ['Phase I', 'Phase II']
   sortFields:
     description: |
       List of field names to sort by (e.g., ["total_nominations", "common_name"]).

--- a/libs/agora/nominated-drugs-comparison-tool/src/lib/nominated-drugs-comparison-tool.component.spec.ts
+++ b/libs/agora/nominated-drugs-comparison-tool/src/lib/nominated-drugs-comparison-tool.component.spec.ts
@@ -1,12 +1,16 @@
 import { provideHttpClient } from '@angular/common/http';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
-import { ComparisonToolConfigService } from '@sagebionetworks/agora/api-client';
+import {
+  ComparisonToolConfigService,
+  NominatedDrugService,
+} from '@sagebionetworks/agora/api-client';
 import {
   AGORA_LOADING_ICON_COLORS,
   NOMINATED_CTS_VISUALIZATION_OVERVIEW_PANES,
 } from '@sagebionetworks/agora/config';
 import { ComparisonToolComponent } from '@sagebionetworks/explorers/comparison-tool';
+import { ComparisonToolQuery } from '@sagebionetworks/explorers/models';
 import {
   PlatformService,
   provideComparisonToolFilterService,
@@ -50,8 +54,19 @@ async function setup() {
   const comparisonToolService = fixture.debugElement.injector.get(
     NominatedDrugsComparisonToolService,
   );
-  return { component, comparisonToolService };
+  const nominatedDrugService = fixture.debugElement.injector.get(NominatedDrugService);
+  return { component, comparisonToolService, nominatedDrugService };
 }
+
+const emptyQuery: ComparisonToolQuery = {
+  categories: [],
+  pinnedItems: [],
+  pageNumber: 0,
+  pageSize: 100,
+  multiSortMeta: [],
+  searchTerm: null,
+  filters: [],
+};
 
 describe('NominatedDrugsComparisonToolComponent', () => {
   it('should create', async () => {
@@ -63,6 +78,21 @@ describe('NominatedDrugsComparisonToolComponent', () => {
     const { comparisonToolService } = await setup();
     expect(comparisonToolService.viewConfig().visualizationOverviewPanes).toBe(
       NOMINATED_CTS_VISUALIZATION_OVERVIEW_PANES,
+    );
+  });
+
+  it('should send the selected clinical trial phase filter in the unpinned query', async () => {
+    const { component, comparisonToolService, nominatedDrugService } = await setup();
+    const selectedPhases = ['Phase I', 'Phase II'];
+    jest.spyOn(comparisonToolService, 'selectedFilters').mockReturnValue({ phase: selectedPhases });
+    const getNominatedDrugsSpy = jest
+      .spyOn(nominatedDrugService, 'getNominatedDrugs')
+      .mockReturnValue(of({ nominatedDrugs: [], page: { totalElements: 0 } }) as never);
+
+    component.getUnpinnedData(emptyQuery);
+
+    expect(getNominatedDrugsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ maximumClinicalTrialPhase: selectedPhases }),
     );
   });
 });

--- a/libs/agora/nominated-drugs-comparison-tool/src/lib/nominated-drugs-comparison-tool.component.spec.ts
+++ b/libs/agora/nominated-drugs-comparison-tool/src/lib/nominated-drugs-comparison-tool.component.spec.ts
@@ -10,14 +10,16 @@ import {
   NOMINATED_CTS_VISUALIZATION_OVERVIEW_PANES,
 } from '@sagebionetworks/agora/config';
 import { ComparisonToolComponent } from '@sagebionetworks/explorers/comparison-tool';
-import { ComparisonToolQuery } from '@sagebionetworks/explorers/models';
 import {
   PlatformService,
   provideComparisonToolFilterService,
   provideComparisonToolService,
   provideExplorersConfig,
 } from '@sagebionetworks/explorers/services';
-import { provideLoadingIconColors } from '@sagebionetworks/explorers/testing';
+import {
+  mockEmptyComparisonToolQuery,
+  provideLoadingIconColors,
+} from '@sagebionetworks/explorers/testing';
 import { render } from '@testing-library/angular';
 import { MessageService } from 'primeng/api';
 import { of } from 'rxjs';
@@ -58,16 +60,6 @@ async function setup() {
   return { component, comparisonToolService, nominatedDrugService };
 }
 
-const emptyQuery: ComparisonToolQuery = {
-  categories: [],
-  pinnedItems: [],
-  pageNumber: 0,
-  pageSize: 100,
-  multiSortMeta: [],
-  searchTerm: null,
-  filters: [],
-};
-
 describe('NominatedDrugsComparisonToolComponent', () => {
   it('should create', async () => {
     const { component } = await setup();
@@ -89,7 +81,7 @@ describe('NominatedDrugsComparisonToolComponent', () => {
       .spyOn(nominatedDrugService, 'getNominatedDrugs')
       .mockReturnValue(of({ nominatedDrugs: [], page: { totalElements: 0 } }) as never);
 
-    component.getUnpinnedData(emptyQuery);
+    component.getUnpinnedData(mockEmptyComparisonToolQuery);
 
     expect(getNominatedDrugsSpy).toHaveBeenCalledWith(
       expect.objectContaining({ maximumClinicalTrialPhase: selectedPhases }),

--- a/libs/agora/nominated-drugs-comparison-tool/src/lib/nominated-drugs-comparison-tool.component.ts
+++ b/libs/agora/nominated-drugs-comparison-tool/src/lib/nominated-drugs-comparison-tool.component.ts
@@ -128,6 +128,7 @@ export class NominatedDrugsComparisonToolComponent implements OnInit, OnDestroy 
       principalInvestigators: selectedFilters['nominatingPis'],
       totalNominations: selectedFilters['nominations']?.map(Number) ?? [],
       modality: selectedFilters['modalities'],
+      maximumClinicalTrialPhase: selectedFilters['phase'],
       sortFields,
       sortOrders,
     };

--- a/libs/explorers/constants/src/lib/comparison-tool.ts
+++ b/libs/explorers/constants/src/lib/comparison-tool.ts
@@ -4,3 +4,6 @@ export const RESERVED_COMPARISON_TOOL_QUERY_PARAM_KEYS = new Set([
   'sortFields',
   'sortOrders',
 ]);
+
+export const VALID_PAGE_SIZES: readonly number[] = [10, 25, 50];
+export const DEFAULT_PAGE_SIZE = VALID_PAGE_SIZES[0];

--- a/libs/explorers/services/src/lib/app-storage.constants.ts
+++ b/libs/explorers/services/src/lib/app-storage.constants.ts
@@ -1,4 +1,4 @@
+export { DEFAULT_PAGE_SIZE, VALID_PAGE_SIZES } from '@sagebionetworks/explorers/constants';
+
 export const HIDE_VISUALIZATION_OVERVIEW_KEY = 'hide_visualization_overview';
 export const PAGE_SIZE_KEY = 'comparison_tool_page_size';
-export const VALID_PAGE_SIZES: readonly number[] = [10, 25, 50];
-export const DEFAULT_PAGE_SIZE = VALID_PAGE_SIZES[0];

--- a/libs/explorers/testing/src/lib/mocks/comparison-tool-mocks.ts
+++ b/libs/explorers/testing/src/lib/mocks/comparison-tool-mocks.ts
@@ -1,8 +1,19 @@
 import {
   ComparisonToolConfig,
+  ComparisonToolQuery,
   HeatmapDetailsPanelData,
   SynapseWikiParams,
 } from '@sagebionetworks/explorers/models';
+
+export const mockEmptyComparisonToolQuery: ComparisonToolQuery = {
+  categories: [],
+  pinnedItems: [],
+  pageNumber: 0,
+  pageSize: 100,
+  multiSortMeta: [],
+  searchTerm: null,
+  filters: [],
+};
 
 export const mockComparisonToolSelectorsWikiParams: { [key: string]: SynapseWikiParams } = {
   Red: {


### PR DESCRIPTION
## Description

The Agora mv117 data release adds a **Max Clinical Trial Phase** filterset to the Nominated Drugs Comparison Tool.  This PR wires the filter through end to end so users can narrow nominated drugs by clinical trial phase.

## Related Issue

- [AG-2156](https://sagebionetworks.jira.com/browse/AG-2156) — Add `maximum_clinical_trial_phase` filter to backend and wire up in frontend
  - Related: [AG-2109](https://sagebionetworks.jira.com/browse/AG-2109) — ui_config: add clinical phase filterset (deployed the filterset definition to Synapse)
  - Parent context: [AG-2076](https://sagebionetworks.jira.com/browse/AG-2076) — Update Agora to support changes in mv117

## Changelog

- Add `maximumClinicalTrialPhase` query parameter to the Nominated Drug search OpenAPI schema and regenerate the Java DTO and Angular client
- Include `maximumClinicalTrialPhase` in the `NominatedDrugService` `@Cacheable` key so results are not served from a cache entry that ignores the phase selection
- Map the `phase` filterset selection to the `maximumClinicalTrialPhase` query field in the Nominated Drugs CT component
- Extend backend repository/service tests and add a frontend test covering the new filter

## Testing

- Open the Nominated Drugs Comparison Tool and confirm the **Max Clinical Trial Phase** filter (short name "Phase") appears in the filter panel with options Preclinical, Phase I–IV, and Unknown.
- Select a single phase (e.g. Preclinical) and confirm the result set narrows to only drugs with that phase and the URL gains `?phase=Preclinical`.
- Select multiple phases and confirm results include drugs matching any selected phase.
- Switch between different phase selections in succession and confirm results update each time (guards against the cache-key regression where a stale cached page was returned for every phase).
- Call `GET /v1/comparison-tools/drugs?maximumClinicalTrialPhase=Preclinical&sortFields=total_nominations&sortOrders=-1` and confirm `page.totalElements` and the returned rows reflect only Preclinical drugs; an unknown value returns zero rows.

### Preview

Screenshot showing new filter enabled and correct filter being applied.
<img width="1804" height="769" alt="image" src="https://github.com/user-attachments/assets/d491f446-71a5-481d-a0ad-f0a79199b8bf" />

[AG-2156]: https://sagebionetworks.jira.com/browse/AG-2156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-2109]: https://sagebionetworks.jira.com/browse/AG-2109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-2076]: https://sagebionetworks.jira.com/browse/AG-2076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ