### PR TITLE
feat(model-ad): filter differential expression results by sex (MG-1002)

### DIFF
--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/api/TranscriptomicsApiDelegateImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/api/TranscriptomicsApiDelegateImpl.java
@@ -28,6 +28,7 @@ public class TranscriptomicsApiDelegateImpl implements TranscriptomicsApiDelegat
     "biodomains",
     "modelType",
     "name",
+    "sex",
     "sortFields",
     "sortOrders"
   );

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/dto/TranscriptomicsSearchQueryDto.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/dto/TranscriptomicsSearchQueryDto.java
@@ -53,6 +53,9 @@ public class TranscriptomicsSearchQueryDto {
   private @Nullable List<String> name;
 
   @Valid
+  private @Nullable List<String> sex;
+
+  @Valid
   private List<String> sortFields = new ArrayList<>();
 
   /**
@@ -329,6 +332,34 @@ public class TranscriptomicsSearchQueryDto {
     this.name = name;
   }
 
+  public TranscriptomicsSearchQueryDto sex(@Nullable List<String> sex) {
+    this.sex = sex;
+    return this;
+  }
+
+  public TranscriptomicsSearchQueryDto addSexItem(String sexItem) {
+    if (this.sex == null) {
+      this.sex = new ArrayList<>();
+    }
+    this.sex.add(sexItem);
+    return this;
+  }
+
+  /**
+   * Filter by sex.
+   * @return sex
+   */
+  
+  @Schema(name = "sex", example = "[\"Female\",\"Male\"]", description = "Filter by sex.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("sex")
+  public @Nullable List<String> getSex() {
+    return sex;
+  }
+
+  public void setSex(@Nullable List<String> sex) {
+    this.sex = sex;
+  }
+
   public TranscriptomicsSearchQueryDto sortFields(List<String> sortFields) {
     this.sortFields = sortFields;
     return this;
@@ -403,13 +434,14 @@ public class TranscriptomicsSearchQueryDto {
         Objects.equals(this.biodomains, transcriptomicsSearchQuery.biodomains) &&
         Objects.equals(this.modelType, transcriptomicsSearchQuery.modelType) &&
         Objects.equals(this.name, transcriptomicsSearchQuery.name) &&
+        Objects.equals(this.sex, transcriptomicsSearchQuery.sex) &&
         Objects.equals(this.sortFields, transcriptomicsSearchQuery.sortFields) &&
         Objects.equals(this.sortOrders, transcriptomicsSearchQuery.sortOrders);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(pageNumber, pageSize, categories, items, itemFilterType, search, biodomains, modelType, name, sortFields, sortOrders);
+    return Objects.hash(pageNumber, pageSize, categories, items, itemFilterType, search, biodomains, modelType, name, sex, sortFields, sortOrders);
   }
 
   @Override
@@ -425,6 +457,7 @@ public class TranscriptomicsSearchQueryDto {
     sb.append("    biodomains: ").append(toIndentedString(biodomains)).append("\n");
     sb.append("    modelType: ").append(toIndentedString(modelType)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    sex: ").append(toIndentedString(sex)).append("\n");
     sb.append("    sortFields: ").append(toIndentedString(sortFields)).append("\n");
     sb.append("    sortOrders: ").append(toIndentedString(sortOrders)).append("\n");
     sb.append("}");
@@ -464,6 +497,7 @@ public class TranscriptomicsSearchQueryDto {
       this.instance.setBiodomains(value.biodomains);
       this.instance.setModelType(value.modelType);
       this.instance.setName(value.name);
+      this.instance.setSex(value.sex);
       this.instance.setSortFields(value.sortFields);
       this.instance.setSortOrders(value.sortOrders);
       return this;
@@ -511,6 +545,11 @@ public class TranscriptomicsSearchQueryDto {
     
     public TranscriptomicsSearchQueryDto.Builder name(List<String> name) {
       this.instance.name(name);
+      return this;
+    }
+    
+    public TranscriptomicsSearchQueryDto.Builder sex(List<String> sex) {
+      this.instance.sex(sex);
       return this;
     }
     

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -75,9 +76,31 @@ public class CustomTranscriptomicsRepositoryImpl
     .dataFilter("biodomains", TranscriptomicsSearchQueryDto::getBiodomains)
     .dataFilter("model_type", TranscriptomicsSearchQueryDto::getModelType)
     .dataFilter("name.link_text", TranscriptomicsSearchQueryDto::getName)
+    // TODO(MG-1004): replace with TranscriptomicsSearchQueryDto::getSex
+    // once rna_de_aggregate stores singular Female/Male
+    .dataFilter("sex", query -> expandSexMatchValues(query.getSex()))
     .compositeItemFilter(item -> TranscriptomicsIdentifier.parse(item).toCriteria())
     .searchFilter(GENE_SYMBOL_FIELD)
     .build();
+
+  /**
+   * Expands each requested sex to every form stored in the source data, so a singular query value
+   * still matches the plural values in {@code rna_de_aggregate}. Returns an empty list for a null
+   * query value, which {@link ComparisonToolRepositorySupport} skips.
+   *
+   * <p>See {@link TranscriptomicsIdentifier#sexMatchValues(String)}, which owns the plural fallback
+   * shared with the composite item filter.
+   */
+  private static List<String> expandSexMatchValues(@Nullable List<String> sexes) {
+    if (sexes == null) {
+      return List.of();
+    }
+    return sexes
+      .stream()
+      .map(TranscriptomicsIdentifier::sexMatchValues)
+      .flatMap(List::stream)
+      .toList();
+  }
 
   /**
    * Maps each heatmap time-point column to its nested {@code log2_fc} value

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
@@ -20,7 +20,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -76,31 +75,10 @@ public class CustomTranscriptomicsRepositoryImpl
     .dataFilter("biodomains", TranscriptomicsSearchQueryDto::getBiodomains)
     .dataFilter("model_type", TranscriptomicsSearchQueryDto::getModelType)
     .dataFilter("name.link_text", TranscriptomicsSearchQueryDto::getName)
-    // TODO(MG-1004): replace with TranscriptomicsSearchQueryDto::getSex
-    // once rna_de_aggregate stores singular Female/Male
-    .dataFilter("sex", query -> expandSexMatchValues(query.getSex()))
+    .dataFilter("sex", TranscriptomicsSearchQueryDto::getSex)
     .compositeItemFilter(item -> TranscriptomicsIdentifier.parse(item).toCriteria())
     .searchFilter(GENE_SYMBOL_FIELD)
     .build();
-
-  /**
-   * Expands each requested sex to every form stored in the source data, so a singular query value
-   * still matches the plural values in {@code rna_de_aggregate}. Returns an empty list for a null
-   * query value, which {@link ComparisonToolRepositorySupport} skips.
-   *
-   * <p>See {@link TranscriptomicsIdentifier#sexMatchValues(String)}, which owns the plural fallback
-   * shared with the composite item filter.
-   */
-  private static List<String> expandSexMatchValues(@Nullable List<String> sexes) {
-    if (sexes == null) {
-      return List.of();
-    }
-    return sexes
-      .stream()
-      .map(TranscriptomicsIdentifier::sexMatchValues)
-      .flatMap(List::stream)
-      .toList();
-  }
 
   /**
    * Maps each heatmap time-point column to its nested {@code log2_fc} value

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/service/TranscriptomicsService.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/service/TranscriptomicsService.java
@@ -34,7 +34,7 @@ public class TranscriptomicsService {
   @Cacheable(
     key = "T(org.sagebionetworks.explorers.ApiHelper)" +
     ".buildCacheKey('transcriptomics', #query.itemFilterType, #query.items, " +
-    "#query.search, #query.biodomains, #query.modelType, #query.name, " +
+    "#query.search, #query.biodomains, #query.modelType, #query.name, #query.sex, " +
     "#tissue, #query.pageNumber, #query.pageSize, " +
     "#query.sortFields, #query.sortOrders)"
   )

--- a/apps/model-ad/api-next/src/main/resources/openapi.yaml
+++ b/apps/model-ad/api-next/src/main/resources/openapi.yaml
@@ -1570,6 +1570,15 @@ components:
             type: string
           nullable: true
           type: array
+        sex:
+          description: Filter by sex.
+          example:
+            - Female
+            - Male
+          items:
+            type: string
+          nullable: true
+          type: array
         sortFields:
           description: |
             List of field names to sort by (e.g., "gene_symbol,name").

--- a/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImplTest.java
+++ b/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImplTest.java
@@ -97,11 +97,9 @@ class CustomTranscriptomicsRepositoryImplTest {
     assertThat(andConditions.size()).isGreaterThanOrEqualTo(3);
   }
 
-  // TODO(MG-1004): assert a plain $in of the requested values once rna_de_aggregate stores
-  // singular Female/Male
   @Test
-  @DisplayName("should match singular and plural source sex values when filtering by sex")
-  void shouldMatchSingularAndPluralSourceSexValuesWhenFilteringBySex() {
+  @DisplayName("should match the requested sex values when filtering by sex")
+  void shouldMatchRequestedSexValuesWhenFilteringBySex() {
     TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
       .sex(Arrays.asList("Female", "Male"))
       .itemFilterType(ItemFilterTypeQueryDto.EXCLUDE)
@@ -112,7 +110,7 @@ class CustomTranscriptomicsRepositoryImplTest {
     Document criteriaDoc = captureCountQuery().getQueryObject();
     List<Document> andConditions = (List<Document>) criteriaDoc.get("$and");
     assertThat(andConditions).contains(
-      new Document("sex", new Document("$in", List.of("Female", "Females", "Male", "Males")))
+      new Document("sex", new Document("$in", List.of("Female", "Male")))
     );
   }
 

--- a/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImplTest.java
+++ b/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImplTest.java
@@ -97,6 +97,25 @@ class CustomTranscriptomicsRepositoryImplTest {
     assertThat(andConditions.size()).isGreaterThanOrEqualTo(3);
   }
 
+  // TODO(MG-1004): assert a plain $in of the requested values once rna_de_aggregate stores
+  // singular Female/Male
+  @Test
+  @DisplayName("should match singular and plural source sex values when filtering by sex")
+  void shouldMatchSingularAndPluralSourceSexValuesWhenFilteringBySex() {
+    TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
+      .sex(Arrays.asList("Female", "Male"))
+      .itemFilterType(ItemFilterTypeQueryDto.EXCLUDE)
+      .build();
+
+    repository.findAll(PageRequest.of(0, 10), query, Collections.emptyList(), "test-tissue");
+
+    Document criteriaDoc = captureCountQuery().getQueryObject();
+    List<Document> andConditions = (List<Document>) criteriaDoc.get("$and");
+    assertThat(andConditions).contains(
+      new Document("sex", new Document("$in", List.of("Female", "Females", "Male", "Males")))
+    );
+  }
+
   @Test
   @DisplayName("should search on gene_symbol with fallback to ensembl_gene_id for single term")
   void shouldSearchOnDisplayGeneSymbolWithSingleTerm() {

--- a/apps/model-ad/app/e2e/differential-expression-comparison-tool.spec.ts
+++ b/apps/model-ad/app/e2e/differential-expression-comparison-tool.spec.ts
@@ -421,6 +421,7 @@ test.describe('differential expression', () => {
       page,
     }) => {
       await navigateToComparison(page, CT_PAGE, true);
+      // TODO(MG-1036): first arg becomes `'sexes'`
       await testFilterSelectionUpdatesUrl(page, 'sex', 'Sex', 'Female');
     });
 
@@ -428,6 +429,7 @@ test.describe('differential expression', () => {
       const expectedFilterParams = {
         biodomains: ['Apoptosis', 'Epigenetic', 'Myelination'],
         models: ['APOE4'],
+        // TODO(MG-1036): becomes `sexes: ['Female']`
         sex: ['Female'],
       };
       const expectedSelectedFilters = {
@@ -450,6 +452,7 @@ test.describe('differential expression', () => {
       const expectedInitialFilterParams = {
         modelTypes: ['Familial AD'],
         biodomains: ['Apoptosis', 'Epigenetic', 'Myelination'],
+        // TODO(MG-1036): becomes `sexes: ['Female']`
         sex: ['Female'],
       };
 

--- a/apps/model-ad/app/e2e/differential-expression-comparison-tool.spec.ts
+++ b/apps/model-ad/app/e2e/differential-expression-comparison-tool.spec.ts
@@ -421,16 +421,14 @@ test.describe('differential expression', () => {
       page,
     }) => {
       await navigateToComparison(page, CT_PAGE, true);
-      // TODO(MG-1036): first arg becomes `'sexes'`
-      await testFilterSelectionUpdatesUrl(page, 'sex', 'Sex', 'Female');
+      await testFilterSelectionUpdatesUrl(page, 'sexes', 'Sex', 'Female');
     });
 
     test('filter selections are restored from URL on page load', async ({ page }) => {
       const expectedFilterParams = {
         biodomains: ['Apoptosis', 'Epigenetic', 'Myelination'],
         models: ['APOE4'],
-        // TODO(MG-1036): becomes `sexes: ['Female']`
-        sex: ['Female'],
+        sexes: ['Female'],
       };
       const expectedSelectedFilters = {
         'Biological Domain': ['Apoptosis', 'Epigenetic', 'Myelination'],
@@ -452,8 +450,7 @@ test.describe('differential expression', () => {
       const expectedInitialFilterParams = {
         modelTypes: ['Familial AD'],
         biodomains: ['Apoptosis', 'Epigenetic', 'Myelination'],
-        // TODO(MG-1036): becomes `sexes: ['Female']`
-        sex: ['Female'],
+        sexes: ['Female'],
       };
 
       await navigateToComparison(

--- a/apps/model-ad/app/e2e/differential-expression-comparison-tool.spec.ts
+++ b/apps/model-ad/app/e2e/differential-expression-comparison-tool.spec.ts
@@ -33,7 +33,11 @@ import {
   testTableReturnsToFirstPageWhenSortChanged,
   unPinByName,
 } from '@sagebionetworks/explorers/testing/e2e';
-import { fetchComparisonToolConfig, navigateToComparison } from './helpers/comparison-tool';
+import {
+  fetchComparisonToolConfig,
+  fetchTranscriptomics,
+  navigateToComparison,
+} from './helpers/comparison-tool';
 
 const CT_PAGE = 'Differential Expression';
 const categories = ['RNA - DIFFERENTIAL EXPRESSION', 'Tissue - Hippocampus'];
@@ -340,6 +344,13 @@ test.describe('differential expression', () => {
     await expect(popup.getByRole('heading', { level: 1, name: specialModel })).toBeVisible();
   });
 
+  test('sex filter returns only results for the selected sex', async ({ page }) => {
+    const results = await fetchTranscriptomics(page, categories, { sex: ['Female'] });
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((result) => result.sex === 'Female')).toBe(true);
+  });
+
   test.describe('sort URL sync', () => {
     // Columns: 0=Gene (gene_symbol), 1=Model (name), 2=Control, 3=4 months, 4=12 months
     // Default sort: gene_symbol ASC, name ASC
@@ -406,14 +417,23 @@ test.describe('differential expression', () => {
       await testFilterSelectionUpdatesUrl(page, 'modelTypes', 'Model Type', 'Familial AD');
     });
 
+    test('sex filter selections are added to URL when selected and removed when cleared', async ({
+      page,
+    }) => {
+      await navigateToComparison(page, CT_PAGE, true);
+      await testFilterSelectionUpdatesUrl(page, 'sex', 'Sex', 'Female');
+    });
+
     test('filter selections are restored from URL on page load', async ({ page }) => {
       const expectedFilterParams = {
         biodomains: ['Apoptosis', 'Epigenetic', 'Myelination'],
         models: ['APOE4'],
+        sex: ['Female'],
       };
       const expectedSelectedFilters = {
         'Biological Domain': ['Apoptosis', 'Epigenetic', 'Myelination'],
         'Mouse Model': ['APOE4'],
+        Sex: ['Female'],
       };
 
       await navigateToComparison(
@@ -430,6 +450,7 @@ test.describe('differential expression', () => {
       const expectedInitialFilterParams = {
         modelTypes: ['Familial AD'],
         biodomains: ['Apoptosis', 'Epigenetic', 'Myelination'],
+        sex: ['Female'],
       };
 
       await navigateToComparison(

--- a/apps/model-ad/app/e2e/helpers/comparison-tool.ts
+++ b/apps/model-ad/app/e2e/helpers/comparison-tool.ts
@@ -44,11 +44,18 @@ export const fetchComparisonToolData = async <T>(
   page: Page,
   name: string,
   categories: string[] = [],
+  filterParams: Record<string, string[]> = {},
 ): Promise<T> => {
   const params = new URLSearchParams();
   params.append('itemFilterType', 'exclude');
   for (const category of categories) {
     params.append('categories', category);
+  }
+
+  for (const [key, values] of Object.entries(filterParams)) {
+    for (const value of values) {
+      params.append(key, value);
+    }
   }
 
   // sortFields and sortOrders are required by the API
@@ -85,12 +92,14 @@ export const fetchDiseaseCorrelations = async (
 
 export const fetchTranscriptomics = async (
   page: Page,
-  categories = ['RNA - DIFFERENTIAL EXPRESSION', 'Tissue - Cortex', 'female'],
+  categories = ['RNA - DIFFERENTIAL EXPRESSION', 'Tissue - Cerebral Cortex'],
+  filterParams: Record<string, string[]> = {},
 ): Promise<Transcriptomics[]> => {
   const data = await fetchComparisonToolData<TranscriptomicsPage>(
     page,
-    'Transcriptomics',
+    'Differential Expression',
     categories,
+    filterParams,
   );
   return data.transcriptomics;
 };

--- a/libs/model-ad/api-client-angular/src/lib/model/transcriptomics-search-query.ts
+++ b/libs/model-ad/api-client-angular/src/lib/model/transcriptomics-search-query.ts
@@ -47,6 +47,10 @@ export interface TranscriptomicsSearchQuery {
    */
   name?: Array<string> | null;
   /**
+   * Filter by sex.
+   */
+  sex?: Array<string> | null;
+  /**
    * List of field names to sort by (e.g., \"gene_symbol,name\"). Each field in sortFields must have a corresponding order in sortOrders.
    */
   sortFields: Array<string>;

--- a/libs/model-ad/api-description/openapi/api-next-public.openapi.yaml
+++ b/libs/model-ad/api-description/openapi/api-next-public.openapi.yaml
@@ -1073,6 +1073,15 @@ components:
           example:
             - 3xTg-AD
             - 5xFAD (IU/Jax/Pitt)
+        sex:
+          description: Filter by sex.
+          type: array
+          items:
+            type: string
+          nullable: true
+          example:
+            - Female
+            - Male
         sortFields:
           description: |
             List of field names to sort by (e.g., "gene_symbol,name").

--- a/libs/model-ad/api-description/openapi/api-next-service.openapi.yaml
+++ b/libs/model-ad/api-description/openapi/api-next-service.openapi.yaml
@@ -1073,6 +1073,15 @@ components:
           example:
             - 3xTg-AD
             - 5xFAD (IU/Jax/Pitt)
+        sex:
+          description: Filter by sex.
+          type: array
+          items:
+            type: string
+          nullable: true
+          example:
+            - Female
+            - Male
         sortFields:
           description: |
             List of field names to sort by (e.g., "gene_symbol,name").

--- a/libs/model-ad/api-description/openapi/openapi.yaml
+++ b/libs/model-ad/api-description/openapi/openapi.yaml
@@ -1106,6 +1106,15 @@ components:
           example:
             - 3xTg-AD
             - 5xFAD (IU/Jax/Pitt)
+        sex:
+          description: Filter by sex.
+          type: array
+          items:
+            type: string
+          nullable: true
+          example:
+            - Female
+            - Male
         sortFields:
           description: |
             List of field names to sort by (e.g., "gene_symbol,name").

--- a/libs/model-ad/api-description/src/components/schemas/TranscriptomicsSearchQuery.yaml
+++ b/libs/model-ad/api-description/src/components/schemas/TranscriptomicsSearchQuery.yaml
@@ -71,6 +71,13 @@ properties:
       type: string
     nullable: true
     example: ['3xTg-AD', '5xFAD (IU/Jax/Pitt)']
+  sex:
+    description: Filter by sex.
+    type: array
+    items:
+      type: string
+    nullable: true
+    example: ['Female', 'Male']
   sortFields:
     description: |
       List of field names to sort by (e.g., "gene_symbol,name").

--- a/libs/model-ad/differential-expression-comparison-tool/src/lib/differential-expression-comparison-tool.component.spec.ts
+++ b/libs/model-ad/differential-expression-comparison-tool/src/lib/differential-expression-comparison-tool.component.spec.ts
@@ -150,6 +150,7 @@ describe('DifferentialExpressionComparisonToolComponent', () => {
   it('should send the selected sex filter in the unpinned query', async () => {
     const { component, comparisonToolService, transcriptomicsService } = await setup();
     const selectedSexes = ['Female'];
+    // TODO(MG-1036): mocked value becomes `{ sexes: selectedSexes }`
     jest.spyOn(comparisonToolService, 'selectedFilters').mockReturnValue({ sex: selectedSexes });
     const getTranscriptomicsSpy = jest
       .spyOn(transcriptomicsService, 'getTranscriptomics')

--- a/libs/model-ad/differential-expression-comparison-tool/src/lib/differential-expression-comparison-tool.component.spec.ts
+++ b/libs/model-ad/differential-expression-comparison-tool/src/lib/differential-expression-comparison-tool.component.spec.ts
@@ -150,8 +150,7 @@ describe('DifferentialExpressionComparisonToolComponent', () => {
   it('should send the selected sex filter in the unpinned query', async () => {
     const { component, comparisonToolService, transcriptomicsService } = await setup();
     const selectedSexes = ['Female'];
-    // TODO(MG-1036): mocked value becomes `{ sexes: selectedSexes }`
-    jest.spyOn(comparisonToolService, 'selectedFilters').mockReturnValue({ sex: selectedSexes });
+    jest.spyOn(comparisonToolService, 'selectedFilters').mockReturnValue({ sexes: selectedSexes });
     const getTranscriptomicsSpy = jest
       .spyOn(transcriptomicsService, 'getTranscriptomics')
       .mockReturnValue(of(mockPage([])) as any);

--- a/libs/model-ad/differential-expression-comparison-tool/src/lib/differential-expression-comparison-tool.component.spec.ts
+++ b/libs/model-ad/differential-expression-comparison-tool/src/lib/differential-expression-comparison-tool.component.spec.ts
@@ -9,7 +9,10 @@ import {
   provideComparisonToolService,
   provideExplorersConfig,
 } from '@sagebionetworks/explorers/services';
-import { provideLoadingIconColors } from '@sagebionetworks/explorers/testing';
+import {
+  mockEmptyComparisonToolQuery,
+  provideLoadingIconColors,
+} from '@sagebionetworks/explorers/testing';
 import {
   ComparisonToolConfigService,
   Sex,
@@ -142,5 +145,20 @@ describe('DifferentialExpressionComparisonToolComponent', () => {
         name: expect.objectContaining({ link_url: 'models/5xFAD (UCI)' }),
       }),
     ]);
+  });
+
+  it('should send the selected sex filter in the unpinned query', async () => {
+    const { component, comparisonToolService, transcriptomicsService } = await setup();
+    const selectedSexes = ['Female'];
+    jest.spyOn(comparisonToolService, 'selectedFilters').mockReturnValue({ sex: selectedSexes });
+    const getTranscriptomicsSpy = jest
+      .spyOn(transcriptomicsService, 'getTranscriptomics')
+      .mockReturnValue(of(mockPage([])) as any);
+
+    component.getUnpinnedData(mockEmptyComparisonToolQuery);
+
+    expect(getTranscriptomicsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ sex: selectedSexes }),
+    );
   });
 });

--- a/libs/model-ad/differential-expression-comparison-tool/src/lib/differential-expression-comparison-tool.component.ts
+++ b/libs/model-ad/differential-expression-comparison-tool/src/lib/differential-expression-comparison-tool.component.ts
@@ -177,8 +177,7 @@ export class DifferentialExpressionComparisonToolComponent implements OnInit, On
       biodomains: selectedFilters['biodomains'],
       modelType: selectedFilters['modelTypes'],
       name: selectedFilters['models'],
-      // TODO(MG-1036): becomes `sex: selectedFilters['sexes']`
-      sex: selectedFilters['sex'],
+      sex: selectedFilters['sexes'],
       sortFields,
       sortOrders,
     };

--- a/libs/model-ad/differential-expression-comparison-tool/src/lib/differential-expression-comparison-tool.component.ts
+++ b/libs/model-ad/differential-expression-comparison-tool/src/lib/differential-expression-comparison-tool.component.ts
@@ -177,6 +177,7 @@ export class DifferentialExpressionComparisonToolComponent implements OnInit, On
       biodomains: selectedFilters['biodomains'],
       modelType: selectedFilters['modelTypes'],
       name: selectedFilters['models'],
+      sex: selectedFilters['sex'],
       sortFields,
       sortOrders,
     };

--- a/libs/model-ad/differential-expression-comparison-tool/src/lib/differential-expression-comparison-tool.component.ts
+++ b/libs/model-ad/differential-expression-comparison-tool/src/lib/differential-expression-comparison-tool.component.ts
@@ -177,6 +177,7 @@ export class DifferentialExpressionComparisonToolComponent implements OnInit, On
       biodomains: selectedFilters['biodomains'],
       modelType: selectedFilters['modelTypes'],
       name: selectedFilters['models'],
+      // TODO(MG-1036): becomes `sex: selectedFilters['sexes']`
       sex: selectedFilters['sex'],
       sortFields,
       sortOrders,


### PR DESCRIPTION
## Description

The Differential Expression comparison tool renders a Sex filterset from its `ui_config`, but selecting a value had no effect — the key was never read from the filter panel and the API had no matching query parameter. This adds the `sex` parameter end to end, from the OpenAPI contract through the Mongo aggregation to the Angular component, so a Sex selection actually narrows the table and round-trips through the URL like the other filtersets. 

## Related Issue

- [MG-1002](https://sagebionetworks.jira.com/browse/MG-1002)

## Changelog

- Add sex filter to backend and wire up to frontend 
- Cover the new sex filter with unit tests for the query and repository, and e2e tests for filtered results and URL sync
- Repair the transcriptomics e2e fetch helper, which requested a comparison tool and tissue category that no longer exist, and let it pass filter params

## Testing

- Bring up the Model-AD stack and open the Differential Expression comparison tool. Select **Sex → Female** and confirm the table only shows Female rows and that `sex=Female` is added to the URL.
- Clear the Sex selection and confirm the row set returns to unfiltered and `sex` is dropped from the URL. Then apply Sex together with Model Type and Biological Domain and confirm the filters compose.
- Load the tool with `?sex=Female` (plus another filter param) already in the URL and confirm the Sex chip is restored in the filter panel, then confirm **Clear All** removes every filter param from the URL.
- Pin a few rows, apply a Sex filter, and confirm the pinned rows still render correctly — pinned rows resolve through the composite item filter, which shares the same singular/plural sex handling.
- Confirm requesting an unsupported param name still fails validation as before, i.e. `sex` was added to the allowed set without loosening the rest.

### Preview

Navigate to the differential expression CT with a "Female" sex filter applied. See that on dev, both Male and Female rows are shown, but in this PR, only Female rows are shown: 

dev | this PR 
:---: | :---: 
<img width="3384" height="2332" alt="MG-1002_dev" src="https://github.com/user-attachments/assets/bde4b534-a1a8-4e15-8014-6e166aa6e6ed" /> | <img width="3384" height="2332" alt="MG-1002_pr" src="https://github.com/user-attachments/assets/c6357259-62a6-4ea2-ac1b-d0abd1f80fca" />


[MG-1002]: https://sagebionetworks.jira.com/browse/MG-1002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-1004]: https://sagebionetworks.jira.com/browse/MG-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-1036]: https://sagebionetworks.jira.com/browse/MG-1036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ