### PR TITLE
fix(agora): adjust drug tile copy (AG-2163)

### DIFF
--- a/libs/agora/home/src/lib/home.component.html
+++ b/libs/agora/home/src/lib/home.component.html
@@ -71,7 +71,7 @@
         <explorers-home-card
           [title]="'Nominated Drugs'"
           [description]="
-            'Explore over 65 agents that research teams have nominated as potential therapies for AD treatment or prevention.'
+            'Explore over 65 repurposable or repositionable candidate drugs that research teams have nominated as potential therapies for AD treatment or prevention.'
           "
           [routerLink]="`/${ROUTE_PATHS.NOMINATED_DRUGS}`"
           [imagePath]="'agora-assets/images/nominated-drugs-icon.svg'"


### PR DESCRIPTION
## Description

Fix Agora home page drug tile copy. 

## Related Issue

[AG-2163](https://sagebionetworks.jira.com/browse/AG-2163)

## Changelog

- Update copy in Agora home page drug tile

## Testing

- Check that drug tile on Agora home page matches copy in ticket

## Preview

dev | this PR
:---: | :---: 
<img width="692" height="324" alt="image" src="https://github.com/user-attachments/assets/1ac75330-27da-43af-92df-bf9213e88968" /> | <img width="685" height="325" alt="image" src="https://github.com/user-attachments/assets/496c3cb1-f119-4d46-a139-7017cd6f2e48" />


[AG-2163]: https://sagebionetworks.jira.com/browse/AG-2163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ