### PR TITLE
feat(model-ad): update subtitle on gene details pages (MG-1024)

### DIFF
--- a/libs/model-ad/gene-details/src/lib/gene-details.component.spec.ts
+++ b/libs/model-ad/gene-details/src/lib/gene-details.component.spec.ts
@@ -88,9 +88,7 @@ describe('GeneDetailsComponent', () => {
 
   it('should display model name', async () => {
     await setup();
-    expect(
-      screen.getByText(`${transcriptomicsIndividualMocks[0].name} (Females & Males)`),
-    ).toBeInTheDocument();
+    expect(screen.getByText(`${transcriptomicsIndividualMocks[0].name}`)).toBeInTheDocument();
   });
 
   it('should convert data to CSV and set filename correctly', async () => {

--- a/libs/model-ad/gene-details/src/lib/gene-details.component.ts
+++ b/libs/model-ad/gene-details/src/lib/gene-details.component.ts
@@ -60,7 +60,7 @@ export class GeneDetailsComponent implements OnInit, AfterViewInit {
   });
 
   subtitle = computed(() => {
-    return this.modelIdentifier ? `${this.modelIdentifier} (Females & Males)` : '';
+    return this.modelIdentifier ? `${this.modelIdentifier}` : '';
   });
 
   xAxisOrder = computed(() => this.primaryGene()?.result_order);


### PR DESCRIPTION
## Description

Update subtitle on gene details pages.

## Related Issue

- [MG-1024](https://sagebionetworks.jira.com/browse/MG-1024)

## Changelog

- Update subtitle on gene details pages to remove "(Females & Males)"

## Testing

- Navigate to gene details page and confirm that "(Females & Males)" is not displayed in subtitle

## Preview

`/genes/ENSMUSG00000086714?modelGroup=5xFAD%20(IU%2FJax%2FPitt)&tissue=Hemibrain`

dev | this PR 
:---: | :---: 
<img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/51291098-2f64-4ca3-9c85-6afc82394272" /> | <img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/bbfb7183-0061-4244-bc75-d9a619692eff" />


[MG-1024]: https://sagebionetworks.jira.com/browse/MG-1024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ