### PR TITLE
feat(model-ad): bump to mv129, align models with updated data (MG-1009)

### DIFF
--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/dto/ComparisonToolPageDto.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/dto/ComparisonToolPageDto.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.14.0")
 public enum ComparisonToolPageDto {
   
+  MARMOSET_MODEL_OVERVIEW("Marmoset Model Overview"),
+  
   MODEL_OVERVIEW("Model Overview"),
   
   DIFFERENTIAL_EXPRESSION("Differential Expression"),

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/dto/TranscriptomicsIdentifier.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/dto/TranscriptomicsIdentifier.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.model.ad.api.next.model.dto;
 
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Value;
@@ -87,17 +86,7 @@ public class TranscriptomicsIdentifier {
       .andOperator(
         Criteria.where("ensembl_gene_id").is(ensemblGeneId),
         Criteria.where("name.link_text").is(name),
-        Criteria.where("sex").in(sexMatchValues())
+        Criteria.where("sex").is(sex)
       );
-  }
-
-  // TODO(MG-1004): drop the plural fallback once rna_de_aggregate stores singular Female/Male.
-  // composite_id sex is normalized to singular (see TranscriptomicsMapper), but the source data
-  // still stores plural Females/Males, so the round-trip filter must match either form.
-  private List<String> sexMatchValues() {
-    if ("Female".equals(sex) || "Male".equals(sex)) {
-      return List.of(sex, sex + "s");
-    }
-    return List.of(sex);
   }
 }

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/mapper/TranscriptomicsMapper.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/mapper/TranscriptomicsMapper.java
@@ -26,10 +26,8 @@ public class TranscriptomicsMapper {
       ? List.of()
       : List.copyOf(document.getBiodomains());
 
-    String sex = normalizeSex(document.getSex());
-
     TranscriptomicsDto dto = new TranscriptomicsDto(
-      getCompositeId(document, sex),
+      getCompositeId(document),
       document.getEnsemblGeneId(),
       getGeneSymbolWithFallback(document),
       biodomains,
@@ -38,7 +36,7 @@ public class TranscriptomicsMapper {
       document.getModelGroup(),
       document.getModelType(),
       document.getTissue(),
-      EnumConverter.toSexDto(sex, "transcriptomics record")
+      EnumConverter.toSexDto(document.getSex(), "transcriptomics record")
     );
 
     dto.set4months(toFoldChangeDto(document.getFourMonths()));
@@ -48,23 +46,12 @@ public class TranscriptomicsMapper {
     return dto;
   }
 
-  private String getCompositeId(TranscriptomicsDocument document, String sex) {
+  private String getCompositeId(TranscriptomicsDocument document) {
     String ensemblGeneId = document.getEnsemblGeneId();
     String name = document.getName().getLinkText();
+    String sex = document.getSex();
 
     return String.format("%s~%s~%s", ensemblGeneId, name, sex);
-  }
-
-  // TODO(MG-1004): remove once rna_de_aggregate stores singular Female/Male like the schema and
-  // other collections. The source data currently uses plural Females/Males.
-  private @Nullable String normalizeSex(@Nullable String sex) {
-    if ("Females".equals(sex)) {
-      return "Female";
-    }
-    if ("Males".equals(sex)) {
-      return "Male";
-    }
-    return sex;
   }
 
   private String getGeneSymbolWithFallback(TranscriptomicsDocument document) {

--- a/apps/model-ad/api-next/src/main/resources/openapi.yaml
+++ b/apps/model-ad/api-next/src/main/resources/openapi.yaml
@@ -426,6 +426,7 @@ components:
     ComparisonToolPage:
       description: The type of comparison tool page
       enum:
+        - Marmoset Model Overview
         - Model Overview
         - Differential Expression
         - Disease Correlation

--- a/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/dto/TranscriptomicsIdentifierTest.java
+++ b/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/dto/TranscriptomicsIdentifierTest.java
@@ -175,30 +175,7 @@ class TranscriptomicsIdentifierTest {
     assertThat(andClauses).hasSize(3);
     assertThat(andClauses.get(0)).isEqualTo(new Document("ensembl_gene_id", "ENSMUSG00000000001"));
     assertThat(andClauses.get(1)).isEqualTo(new Document("name.link_text", "5xFAD"));
-    // MG-1004: sex matches singular or plural source data (Female / Females)
-    assertThat(andClauses.get(2)).isEqualTo(
-      new Document("sex", new Document("$in", List.of("Female", "Females")))
-    );
-  }
-
-  // TODO(MG-1004): remove this test once rna_de_aggregate stores singular Female/Male
-  @Test
-  @DisplayName("should match plural source sex values for male identifier")
-  void shouldMatchPluralSourceSexValuesForMale() {
-    TranscriptomicsIdentifier identifier = TranscriptomicsIdentifier.builder()
-      .ensemblGeneId("ENSMUSG00000000001")
-      .name("5xFAD")
-      .sex("Male")
-      .build();
-
-    List<Document> andClauses = identifier
-      .toCriteria()
-      .getCriteriaObject()
-      .getList("$and", Document.class);
-
-    assertThat(andClauses.get(2)).isEqualTo(
-      new Document("sex", new Document("$in", List.of("Male", "Males")))
-    );
+    assertThat(andClauses.get(2)).isEqualTo(new Document("sex", "Female"));
   }
 
   @Test

--- a/apps/model-ad/data/.env.example
+++ b/apps/model-ad/data/.env.example
@@ -7,5 +7,5 @@ DB_HOST="model-ad-mongo" # must match mongo service name
 
 # specifies data release manifest
 DATA_FILE="syn73774820"
-DATA_VERSION="128"
+DATA_VERSION="129"
 SYNAPSE_AUTH_TOKEN="model-ad-service-user-pat-here"

--- a/apps/model-ad/data/.env.example
+++ b/apps/model-ad/data/.env.example
@@ -7,5 +7,5 @@ DB_HOST="model-ad-mongo" # must match mongo service name
 
 # specifies data release manifest
 DATA_FILE="syn73774820"
-DATA_VERSION="96"
+DATA_VERSION="128"
 SYNAPSE_AUTH_TOKEN="model-ad-service-user-pat-here"

--- a/libs/explorers/models/src/lib/comparison-tool.ts
+++ b/libs/explorers/models/src/lib/comparison-tool.ts
@@ -101,6 +101,7 @@ export interface ComparisonToolConfigFilter {
 }
 
 export type ComparisonToolPage =
+  | 'Marmoset Model Overview'
   | 'Model Overview'
   | 'Differential Expression'
   | 'Disease Correlation'

--- a/libs/model-ad/api-client-angular/src/lib/model/comparison-tool-page.ts
+++ b/libs/model-ad/api-client-angular/src/lib/model/comparison-tool-page.ts
@@ -12,11 +12,13 @@
  * The type of comparison tool page
  */
 export type ComparisonToolPage =
+  | 'Marmoset Model Overview'
   | 'Model Overview'
   | 'Differential Expression'
   | 'Disease Correlation';
 
 export const ComparisonToolPage = {
+  MarmosetModelOverview: 'Marmoset Model Overview' as ComparisonToolPage,
   ModelOverview: 'Model Overview' as ComparisonToolPage,
   DifferentialExpression: 'Differential Expression' as ComparisonToolPage,
   DiseaseCorrelation: 'Disease Correlation' as ComparisonToolPage,

--- a/libs/model-ad/api-description/openapi/api-next-public.openapi.yaml
+++ b/libs/model-ad/api-description/openapi/api-next-public.openapi.yaml
@@ -266,6 +266,7 @@ components:
       type: string
       description: The type of comparison tool page
       enum:
+        - Marmoset Model Overview
         - Model Overview
         - Differential Expression
         - Disease Correlation

--- a/libs/model-ad/api-description/openapi/api-next-service.openapi.yaml
+++ b/libs/model-ad/api-description/openapi/api-next-service.openapi.yaml
@@ -266,6 +266,7 @@ components:
       type: string
       description: The type of comparison tool page
       enum:
+        - Marmoset Model Overview
         - Model Overview
         - Differential Expression
         - Disease Correlation

--- a/libs/model-ad/api-description/openapi/openapi.yaml
+++ b/libs/model-ad/api-description/openapi/openapi.yaml
@@ -299,6 +299,7 @@ components:
       type: string
       description: The type of comparison tool page
       enum:
+        - Marmoset Model Overview
         - Model Overview
         - Differential Expression
         - Disease Correlation

--- a/libs/model-ad/api-description/src/components/schemas/ComparisonToolPage.yaml
+++ b/libs/model-ad/api-description/src/components/schemas/ComparisonToolPage.yaml
@@ -1,6 +1,7 @@
 type: string
 description: The type of comparison tool page
 enum:
+  - Marmoset Model Overview
   - Model Overview
   - Differential Expression
   - Disease Correlation


### PR DESCRIPTION
## Description

Model-AD data release mv129 adds the missing `Marmoset Model Overview` comparison tool page to `ui_config` and normalizes `rna_de_aggregate` sex values to the singular `Female`/`Male` form used by the schema and every other collection.

> [!NOTE]
> Merge should be coordinated with https://github.com/Sage-Bionetworks/model-ad-data-manager/pull/44

## Related Issue

- [MG-1009](https://sagebionetworks.jira.com/browse/MG-1009)
- [MG-1008](https://sagebionetworks.jira.com/browse/MG-1008)
- [MG-1004](https://sagebionetworks.jira.com/browse/MG-1004)

## Changelog

- Bump model-ad-data `DATA_VERSION` to `129`
- Add `Marmoset Model Overview` to the model-ad OpenAPI `ComparisonToolPage` enum and to the shared explorers `ComparisonToolPage` type
- Remove the plural sex normalization workaround from the Transcriptomics CT backend

## Testing

- Load the mv129 dataset (`DATA_VERSION=129`) and serve the model-ad stack, then confirm the API starts and the comparison tool config endpoint returns configs without enum conversion errors
- Load `http://localhost:8000/api/v1/comparison-tools/config?page=Marmoset%20Model%20Overview` and confirm it returns the marmoset overview config rather than a 400/500
- Open the Differential Expression comparison tool and confirm rows render with `Female` / `Male` sex values (no plural `Females` / `Males` leaking through)
- In Differential Expression, pin/select a row for a specific gene, model, and sex, then confirm the pinned row resolves correctly

## Preview

Marmoset model overview loads from ui_config endpoint: 

<img width="895" height="553" alt="image" src="https://github.com/user-attachments/assets/705981dd-05f0-4fa3-834a-3dbf83290277" />

Differential Expression CT still correctly pins rows by sex: 

<img width="4064" height="2334" alt="image" src="https://github.com/user-attachments/assets/48aa19aa-c4c7-402e-86dc-28aec3213e94" />


[MG-1009]: https://sagebionetworks.jira.com/browse/MG-1009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-1008]: https://sagebionetworks.jira.com/browse/MG-1008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-1004]: https://sagebionetworks.jira.com/browse/MG-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ