### PR TITLE
fix(explorers): preserve horizontal scroll position when sorting comparison tool (AG-2160)

### DIFF
--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-table.component.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-table.component.ts
@@ -95,7 +95,17 @@ export class ComparisonToolTableComponent implements AfterViewInit {
       // so wait for fonts to be ready before calculating column widths
       // to prevent incorrect measurements
       document.fonts.ready.then(() => {
+        // Measurement briefly pulls cells out of flow, collapsing the table so the
+        // browser clamps the scroll container's scrollLeft. Save and restore it so
+        // sorting/data changes don't reset the user's horizontal scroll position.
+        const scrollContainer = this.tableElement()?.nativeElement.closest(
+          '.comparison-tool-body',
+        ) as HTMLElement | null;
+        const savedScrollLeft = scrollContainer?.scrollLeft ?? 0;
         this.columnWidths.set(this.calculateNonPrimaryColumnWidths());
+        if (scrollContainer) {
+          scrollContainer.scrollLeft = savedScrollLeft;
+        }
       });
     }
   }

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-table.component.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-table.component.ts
@@ -20,6 +20,7 @@ import { SvgIconComponent } from '@sagebionetworks/explorers/util';
 import { TooltipModule } from 'primeng/tooltip';
 import { BaseTableComponent } from './base-table/base-table.component';
 import { ComparisonToolColumnsComponent } from './comparison-tool-columns/comparison-tool-columns.component';
+import { COMPARISON_TOOL_BODY_CLASS } from './comparison-tool-table.constants';
 import {
   clampAndFormatWidths,
   getCellsByColumn,
@@ -99,7 +100,7 @@ export class ComparisonToolTableComponent implements AfterViewInit {
         // browser clamps the scroll container's scrollLeft. Save and restore it so
         // sorting/data changes don't reset the user's horizontal scroll position.
         const scrollContainer = this.tableElement()?.nativeElement.closest(
-          '.comparison-tool-body',
+          `.${COMPARISON_TOOL_BODY_CLASS}`,
         ) as HTMLElement | null;
         const savedScrollLeft = scrollContainer?.scrollLeft ?? 0;
         this.columnWidths.set(this.calculateNonPrimaryColumnWidths());

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-table.constants.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/comparison-tool-table.constants.ts
@@ -13,6 +13,9 @@ export const MAX_COLUMN_WIDTH_PX = 300;
 export const COLUMN_HEADER_CLASS = 'column-header';
 export const COLUMN_HEADER_TEXT_CLASS = 'column-header-text';
 
+// CSS class(es) — bound in comparison-tool.component.html
+export const COMPARISON_TOOL_BODY_CLASS = 'comparison-tool-body';
+
 // Keep in sync with the corresponding $comparison-tool-* variables in
 // libs/explorers/styles/src/lib/_variables.scss.
 export const COLUMN_HEADER_MARGIN_LEFT_PX = 10;


### PR DESCRIPTION
## Description

In the comparison tool (Nominated Targets, Nominated Drugs, and the Model-AD tables), scrolling the table horizontally and then clicking a column sort button snapped the table back to the far left, forcing users to re-scroll after every sort. Sorting triggers a column-width remeasurement that briefly pulls cells out of flow, collapsing the table so the browser clamps the scroll container's `scrollLeft` to zero. This change captures and restores the horizontal scroll position around that remeasurement so the user's view stays put when they interact with the table.

## Related Issue

- [AG-2160](https://sagebionetworks.jira.com/browse/AG-2160)

## Changelog

- Preserve the comparison tool's horizontal scroll position across the column-width recalculation that runs on sort and data changes

## Testing

- Open the Nominated Targets comparison tool in Agora and scroll the table fully to the right
- Click a sort button on a right-side column and confirm the horizontal scroll position is preserved (no jump to the left) and the sort applies correctly
- Repeat with pinned rows present and with an active search/filter to confirm both the pinned and unpinned tables behave
- Verify the same behavior on a Model-AD comparison tool table to confirm the shared fix works cross-product
- Resize the browser window while scrolled horizontally and confirm the scroll position is not disrupted

### Preview

Before

https://github.com/user-attachments/assets/7d028737-cd27-47fb-80ed-0aa6538d58a2 

After

https://github.com/user-attachments/assets/83bfa72a-e35c-4776-b140-5015f078ec77



[AG-2160]: https://sagebionetworks.jira.com/browse/AG-2160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ