### PR TITLE
feat(model-ad): make matched control text conditional (MG-892)

### DIFF
--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.ts
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.ts
@@ -19,6 +19,7 @@ import { DEBOUNCE_TIME_MS } from '@sagebionetworks/explorers/constants';
 import { SearchResult } from '@sagebionetworks/explorers/models';
 import { PlatformService } from '@sagebionetworks/explorers/services';
 import { SanitizeHtmlPipe } from '@sagebionetworks/explorers/util';
+import { pluralize } from '@sagebionetworks/shared/util';
 import {
   catchError,
   debounceTime,
@@ -139,7 +140,7 @@ export class SearchInputComponent implements AfterViewInit {
 
   getNotValidSearchMessage(minimumSearchLength: number): string {
     const numWords = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine'];
-    return `Please enter at least ${numWords[minimumSearchLength - 1]} character${minimumSearchLength > 1 ? 's' : ''}.`;
+    return `Please enter at least ${numWords[minimumSearchLength - 1]} ${pluralize('character', minimumSearchLength)}.`;
   }
 
   search(query: string): Observable<SearchResult[]> {

--- a/libs/model-ad/model-details/src/lib/components/marmoset-model-details-hero/marmoset-model-details-hero.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/marmoset-model-details-hero/marmoset-model-details-hero.component.spec.ts
@@ -39,7 +39,7 @@ describe('MarmosetModelDetailsHeroComponent', () => {
 
   it('should not display mouse-only sections', async () => {
     await setup();
-    expect(screen.queryByText('Matched Controls')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Matched Control/)).not.toBeInTheDocument();
     expect(screen.queryByText('ALSO KNOWN AS')).not.toBeInTheDocument();
     expect(screen.queryByText('JAX Stock Number:', { exact: false })).not.toBeInTheDocument();
     expect(screen.queryByText('RRID:', { exact: false })).not.toBeInTheDocument();

--- a/libs/model-ad/model-details/src/lib/components/model-details-modified-genes/model-details-modified-genes.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-modified-genes/model-details-modified-genes.component.ts
@@ -1,6 +1,7 @@
 import { Component, computed, input } from '@angular/core';
 import { SanitizeHtmlPipe } from '@sagebionetworks/explorers/util';
 import { GeneticInfo } from '@sagebionetworks/model-ad/api-client';
+import { pluralize } from '@sagebionetworks/shared/util';
 
 const ENSEMBL_GENE_ID_PREFIX_TO_SPECIES: Record<string, string> = {
   ENSMUSG: 'Mus_musculus',
@@ -16,7 +17,7 @@ const ENSEMBL_GENE_ID_PREFIX_TO_SPECIES: Record<string, string> = {
 export class ModelDetailsModifiedGenesComponent {
   geneticInfo = input.required<GeneticInfo[]>();
 
-  heading = computed(() => `Modified Gene${this.geneticInfo().length > 1 ? 's' : ''}`);
+  heading = computed(() => `Modified ${pluralize('Gene', this.geneticInfo().length)}`);
 
   getGeneUrl(gene: string) {
     const prefix = Object.keys(ENSEMBL_GENE_ID_PREFIX_TO_SPECIES).find((p) => gene.startsWith(p));

--- a/libs/model-ad/model-details/src/lib/components/mouse-model-details-hero/mouse-model-details-hero.component.html
+++ b/libs/model-ad/model-details/src/lib/components/mouse-model-details-hero/mouse-model-details-hero.component.html
@@ -8,7 +8,7 @@
 
     <model-ad-model-details-modified-genes [geneticInfo]="model().genetic_info" />
 
-    <h4>Matched Controls</h4>
+    <h4>{{ matchedControlsHeading() }}</h4>
     <p>
       @for (matched_control of model().matched_controls; track matched_control; let last = $last) {
         <a [href]="this.MATCHED_CONTROLS_URLS[matched_control]" target="_blank">{{

--- a/libs/model-ad/model-details/src/lib/components/mouse-model-details-hero/mouse-model-details-hero.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/mouse-model-details-hero/mouse-model-details-hero.component.spec.ts
@@ -39,9 +39,19 @@ describe('MouseModelDetailsHeroComponent', () => {
     });
   });
 
-  it('should display matched controls', async () => {
-    await setup();
-    expect(screen.getByText(mouseModelMock.matched_controls.join(', '))).toBeInTheDocument();
+  it('should display a singular heading for one matched control', async () => {
+    await setup({ ...mouseModelMock, matched_controls: ['B6129'] });
+    expect(screen.getByText('Matched Control')).toBeVisible();
+    expect(screen.getByRole('link', { name: 'B6129' })).toBeInTheDocument();
+  });
+
+  it('should display a plural heading for multiple matched controls', async () => {
+    const matchedControls = ['B6129', 'C57BL/6J'];
+    await setup({ ...mouseModelMock, matched_controls: matchedControls });
+    expect(screen.getByText('Matched Controls')).toBeVisible();
+    matchedControls.forEach((matchedControl) => {
+      expect(screen.getByRole('link', { name: matchedControl })).toBeInTheDocument();
+    });
   });
 
   it('should display JAX stock number as link', async () => {

--- a/libs/model-ad/model-details/src/lib/components/mouse-model-details-hero/mouse-model-details-hero.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/mouse-model-details-hero/mouse-model-details-hero.component.ts
@@ -1,6 +1,7 @@
 import { Component, computed, input } from '@angular/core';
 import { SanitizeHtmlPipe } from '@sagebionetworks/explorers/util';
 import { MouseModel } from '@sagebionetworks/model-ad/api-client';
+import { pluralize } from '@sagebionetworks/shared/util';
 import { ModelDetailsModifiedGenesComponent } from '../model-details-modified-genes/model-details-modified-genes.component';
 
 @Component({
@@ -22,6 +23,6 @@ export class MouseModelDetailsHeroComponent {
   model = input.required<MouseModel>();
 
   matchedControlsHeading = computed(
-    () => `Matched Control${this.model().matched_controls.length > 1 ? 's' : ''}`,
+    () => `Matched ${pluralize('Control', this.model().matched_controls.length)}`,
   );
 }

--- a/libs/model-ad/model-details/src/lib/components/mouse-model-details-hero/mouse-model-details-hero.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/mouse-model-details-hero/mouse-model-details-hero.component.ts
@@ -1,4 +1,4 @@
-import { Component, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { SanitizeHtmlPipe } from '@sagebionetworks/explorers/util';
 import { MouseModel } from '@sagebionetworks/model-ad/api-client';
 import { ModelDetailsModifiedGenesComponent } from '../model-details-modified-genes/model-details-modified-genes.component';
@@ -20,4 +20,8 @@ export class MouseModelDetailsHeroComponent {
   };
 
   model = input.required<MouseModel>();
+
+  matchedControlsHeading = computed(
+    () => `Matched Control${this.model().matched_controls.length > 1 ? 's' : ''}`,
+  );
 }

--- a/libs/shared/typescript/util/src/lib/helpers.spec.ts
+++ b/libs/shared/typescript/util/src/lib/helpers.spec.ts
@@ -3,6 +3,7 @@ import {
   escapeRegexChars,
   getRandomInt,
   isExternalLink,
+  pluralize,
   removeParentheses,
   toKebabCase,
 } from './helpers';
@@ -31,6 +32,25 @@ describe('capitalizeFirstLetter', () => {
 
   it('should handle a single character', () => {
     expect(capitalizeFirstLetter('a')).toBe('A');
+  });
+});
+
+describe('pluralize', () => {
+  it('should return the singular form when count is 1', () => {
+    expect(pluralize('Control', 1)).toBe('Control');
+  });
+
+  it('should return the plural form when count is greater than 1', () => {
+    expect(pluralize('Control', 2)).toBe('Controls');
+  });
+
+  it('should return the plural form when count is 0', () => {
+    expect(pluralize('Control', 0)).toBe('Controls');
+  });
+
+  it('should use the provided plural form for irregular words', () => {
+    expect(pluralize('mouse', 1, 'mice')).toBe('mouse');
+    expect(pluralize('mouse', 3, 'mice')).toBe('mice');
   });
 });
 

--- a/libs/shared/typescript/util/src/lib/helpers.ts
+++ b/libs/shared/typescript/util/src/lib/helpers.ts
@@ -54,6 +54,17 @@ export function toKebabCase(s: string): string {
 }
 
 /**
+ * Selects the singular or plural form of a word based on a count
+ * @param singular - The singular form of the word
+ * @param count - The number of items being described
+ * @param plural - The plural form, defaulting to the singular with an appended "s"
+ * @returns The singular form when count is exactly 1, otherwise the plural form
+ */
+export function pluralize(singular: string, count: number, plural = `${singular}s`): string {
+  return count === 1 ? singular : plural;
+}
+
+/**
  * Capitalizes the first letter of a string, leaving the rest unchanged
  * @param value - The string to capitalize
  * @returns The string with its first letter uppercased, or an empty string for nullish/empty input


### PR DESCRIPTION
## Description

The mouse model details hero always rendered the plural heading "Matched Controls", even when a model had only one. The heading is now pluralized based on the number of matched controls.

## Related Issue

- [MG-892](https://sagebionetworks.jira.com/browse/MG-892)

## Changelog

- Pluralize the matched controls heading based on how many matched controls the model has

## Testing

- Open a mouse model details page for a model with a single matched control and confirm the heading reads "Matched Control" (e.g. `/models/3xTg-AD?modelOrganism=mouse`)
- Open a mouse model details page for a model with multiple matched controls and confirm the heading reads "Matched Controls" and each control links out correctly (e.g. `/models/Abca7*V1599M?modelOrganism=mouse`)

### Preview

case | dev | this PR | change 
:---: | :---: | :---: | :---: 
singular | <img width="1124" height="658" alt="MG-892_dev_singular" src="https://github.com/user-attachments/assets/db68d87d-59c1-4967-b80a-108aacce0e80" /> | <img width="814" height="657" alt="MG-892_pr_singular" src="https://github.com/user-attachments/assets/c988eb92-20bc-4406-ae55-67fc704655e2" /> | Matched Controls -> Matched Control
plural | <img width="515" height="584" alt="MG-892_dev_plural" src="https://github.com/user-attachments/assets/0e7da41d-fb6c-492b-a883-fc3be8fe5cd9" /> | <img width="355" height="568" alt="MG-892_pr_plural" src="https://github.com/user-attachments/assets/6ad5e44f-1683-4967-ae18-9c49749a9d77" /> | no change



[MG-892]: https://sagebionetworks.jira.com/browse/MG-892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ