### PR TITLE
fix(model-ad,qtl): deploy model-ad and qtl storybooks on isolated changes (MG-1019)

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -20,7 +20,7 @@ concurrency:
 # Parent products with storybooks (space-separated)
 # Update this list when adding new storybooks to composite storybook
 env:
-  STORYBOOK_PRODUCTS: 'agora explorers'
+  STORYBOOK_PRODUCTS: 'agora explorers model-ad qtl'
 
 jobs:
   check-affected:

--- a/libs/model-ad/storybook/README.md
+++ b/libs/model-ad/storybook/README.md
@@ -1,0 +1,3 @@
+# model-ad-storybook
+
+This library was generated with [Nx](https://nx.dev).

--- a/libs/qtl/storybook/README.md
+++ b/libs/qtl/storybook/README.md
@@ -1,3 +1,3 @@
 # qtl-storybook
 
-This library was generated with [Nx](https://nx.dev).
+Storybook host for the QTL scope. This library was generated with [Nx](https://nx.dev).


### PR DESCRIPTION
## Description

An isolated change to the Model AD or QTL storybook never redeployed to gh-pages, because neither was listed in `STORYBOOK_PRODUCTS` and so changes to those products don't mark the composite storybook as affected. Those bundles only refreshed as a side effect of an unrelated full-site deploy, so the deployed storybook drifted from source. This PR fixes the workflow and touches both storybooks so the corrected deploy runs on merge.

## Related Issue

- [MG-1019](https://sagebionetworks.jira.com/browse/MG-1019)

## Changelog

- Add `model-ad` and `qtl` to `STORYBOOK_PRODUCTS` in `build-deploy-docs.yml`
- Add a README for the Model-AD storybook and describe the QTL storybook host, so both projects are marked affected and redeploy on merge

## Testing

- On merging this PR, confirm the individual storybook deploy job runs and updates the `model-ad` and `qtl` gh-pages bundles
- After deploy, verify the deployed Model-AD storybook shows the current stories (no removed selector story)

[MG-1019]: https://sagebionetworks.jira.com/browse/MG-1019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ