### PR TITLE
feat(model-ad): enhance TOC with sticky positioning and collapsible UI (MG-971, MG-972)

### DIFF
--- a/apps/model-ad/app/e2e/helpers/model-details.ts
+++ b/apps/model-ad/app/e2e/helpers/model-details.ts
@@ -1,0 +1,21 @@
+import { Page } from '@playwright/test';
+
+export function getTocContainer(page: Page) {
+  return page.locator('.table-of-contents-container');
+}
+
+export function getTocExpandButton(page: Page) {
+  return getTocContainer(page).getByRole('button', { name: 'Expand' });
+}
+
+export function getTocCollapseButton(page: Page) {
+  return getTocContainer(page).getByRole('button', { name: 'Collapse' });
+}
+
+export function getTocList(page: Page) {
+  return page.locator('#toc-list');
+}
+
+export function getTocLinks(page: Page) {
+  return getTocContainer(page).getByTestId('toc-item-link');
+}

--- a/apps/model-ad/app/e2e/model-details.spec.ts
+++ b/apps/model-ad/app/e2e/model-details.spec.ts
@@ -1,24 +1,20 @@
-import { expect, Page, test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import {
   expectComparisonToolTableLoaded,
   expectFilters,
   expectFiltersParams,
+  expectPageAtTop,
+  expectPageNotAtTop,
   waitForScrollToStop,
 } from '@sagebionetworks/explorers/testing/e2e';
 import { baseURL } from '../playwright.config';
+import {
+  getTocCollapseButton,
+  getTocExpandButton,
+  getTocLinks,
+  getTocList,
+} from './helpers/model-details';
 import { searchAndGetSearchListItems } from './helpers/search';
-
-async function isPageAtTop(page: Page) {
-  return await page.evaluate(() => window.pageYOffset === 0);
-}
-
-async function expectPageAtTop(page: Page) {
-  expect(await isPageAtTop(page)).toBe(true);
-}
-
-async function expectPageNotAtTop(page: Page) {
-  expect(await isPageAtTop(page)).toBe(false);
-}
 
 test.describe('model details', () => {
   test('invalid model results in a 404 redirect', async ({ page }) => {
@@ -290,14 +286,17 @@ test.describe('model details - model with special characters', () => {
 });
 
 test.describe('model details - boxplots selector - table of contents', () => {
+  const testModel = 'Abca7*V1599M';
+  const biomarkersPath = `/models/${testModel}/biomarkers`;
+
   test('clicking on table of contents link scrolls to appropriate section', async ({ page }) => {
     const model = '3xTg-AD';
     await page.goto(`/models/${model}/biomarkers`);
     await expect(page.getByRole('heading', { level: 1, name: model })).toBeVisible();
     await expect(page.getByRole('heading', { level: 2, name: 'Table of Contents' })).toBeVisible();
 
-    const toc = page.locator('.table-of-contents-container');
-    const tocLinks = toc.getByRole('button').filter({ hasNotText: /download all/i });
+    await getTocExpandButton(page).click();
+    const tocLinks = getTocLinks(page);
     const tocLinksCount = await tocLinks.count();
 
     for (let i = 0; i < tocLinksCount; i++) {
@@ -315,46 +314,106 @@ test.describe('model details - boxplots selector - table of contents', () => {
   test('appropriate section is shown when url includes an evidence type fragment', async ({
     page,
   }) => {
-    const model = 'Abca7*V1599M';
     const fragment = 'soluble-abeta40';
     const section = 'Soluble Aβ40';
-    await page.goto(`/models/${model}/biomarkers#${fragment}`);
-    await expect(page.getByRole('heading', { level: 1, name: model })).toBeVisible();
+    await page.goto(`${biomarkersPath}#${fragment}`);
+    await expect(page.getByRole('heading', { level: 1, name: testModel })).toBeVisible();
     await expect(
       page.getByRole('heading', { level: 2, name: section, exact: true }),
     ).toBeInViewport();
   });
 
   test('clicking on a section adds fragment to url', async ({ page }) => {
-    const model = 'Abca7*V1599M';
-    const basePath = `/models/${model}/biomarkers`;
     const section = 'NfL';
     const fragment = 'nfl';
 
-    await page.goto(basePath);
-    await expect(page.getByRole('heading', { level: 1, name: model })).toBeVisible();
+    await page.goto(biomarkersPath);
+    await expect(page.getByRole('heading', { level: 1, name: testModel })).toBeVisible();
 
-    const nflButton = page.getByRole('button', { name: section, exact: true });
+    await getTocExpandButton(page).click();
+    const nflButton = getTocLinks(page).filter({ hasText: section });
     await nflButton.click();
 
     await expect(page.getByRole('heading', { level: 2, name: section })).toBeInViewport();
-    await page.waitForURL(`${basePath}#${fragment}`);
+    await page.waitForURL(`${biomarkersPath}#${fragment}`);
   });
 
   test('clicking on a section updates fragment in url', async ({ page }) => {
-    const model = 'Abca7*V1599M';
-    const basePath = `/models/${model}/biomarkers`;
     const section = 'NfL';
     const fragment = 'nfl';
 
-    await page.goto(`${basePath}#soluble-abeta40`);
-    await expect(page.getByRole('heading', { level: 1, name: model })).toBeVisible();
+    await page.goto(`${biomarkersPath}#soluble-abeta40`);
+    await expect(page.getByRole('heading', { level: 1, name: testModel })).toBeVisible();
 
-    const nflButton = page.getByRole('button', { name: section, exact: true });
+    await getTocExpandButton(page).click();
+    const nflButton = getTocLinks(page).filter({ hasText: section });
     await nflButton.click();
 
     await expect(page.getByRole('heading', { level: 2, name: section })).toBeInViewport();
-    await page.waitForURL(`${basePath}#${fragment}`);
+    await page.waitForURL(`${biomarkersPath}#${fragment}`);
+  });
+
+  test('TOC starts collapsed on initial load', async ({ page }) => {
+    await page.goto(biomarkersPath);
+    await expect(page.getByRole('heading', { level: 1, name: testModel })).toBeVisible();
+
+    await expect(getTocExpandButton(page)).toBeVisible();
+    await expect(getTocList(page)).toBeHidden();
+  });
+
+  test('expanding TOC shows items', async ({ page }) => {
+    await page.goto(biomarkersPath);
+
+    await getTocExpandButton(page).click();
+
+    await expect(getTocCollapseButton(page)).toBeVisible();
+    await expect(getTocList(page)).toBeVisible();
+    await expect(getTocLinks(page).first()).toBeVisible();
+  });
+
+  test('collapsing TOC hides items', async ({ page }) => {
+    await page.goto(biomarkersPath);
+
+    await getTocExpandButton(page).click();
+    await expect(getTocList(page)).toBeVisible();
+
+    await getTocCollapseButton(page).click();
+
+    await expect(getTocExpandButton(page)).toBeVisible();
+    await expect(getTocList(page)).toBeHidden();
+  });
+
+  test('TOC remains collapsed when loading page with anchor fragment', async ({ page }) => {
+    const fragment = 'soluble-abeta40';
+    const section = 'Soluble Aβ40';
+    await page.goto(`${biomarkersPath}#${fragment}`);
+
+    await expect(page.getByRole('heading', { level: 1, name: testModel })).toBeVisible();
+
+    await expect(getTocExpandButton(page)).toBeVisible();
+    await expect(getTocList(page)).toBeHidden();
+
+    await expect(
+      page.getByRole('heading', { level: 2, name: section, exact: true }),
+    ).toBeInViewport();
+    await expect(page).toHaveURL(`${biomarkersPath}#${fragment}`);
+  });
+
+  test('TOC stays expanded after clicking a link', async ({ page }) => {
+    await page.goto(biomarkersPath);
+
+    await getTocExpandButton(page).click();
+
+    const firstLink = getTocLinks(page).first();
+    const linkText = (await firstLink.textContent()) ?? '';
+    await firstLink.click();
+
+    await expect(getTocCollapseButton(page)).toBeVisible();
+    await expect(getTocList(page)).toBeVisible();
+
+    await expect(
+      page.getByRole('heading', { level: 2, name: linkText, exact: true }),
+    ).toBeInViewport();
   });
 });
 
@@ -502,6 +561,9 @@ test.describe('model details - boxplots selector - share links - updates', () =>
   test('query parameters are maintained when fragment is updated', async ({ page }) => {
     const pathWithParams = `${basePath}?tissue=Hippocampus&sex=Male`;
     await page.goto(pathWithParams);
+
+    await getTocExpandButton(page).click();
+
     await page.getByRole('button', { name: 'Soluble Aβ42', exact: true }).click();
     await page.waitForURL(`${pathWithParams}#soluble-abeta42`);
   });

--- a/libs/explorers/testing/src/lib/e2e/scroll-helpers.ts
+++ b/libs/explorers/testing/src/lib/e2e/scroll-helpers.ts
@@ -30,3 +30,31 @@ export async function waitForScrollToStop(page: Page, timeout = 5000) {
     )
     .toBe(true);
 }
+
+/**
+ * Checks if the page scroll position is at the top (pageYOffset === 0).
+ *
+ * @param page - The Playwright page instance
+ * @returns Promise resolving to true if at top, false otherwise
+ */
+export async function isPageAtTop(page: Page): Promise<boolean> {
+  return await page.evaluate(() => window.pageYOffset === 0);
+}
+
+/**
+ * Asserts that the page scroll position is at the top.
+ *
+ * @param page - The Playwright page instance
+ */
+export async function expectPageAtTop(page: Page): Promise<void> {
+  expect(await isPageAtTop(page)).toBe(true);
+}
+
+/**
+ * Asserts that the page scroll position is not at the top.
+ *
+ * @param page - The Playwright page instance
+ */
+export async function expectPageNotAtTop(page: Page): Promise<void> {
+  expect(await isPageAtTop(page)).toBe(false);
+}

--- a/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.scss
+++ b/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.scss
@@ -162,8 +162,6 @@
 }
 
 .panel-navigation.scrollable {
-  --panel-nav-height: 60px;
-
   user-select: none;
 
   .panel-navigation-inner,

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
@@ -36,7 +36,7 @@
     </div>
   </div>
 
-  <div class="table-of-contents-container full-width-container">
+  <div class="table-of-contents-container full-width-container" #tableOfContentsContainer>
     <div class="table-of-contents-title-bar">
       <h2>Table of Contents</h2>
       <div class="title-bar-actions">

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
@@ -39,31 +39,46 @@
   <div class="table-of-contents-container full-width-container">
     <div class="table-of-contents-title-bar">
       <h2>Table of Contents</h2>
-      <explorers-download-dom-images-zip
-        [domFiles]="domFiles()"
-        [csvFiles]="boxplotSections()"
-        [hasCsvDownload]="true"
-        [hasImageDownload]="true"
-        [filename]="
-          generateBoxplotsZipFilename(
-            selectedFilterOption(),
-            selectedSexOption().value,
-            modelName(),
-            title()
-          )
-        "
-        [downloadImagePaddingPx]="BOXPLOT_DOWNLOAD_IMAGE_PADDING_PX"
-      />
+      <div class="title-bar-actions">
+        <explorers-download-dom-images-zip
+          [domFiles]="domFiles()"
+          [csvFiles]="boxplotSections()"
+          [hasCsvDownload]="true"
+          [hasImageDownload]="true"
+          [filename]="
+            generateBoxplotsZipFilename(
+              selectedFilterOption(),
+              selectedSexOption().value,
+              modelName(),
+              title()
+            )
+          "
+          [downloadImagePaddingPx]="BOXPLOT_DOWNLOAD_IMAGE_PADDING_PX"
+        />
+        <p-button
+          (click)="toggleToc()"
+          [label]="isTocCollapsed() ? 'Expand' : 'Collapse'"
+          [icon]="isTocCollapsed() ? 'pi pi-chevron-down' : 'pi pi-chevron-up'"
+          iconPos="left"
+          type="button"
+          rounded="true"
+          size="small"
+          variant="text"
+          [style]="{ 'min-width': '120px' }"
+        />
+      </div>
     </div>
-    <ul class="table-of-contents">
-      @for (item of tocItems(); track item) {
-        <li>
-          <button (click)="scrollToSection(generateAnchorId(item))">
-            {{ item | decodeGreekEntity }}
-          </button>
-        </li>
-      }
-    </ul>
+    @if (!isTocCollapsed()) {
+      <ul class="table-of-contents" id="toc-list">
+        @for (item of tocItems(); track item) {
+          <li>
+            <button (click)="scrollToSection(generateAnchorId(item))" data-testid="toc-item-link">
+              {{ item | decodeGreekEntity }}
+            </button>
+          </li>
+        }
+      </ul>
+    }
   </div>
 
   <div class="boxplots-container" #boxplotsContainer>

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
@@ -61,6 +61,8 @@
   .table-of-contents-title-bar {
     padding: 20px 0 25px;
     display: flex;
+    flex-wrap: wrap;
+    gap: 30px 20px;
     justify-content: space-between;
     align-items: center;
 
@@ -70,7 +72,8 @@
 
     .title-bar-actions {
       display: flex;
-      gap: 59px;
+      flex-wrap: wrap;
+      gap: 10px 59px;
       align-items: center;
     }
   }

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
@@ -53,6 +53,10 @@
 
 .table-of-contents-container {
   box-shadow: 0 4px 4px 0 rgb(0 0 0 / 25%);
+  position: sticky;
+  top: var(--panel-nav-height);
+  z-index: 10;
+  background-color: white;
 
   .table-of-contents-title-bar {
     padding: 20px 0 25px;

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
@@ -67,6 +67,12 @@
     h2 {
       margin-bottom: 0;
     }
+
+    .title-bar-actions {
+      display: flex;
+      gap: 59px;
+      align-items: center;
+    }
   }
 
   .table-of-contents {

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
@@ -16,6 +16,10 @@ import {
   ModelDetailsBoxplotsSelectorComponent,
 } from './model-details-boxplots-selector.component';
 
+// Longer default timeout for all tests; PrimeNG rendering can be slow in CI
+const TEST_TIMEOUT_MS = 15000;
+jest.setTimeout(TEST_TIMEOUT_MS);
+
 const mockTitle = 'Pathology';
 const mockDescription = 'Test description';
 const mouseFilterConfig: FilterConfig = {
@@ -98,7 +102,7 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
       { timeout: 10000 },
     );
     expect(tissueFilter).toBeVisible();
-  }, 15000);
+  });
 
   it('should convert label to anchor id', async () => {
     const { fixture } = await setupHost();
@@ -304,7 +308,7 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
     await waitFor(() => {
       expect(screen.getAllByRole('listitem').length).toBeGreaterThan(0);
     });
-  }, 15000);
+  });
 
   describe('collapsible TOC', () => {
     it('should start collapsed with expand button and no TOC items visible', async () => {

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
@@ -304,7 +304,7 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
     await waitFor(() => {
       expect(screen.getAllByRole('listitem').length).toBeGreaterThan(0);
     });
-  });
+  }, 15000);
 
   describe('collapsible TOC', () => {
     it('should start collapsed with expand button and no TOC items visible', async () => {

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
@@ -10,6 +10,7 @@ import { ModelData, Sex } from '@sagebionetworks/model-ad/api-client';
 import { mouseModelMock } from '@sagebionetworks/model-ad/testing';
 import { BoxplotsGridComponent } from '@sagebionetworks/model-ad/ui';
 import { render, screen, waitFor } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
 import {
   FilterConfig,
   ModelDetailsBoxplotsSelectorComponent,
@@ -54,12 +55,13 @@ class TestHostComponent {
 }
 
 async function setupHost(overrides: Partial<TestHostComponent> = {}) {
+  const user = userEvent.setup();
   const { fixture } = await render(TestHostComponent, {
     imports: [MockWikiComponent],
     componentInputs: overrides,
     providers: [provideHttpClient(), { provide: SvgIconService, useClass: SvgIconServiceStub }],
   });
-  return { fixture, host: fixture.componentInstance };
+  return { fixture, host: fixture.componentInstance, user };
 }
 
 describe('ModelDetailsBoxplotsSelectorComponent', () => {
@@ -294,9 +296,62 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
   });
 
   it('should populate TOC from anchorDataField', async () => {
-    await setupHost();
+    const { user } = await setupHost();
+
+    const expandButton = screen.getByRole('button', { name: 'Expand' });
+    await user.click(expandButton);
+
     await waitFor(() => {
       expect(screen.getAllByRole('listitem').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('collapsible TOC', () => {
+    it('should start collapsed with expand button and no TOC items visible', async () => {
+      await setupHost();
+
+      const expandButton = screen.getByRole('button', { name: 'Expand' });
+      expect(expandButton).toBeVisible();
+
+      const tocList = screen.queryByRole('list');
+      expect(tocList).not.toBeInTheDocument();
+    });
+
+    it('should show TOC items when expand button is clicked', async () => {
+      const { user } = await setupHost();
+
+      const expandButton = screen.getByRole('button', { name: 'Expand' });
+      await user.click(expandButton);
+
+      await waitFor(() => {
+        const collapseButton = screen.getByRole('button', { name: 'Collapse' });
+        expect(collapseButton).toBeVisible();
+
+        const tocList = screen.getByRole('list');
+        expect(tocList).toBeVisible();
+      });
+    });
+
+    it('should hide TOC items when collapse button is clicked', async () => {
+      const { user } = await setupHost();
+
+      const expandButton = screen.getByRole('button', { name: 'Expand' });
+      await user.click(expandButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('list')).toBeVisible();
+      });
+
+      const collapseButton = screen.getByRole('button', { name: 'Collapse' });
+      await user.click(collapseButton);
+
+      await waitFor(() => {
+        const expandButtonAgain = screen.getByRole('button', { name: 'Expand' });
+        expect(expandButtonAgain).toBeVisible();
+
+        const tocList = screen.queryByRole('list');
+        expect(tocList).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -71,6 +71,7 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
 
   readonly generateAnchorId = generateAnchorId;
 
+  tableOfContentsContainer = viewChild('tableOfContentsContainer', { read: ElementRef });
   boxplotsContainer = viewChild('boxplotsContainer', { read: ElementRef });
   sectionBodies = viewChildren('sectionBody', { read: ElementRef });
 
@@ -343,7 +344,7 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
       const element = container.nativeElement.querySelector(`[id="${anchorId}"]`) as HTMLElement;
 
       if (element) {
-        const tocElement = document.querySelector('.table-of-contents-container');
+        const tocElement = this.tableOfContentsContainer()?.nativeElement;
         const tocHeight = tocElement ? tocElement.getBoundingClientRect().height : 0;
 
         const panelNavHeight = this.helperService.getNumberFromCSSValue(

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -25,6 +25,7 @@ import {
 } from '@sagebionetworks/explorers/ui';
 import { DecodeGreekEntityPipe, ModalLinkComponent } from '@sagebionetworks/explorers/util';
 import { ModelData, Sex } from '@sagebionetworks/model-ad/api-client';
+import { ButtonModule } from 'primeng/button';
 import { SelectModule } from 'primeng/select';
 import { generateAnchorId } from '../../utils';
 
@@ -49,6 +50,7 @@ export interface SectionContext<T = ModelData[]> {
   imports: [
     FormsModule,
     SelectModule,
+    ButtonModule,
     NgTemplateOutlet,
     ModalLinkComponent,
     DecodeGreekEntityPipe,
@@ -116,6 +118,8 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
 
   activeShareLink = signal('');
   lastShareLinkCopied = signal('');
+
+  isTocCollapsed = signal(true);
 
   constructor() {
     effect(() => {
@@ -413,5 +417,9 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
     const filterPart = filterValue !== evidenceType ? `_${filterValue}` : '';
     const filename = `${modelName}_${decodedEvidenceType}${filterPart}_${sex.join('_')}`;
     return this.helperService.cleanFilename(filename);
+  }
+
+  toggleToc(): void {
+    this.isTocCollapsed.set(!this.isTocCollapsed());
   }
 }

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -339,11 +339,14 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
       const element = container.nativeElement.querySelector(`[id="${anchorId}"]`) as HTMLElement;
 
       if (element) {
+        const tocElement = document.querySelector('.table-of-contents-container');
+        const tocHeight = tocElement ? tocElement.getBoundingClientRect().height : 0;
+
         const panelNavHeight = this.helperService.getNumberFromCSSValue(
           getComputedStyle(document.documentElement).getPropertyValue('--panel-nav-height'),
         );
 
-        const yOffset = -(panelNavHeight + this.SCROLL_PADDING);
+        const yOffset = -(tocHeight + panelNavHeight + this.SCROLL_PADDING);
         const elementOffset = this.helperService.getOffset(element);
         const y = elementOffset.top + yOffset;
         window.scrollTo({ top: y, behavior: 'smooth' });

--- a/libs/model-ad/styles/src/lib/_general.scss
+++ b/libs/model-ad/styles/src/lib/_general.scss
@@ -2,3 +2,11 @@ html,
 body {
   color: var(--color-text);
 }
+
+button.p-button-text {
+  color: var(--color-gray-1000);
+
+  &:hover {
+    color: var(--color-action-primary);
+  }
+}


### PR DESCRIPTION
## Description

The table of contents on Model-AD detail pages now remains visible while scrolling and can be collapsed to reduce visual clutter. This improves navigation on pages with many sections by keeping the TOC accessible without taking up permanent screen space.

## Related Issue

- [MG-971](https://sagebionetworks.jira.com/browse/MG-971)
- [MG-972](https://sagebionetworks.jira.com/browse/MG-972)

## Changelog

- Make TOC sticky to navigation header so it remains visible during scroll
- Add expand/collapse button to TOC title bar with chevron icons
- Default TOC to collapsed state on initial page load
- Add e2e tests for collapsible TOC behavior and scroll helpers

## Testing

- Navigate to a model details page with multiple biomarker sections (e.g., `/models/3xTg-AD/biomarkers`)
- Verify the TOC header remains visible at the top of the viewport while scrolling down the page
- Click the "Expand" button and verify the TOC items become visible
- Click the "Collapse" button and verify the TOC items are hidden
- While the TOC is expanded, click a TOC link and verify the page scrolls to the correct section with proper offset
- Load a page with an anchor fragment (e.g., `/models/Abca7*V1599M/biomarkers#soluble-abeta40`) and verify the TOC starts collapsed but the correct section is visible
- Change sex or filter options and verify the TOC remains in its current expanded/collapsed state

## Preview

TOC is sticky when scrolling vertically:

https://github.com/user-attachments/assets/d3748c32-9e39-4493-b0a6-13a137dae808

TOC can be expanded/collapsed: 

https://github.com/user-attachments/assets/9252691b-6bb7-4c26-beab-7db08d83b36f

[MG-971]: https://sagebionetworks.jira.com/browse/MG-971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-972]: https://sagebionetworks.jira.com/browse/MG-972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ