### PR TITLE
fix(bixarena): add PATCH to gateway CORS allowed methods

### DIFF
--- a/apps/bixarena/api-gateway/src/main/resources/application.yml
+++ b/apps/bixarena/api-gateway/src/main/resources/application.yml
@@ -60,6 +60,7 @@ spring:
                 allowedmethods:
                   - GET
                   - POST
+                  - PATCH
                   - DELETE
                   - PUT
                 allowedheaders: '*'

--- a/apps/bixarena/app/server.ts
+++ b/apps/bixarena/app/server.ts
@@ -12,7 +12,7 @@ export function app(): express.Express {
   const indexHtml = join(serverDistFolder, 'index.server.html');
 
   const commonEngine = new CommonEngine({
-    allowedHosts: ['localhost', '*.bioarena.io', 'bioarena.io', '*.elb.amazonaws.com'],
+    allowedHosts: ['localhost', '127.0.0.1', '*.bioarena.io', 'bioarena.io', '*.elb.amazonaws.com'],
   });
 
   server.set('view engine', 'html');

--- a/apps/bixarena/auth-service/src/main/resources/application-prod.yml
+++ b/apps/bixarena/auth-service/src/main/resources/application-prod.yml
@@ -15,6 +15,6 @@ logging:
     org.springframework.security: INFO
 # Production: session cookie uses secure defaults from application.yml
 # - domain: null (host-only)
-# - same-site: Strict
+# - same-site: Lax
 # - secure: true
 # - http-only: true

--- a/apps/bixarena/auth-service/src/main/resources/application-stage.yml
+++ b/apps/bixarena/auth-service/src/main/resources/application-stage.yml
@@ -13,6 +13,6 @@ logging:
     org.sagebionetworks.bixarena: INFO
 # Staging: session cookie uses secure defaults from application.yml
 # - domain: null (host-only)
-# - same-site: Strict
+# - same-site: Lax
 # - secure: true
 # - http-only: true

--- a/apps/bixarena/auth-service/src/main/resources/application.yml
+++ b/apps/bixarena/auth-service/src/main/resources/application.yml
@@ -90,7 +90,7 @@ app:
     name: JSESSIONID
     path: /
     domain: null # Host-only cookie by default (secure for production)
-    same-site: Strict # Strictest setting by default
+    same-site: Lax
     secure: true # Require HTTPS by default
     http-only: true # Prevent JavaScript access
   auth:


### PR DESCRIPTION
## Description

Fixes a bug where browser-initiated PATCH requests to the API gateway were rejected with 403, causing battles to never have `endedAt` set after voting. Also changes the session cookie `SameSite` attribute from `Strict` to `Lax` (industry standard, matching Synapse's own configuration). No behavioral change for same-origin API calls; improves UX for users arriving via external links.

## Related Issue

N/A

## Changelog

- Add `PATCH` to the API gateway's global CORS `allowedmethods` configuration
- Change session cookie `SameSite` from `Strict` to `Lax` in auth-service
- Add `127.0.0.1` to Angular SSR `allowedHosts` for local Docker development

## Testing

- Start a battle on stage, vote, confirm no 403 in browser console on stage
- Confirm login flow still works on stage after deployment

[SMR-713]: https://sagebionetworks.jira.com/browse/SMR-713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ